### PR TITLE
adjust build scripts to use different github repositories

### DIFF
--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -187,7 +187,7 @@ export SOURCE_DATE_EPOCH=1530212462
 # If the manifest changed, contrib/build-wine/manifest.xml needs to be updated.
 export PYTHON_VERSION=3.6.9  # Windows, OSX & Linux AppImage use this to determine what to download/build
 export PYTHON_SRC_TARBALL_HASH="5e2f5f554e3f8f7f0296f7e73d8600c4e9acbaee6b2555b83206edf5153870da"  # If you change PYTHON_VERSION above, update this by downloading the tarball manually and doing a sha256sum on it.
-export DEFAULT_GIT_REPO=https://github.com/PiRK/ElectrumBCHA
+export DEFAULT_GIT_REPO=https://github.com/Bitcoin-ABC/ElectrumABC
 if [ -z "$GIT_REPO" ] ; then
     # If no override from env is present, use default. Support for overrides
     # for the GIT_REPO has been added to allows contributors to test containers

--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -54,25 +54,19 @@ prepare_wine() {
         here=`pwd`
         # Please update these carefully, some versions won't work under Wine
 
-        # !!! WARNING !!! READ THIS BEFORE UPGRADING NSIS
-        # NSIS has a bug in its icon group generation code that causes builds that have not exactly 7 icons to include uninitialized memory.
-        # If you upgrade NSIS, you need to check if the bug still exists in Source/icon.cpp line 267:
-        # https://sourceforge.net/p/nsis/code/HEAD/tree/NSIS/tags/v3021/Source/icon.cpp#l267
-        # Where they are incorrectly using order.size() instead of icon.size() to allocate the buffer and also don't zero the memory.
-        # If the bug hasn't been fixed, you need to check the NSIS generated uninstaller for number of icons and match that count exactly in your .ico file.
-        # See: https://github.com/spesmilo/electrum/commit/570c0aeca39e56c742b77380ec274d178d660c29
-        NSIS_URL='https://github.com/cculianu/Electron-Cash-Build-Tools/releases/download/v1.0/nsis-3.02.1-setup.exe'
-        NSIS_SHA256=736c9062a02e297e335f82252e648a883171c98e0d5120439f538c81d429552e
+        NSIS_URL='https://github.com/PiRK/Electron-Cash-Build-Tools/releases/download/v1.0/nsis-3.06.1-setup.exe'
+        NSIS_SHA256=f60488a676308079bfdf6845dc7114cfd4bbff47b66be4db827b89bb8d7fdc52
 
+        # libusb 1.0.23
         LIBUSB_REPO='https://github.com/libusb/libusb.git'
-        LIBUSB_COMMIT=a5990ab10f68e5ec7498f627d1664b1f842fec4e
+        LIBUSB_COMMIT=e782eeb2514266f6738e242cdcb18e3ae1ed06fa
 
-        PYINSTALLER_REPO='https://github.com/EchterAgo/pyinstaller.git'
+        PYINSTALLER_REPO='https://github.com/PiRK/pyinstaller.git'
         PYINSTALLER_COMMIT=1a8b2d47c277c451f4e358d926a47c096a5615ec
 
         # Satochip pyscard
         PYSCARD_FILENAME=pyscard-1.9.9-cp36-cp36m-win32.whl  # python 3.6, 32-bit
-        PYSCARD_URL=https://github.com/cculianu/Electron-Cash-Build-Tools/releases/download/v1.0/pyscard-1.9.9-cp36-cp36m-win32.whl
+        PYSCARD_URL=https://github.com/PiRK/Electron-Cash-Build-Tools/releases/download/v1.0/pyscard-1.9.9-cp36-cp36m-win32.whl
         PYSCARD_SHA256=99d2b450f322f9ed9682fd2a99d95ce781527e371006cded38327efca8158fe7
 
         ## These settings probably don't need change
@@ -80,13 +74,8 @@ prepare_wine() {
         #export WINEARCH='win32'
         export WINEDEBUG=-all
 
-        PYHOME=c:/python$PYTHON_VERSION  # NB: PYTON_VERSION comes from ../base.sh
+        PYHOME=c:/python$PYTHON_VERSION
         PYTHON="wine $PYHOME/python.exe -OO -B"
-
-        # Clean up Wine environment. Breaks docker so leave this commented-out.
-        #echo "Cleaning $WINEPREFIX"
-        #rm -rf $WINEPREFIX
-        #echo "done"
 
         wine 'wineboot'
 

--- a/contrib/osx/make_osx
+++ b/contrib/osx/make_osx
@@ -147,7 +147,7 @@ python3 -m pip install -I --user -r contrib/osx/requirements-osx-build.txt \
 info "Installing Python Smartcard Module (pyscard)"
 mkdir -p $BUILDDIR
 PYSCARD_FNAME="pyscard-1.9.9-cp36-cp36m-macosx_10_11_x86_64.whl"
-curl -L https://github.com/cculianu/Electron-Cash-Build-Tools/releases/download/v1.0/$PYSCARD_FNAME > $BUILDDIR/$PYSCARD_FNAME
+curl -L https://github.com/PiRK/Electron-Cash-Build-Tools/releases/download/v1.0/$PYSCARD_FNAME > $BUILDDIR/$PYSCARD_FNAME
 verify_hash $BUILDDIR/$PYSCARD_FNAME 336b1cc335049e3ac5fad125c63d4e8fd4d25e85147f999359cdc6a9fde36fa7
 python3 -m pip install $BUILDDIR/$PYSCARD_FNAME --user && pyenv rehash \
     || fail "Could not install pyscard"
@@ -159,7 +159,8 @@ if ((USE_CUSTOM_PYINSTALLER)); then
     # patch has been submitted to the PyInstaller project but has yet to be
     # merged-in (they are very backlogged).
     mkdir -p $BUILDDIR
-    curl -L https://github.com/cculianu/pyinstaller/releases/download/v3.6_AE_Release_1/PyInstaller36_AppleEvents.zip > $BUILDDIR/PyInstaller36_AppleEvents.zip
+    curl -L https://github.com/PiRK/pyinstaller/releases/download/v3.6_AE_Release_1/PyInstaller36_AppleEvents.zip > $BUILDDIR/PyInstaller36_AppleEvents.zip
+
     verify_hash $BUILDDIR/PyInstaller36_AppleEvents.zip 0b2865c6e788abf26717a1c72f0164cba34d10836b9263a4e777a19ee8a79a2c
     python3 -m pip install $BUILDDIR/PyInstaller36_AppleEvents.zip --user --upgrade && pyenv rehash \
         || fail "Could not install PyInstaller"
@@ -183,13 +184,13 @@ info "Making locale..."
 python3 ./contrib/make_locale || fail "Failed to make locale..."
 
 info "Downloading libusb..."
-curl -L https://github.com/cculianu/Electron-Cash-Build-Tools/releases/download/v1.0/libusb-1.0.21.el_capitan.bottle.tar.gz | \
+curl -L https://github.com/PiRK/Electron-Cash-Build-Tools/releases/download/v1.0/libusb-1.0.21.el_capitan.bottle.tar.gz | \
     tar xz --directory $BUILDDIR || fail "Could not download libusb"
 verify_hash $BUILDDIR/libusb/1.0.21/lib/libusb-1.0.dylib d147e7382dfa676d93e8b17d160d50f68e4b01f58f3647c90a8899a7a0519ca3  # this exits on failure
 cp -fp $BUILDDIR/libusb/1.0.21/lib/libusb-1.0.dylib contrib/osx || fail "Could not copy libusb"
 
 info "Downloading ZBar dylib..."
-curl -L https://github.com/cculianu/Electron-Cash-Build-Tools/releases/download/v1.0/v0.23-libzbar.0.dylib.xz | \
+curl -L https://github.com/PiRK/Electron-Cash-Build-Tools/releases/download/v1.0/v0.23-libzbar.0.dylib.xz | \
     xz -d -c > contrib/osx/libzbar.0.dylib || fail "Could not download libzbar"
 verify_hash contrib/osx/libzbar.0.dylib 7b82238dd73e56d9f57913230ea5418c247b292cf96c8996becda961ab001c85
 


### PR DESCRIPTION
This PR changes the url for repositories that provide pinpointed versions of build tools.

It also updates the used NSIS version to a new one without the `icon.size()` bug that  made EC use a customized build.
It also updates the libusb version for the windows build to the latest.

