### PR TITLE
Add a standard way of running the test suites

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,13 +85,10 @@ Compile libsecp256k1 (optional, yet highly recommended)::
 
 For plugin development, see the `plugin documentation <plugins/README.rst>`_.
 
-Running unit tests (very optional, advanced users only)::
+Running unit tests (optional)::
 
-    pip install tox --user
-    tox
+    python3 -m electroncash.tests
 
-Tox will take care of building a faux installation environment, and ensure that
-the mapped import paths work correctly.
 
 Running from source on old Linux
 ================================

--- a/electroncash/tests/__main__.py
+++ b/electroncash/tests/__main__.py
@@ -1,0 +1,48 @@
+import unittest
+
+from .test_asert import Test_ASERTDaa
+from .test_bitcoin import suite as test_bitcoin_suite
+from .test_blockchain import TestBlockchain
+from .test_cashacct import TestCashAccounts
+from .test_cashaddrenc import TestCashAddrAddress
+from .test_commands import TestCommands
+from .test_dnssec import TestDnsSec
+from .test_interface import TestInterface
+from .test_mnemonic import suite as test_mnemonic_suite
+from .test_paymentrequests import Test_PaymentRequests
+from .test_schnorr import suite as test_schnorr_suite
+from .test_simple_config import suite as test_simple_config_suite
+from .test_slp import SLPTests
+from .test_storage_upgrade import TestStorageUpgrade
+from .test_transaction import suite as test_transaction_suite
+from .test_util import TestUtil
+from .test_wallet import suite as test_wallet_suite
+from .test_wallet_vertical import TestWalletKeystoreAddressIntegrity
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(Test_ASERTDaa))
+    test_suite.addTest(test_bitcoin_suite())
+    test_suite.addTest(loadTests(TestBlockchain))
+    test_suite.addTest(loadTests(TestCashAccounts))
+    test_suite.addTest(loadTests(TestCashAddrAddress))
+    test_suite.addTest(loadTests(TestCommands))
+    test_suite.addTest(loadTests(TestDnsSec))
+    test_suite.addTest(loadTests(TestInterface))
+    test_suite.addTest(test_mnemonic_suite())
+    test_suite.addTest(loadTests(Test_PaymentRequests))
+    test_suite.addTest(test_schnorr_suite())
+    test_suite.addTest(test_simple_config_suite())
+    test_suite.addTest(loadTests(SLPTests))
+    test_suite.addTest(loadTests(TestStorageUpgrade))
+    test_suite.addTest(test_transaction_suite())
+    test_suite.addTest(loadTests(TestUtil))
+    test_suite.addTest(test_wallet_suite())
+    test_suite.addTest(loadTests(TestWalletKeystoreAddressIntegrity))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")

--- a/electroncash/tests/test_asert.py
+++ b/electroncash/tests/test_asert.py
@@ -3057,3 +3057,7 @@ class Test_ASERTDaa(unittest.TestCase):
                   (9223372036854775812, 2147492647, 0x1802b73d)]
 
         self.validate_blocksequence(9223372036854775802, 2147483047, 0x1802aee8, blocks)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/electroncash/tests/test_bitcoin.py
+++ b/electroncash/tests/test_bitcoin.py
@@ -443,3 +443,18 @@ class Test_Bip38(unittest.TestCase):
         self.assertTrue(bool(b38.decrypt('ΜΟΛΩΝ ΛΑΒΕ')))
 
         # Success!
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(Test_bitcoin))
+    test_suite.addTest(loadTests(Test_bitcoin_testnet))
+    test_suite.addTest(loadTests(Test_xprv_xpub))
+    test_suite.addTest(loadTests(Test_keyImport))
+    test_suite.addTest(loadTests(Test_Bip38))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")

--- a/electroncash/tests/test_blockchain.py
+++ b/electroncash/tests/test_blockchain.py
@@ -74,3 +74,7 @@ class TestBlockchain(unittest.TestCase):
         # MTP(1010) is TimeStamp(1005), MTP(1004) is TimeStamp(999)
         hdr = {'block_height': block['block_height'] + 1}
         self.assertEqual(chain.get_bits(hdr, chunk), 0x1801b553)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/electroncash/tests/test_cashacct.py
+++ b/electroncash/tests/test_cashacct.py
@@ -197,3 +197,7 @@ class TestCashAccounts(unittest.TestCase):
         d = cashacct.CashAcct._calc_minimal_chashes_for_sorted_lcased_tups(sorted(l))
         self.assertEqual(sum(len(v) for k,v in d.items()), len(set(l)))
         self.assertEqual(d[myname][my_collision_hash], '03')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/electroncash/tests/test_cashaddrenc.py
+++ b/electroncash/tests/test_cashaddrenc.py
@@ -179,5 +179,6 @@ class TestCashAddrAddress(unittest.TestCase):
             self.assertEqual(kind, cashaddr.PUBKEY_TYPE)
             self.assertEqual(addr_hash, hashbytes)
 
+
 if __name__ == '__main__':
     unittest.main()

--- a/electroncash/tests/test_commands.py
+++ b/electroncash/tests/test_commands.py
@@ -31,3 +31,7 @@ class TestCommands(unittest.TestCase):
         self.assertEqual("2asd", Commands._setconfig_normalize_value('rpcpassword', '2asd'))
         self.assertEqual("['file:///var/www/','https://electrum.org']",
             Commands._setconfig_normalize_value('rpcpassword', "['file:///var/www/','https://electrum.org']"))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/electroncash/tests/test_dnssec.py
+++ b/electroncash/tests/test_dnssec.py
@@ -1,4 +1,5 @@
 import dns
+import unittest
 
 from dns.dnssec import ValidationFailure
 
@@ -57,3 +58,7 @@ class TestDnsSec(ElectronCashTestCase):
 
         with self.assertRaises(ValidationFailure):
             dns.dnssec.validate_rrsig(rrset, rrsig, keys, origin, now)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/electroncash/tests/test_interface.py
+++ b/electroncash/tests/test_interface.py
@@ -36,3 +36,7 @@ class TestInterface(unittest.TestCase):
         self.assertFalse(i.check_host_name(
             peercert={'subject': ((('commonName', '*.bar.com'),),)},
             name='sub.foo.bar.com'))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/electroncash/tests/test_mnemonic.py
+++ b/electroncash/tests/test_mnemonic.py
@@ -79,3 +79,17 @@ class Test_Seeds(unittest.TestCase):
     def test_seed_type(self):
         for seed_words, _type in self.mnemonics:
             self.assertEqual(_type, mnemonic.seed_type_name(seed_words), msg=seed_words)
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(Test_NewMnemonic))
+    test_suite.addTest(loadTests(Test_OldMnemonic))
+    test_suite.addTest(loadTests(Test_BIP39Checksum))
+    test_suite.addTest(loadTests(Test_Seeds))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")

--- a/electroncash/tests/test_paymentrequests.py
+++ b/electroncash/tests/test_paymentrequests.py
@@ -144,3 +144,7 @@ class DummyServer:
     def shutdown(self):
         self.httpd.shutdown()
         self.httpd.server_close()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/electroncash/tests/test_schnorr.py
+++ b/electroncash/tests/test_schnorr.py
@@ -100,3 +100,15 @@ class TestBlind(unittest.TestCase):
 
         for a,n in zip(alist, nlist):
             self.assertEqual(jac_1(a,n), jac_2(a,n), msg=(a,n))
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestSchnorr))
+    test_suite.addTest(loadTests(TestBlind))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")

--- a/electroncash/tests/test_simple_config.py
+++ b/electroncash/tests/test_simple_config.py
@@ -145,3 +145,15 @@ class TestUserConfig(unittest.TestCase):
 
         result = read_user_config(self.user_dir)
         self.assertEqual({}, result)
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(Test_SimpleConfig))
+    test_suite.addTest(loadTests(TestUserConfig))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")

--- a/electroncash/tests/test_slp.py
+++ b/electroncash/tests/test_slp.py
@@ -614,3 +614,6 @@ class SLPTests(unittest.TestCase):
 
         print("Completed %d OP_RETURN *build* tests"%ctr)
 
+
+if __name__ == '__main__':
+    unittest.main()

--- a/electroncash/tests/test_storage_upgrade.py
+++ b/electroncash/tests/test_storage_upgrade.py
@@ -1,5 +1,6 @@
 import shutil
 import tempfile
+import unittest
 
 from ..storage import WalletStorage
 from ..wallet import Wallet
@@ -297,3 +298,7 @@ class TestStorageUpgrade(WalletTestCase):
             f.write(wallet_json)
         storage = WalletStorage(self.wallet_path, manual_upgrades=manual_upgrades)
         return storage
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/electroncash/tests/test_transaction.py
+++ b/electroncash/tests/test_transaction.py
@@ -303,3 +303,15 @@ class NetworkMock(object):
 
     def synchronous_get(self, arg):
         return self.unspent
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestBCDataStream))
+    test_suite.addTest(loadTests(TestTransaction))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")

--- a/electroncash/tests/test_util.py
+++ b/electroncash/tests/test_util.py
@@ -110,3 +110,7 @@ class TestUtil(unittest.TestCase):
 
     def test_parse_URI_parameter_polution(self):
         self.assertRaises(Exception, parse_URI, 'bitcoincash:15mKKb2eos1hWa6tisdPwwDC1a5J1y9nma?amount=0.0003&label=test&amount=30.0')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/electroncash/tests/test_wallet.py
+++ b/electroncash/tests/test_wallet.py
@@ -137,3 +137,15 @@ class TestCreateRestoreWallet(WalletTestCase):
         self.assertEqual('Kz7FS9Adyj6RgSVGx5YLjZPanUhuze4yvcziZ1qLA24a3GJJZvBr',
                          wallet.export_private_key(addr0, password=None))
         self.assertEqual(1, len(wallet.get_receiving_addresses()))
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestCreateRestoreWallet))
+    test_suite.addTest(loadTests(TestWalletStorage))
+    return test_suite
+
+
+if __name__ == '__main__':
+    unittest.main(defaultTest="suite")

--- a/electroncash/tests/test_wallet_vertical.py
+++ b/electroncash/tests/test_wallet_vertical.py
@@ -144,3 +144,7 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
                          Address.from_string('3H3iyACDTLJGD2RMjwKZcCwpdYZLwEZzKb'))
         self.assertEqual(w.get_change_addresses()[0],
                          Address.from_string('31hyfHrkhNjiPZp1t7oky5CGNYqSqDAVM9'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This pull request add a standard way of running tests that does not require any non standard library. It uses the tools provided by the standard python library `unittest`, without even  requiring any knowledge about that library by the caller.