### PR TITLE
Fix a bug in server list widget

### DIFF
--- a/electroncash_gui/qt/network_dialog.py
+++ b/electroncash_gui/qt/network_dialog.py
@@ -173,7 +173,7 @@ class NodesListWidget(QTreeWidget):
         pt.setX(50)
         self.customContextMenuRequested.emit(pt)
 
-    def update(self, network, servers):
+    def update_servers(self, network, servers):
         item = self.currentItem()
         selection_data = None
         if item:
@@ -845,7 +845,7 @@ class NetworkChoiceLayout(QObject, PrintError):
         self.req_max_sb.setValue(params.max)
         self.req_chunk_sb.setValue(params.chunkSize)
 
-        self.nodes_list_widget.update(self.network, self.servers)
+        self.nodes_list_widget.update_servers(self.network, self.servers)
 
     def fill_in_proxy_settings(self):
         host, port, protocol, proxy_config, auto_connect = self.network.get_parameters()

--- a/electroncash_gui/qt/network_dialog.py
+++ b/electroncash_gui/qt/network_dialog.py
@@ -214,7 +214,7 @@ class NodesListWidget(QTreeWidget):
 
         # restore selection, if there was any
         if restore_sel:
-            restore_sel[0].setCurrentItem(restore_sel[1])
+            self.setCurrentItem(restore_sel[1])
 
         h = self.header()
         h.setStretchLastSection(False)


### PR DESCRIPTION
Clicking on a server in the network overview dialog (Menu Network -> Overview) in a case where there are multiple chains caused the following error:
```
  File ".../ElectrumBCHA/electroncash_gui/qt/network_dialog.py", line 843, in update
    self.nodes_list_widget.update(self.network, self.servers)
  File ".../ElectrumBCHA/electroncash_gui/qt/network_dialog.py", line 217, in update
    restore_sel[0].setCurrentItem(restore_sel[1])
AttributeError: 'QTreeWidgetItem' object has no attribute 'setCurrentItem'
```
Bug reported by @majcosta 