### PR TITLE
Remove unused imports

### DIFF
--- a/electroncash/bitcoin.py
+++ b/electroncash/bitcoin.py
@@ -28,18 +28,15 @@ import hashlib
 import base64
 import hmac
 import os
-import json
 
 import ecdsa
 import pyaes
 
 from typing import Tuple
 
-from .constants import PROJECT_NAME
 from . import networks
 from .util import (bfh, bh2u, to_string, print_error, InvalidPassword,
                    assert_bytes, to_bytes, inv_dict, profiler)
-from . import version
 from .ecc_fast import do_monkey_patching_of_python_ecdsa_internals_with_libsecp256k1
 
 # Ensure Python interpreter is not running with -O, since this entire
@@ -50,6 +47,7 @@ except AssertionError:
     pass
 else:
     import sys
+    from .constants import PROJECT_NAME
     sys.exit(f'{PROJECT_NAME} uses "assert" statements for its normal control'
              f' flow.\nPlease run this application without the python "-O" '
              f'(optimize) flag.')

--- a/electroncash/blockchain.py
+++ b/electroncash/blockchain.py
@@ -22,7 +22,6 @@
 # SOFTWARE.
 
 import os
-import sys
 import threading
 
 from typing import Optional

--- a/electroncash/blockchain.py
+++ b/electroncash/blockchain.py
@@ -31,7 +31,8 @@ from . import asert_daa
 from . import networks
 from . import util
 
-from .bitcoin import *
+from . import bitcoin
+
 
 class VerifyError(Exception):
     '''Exception used for blockchain verification errors.'''
@@ -85,19 +86,19 @@ NULL_HASH_BYTES = bytes([0]) * 32
 NULL_HASH_HEX = NULL_HASH_BYTES.hex()
 
 def serialize_header(res):
-    s = int_to_hex(res.get('version'), 4) \
-        + rev_hex(res.get('prev_block_hash')) \
-        + rev_hex(res.get('merkle_root')) \
-        + int_to_hex(int(res.get('timestamp')), 4) \
-        + int_to_hex(int(res.get('bits')), 4) \
-        + int_to_hex(int(res.get('nonce')), 4)
+    s = bitcoin.int_to_hex(res.get('version'), 4) \
+        + bitcoin.rev_hex(res.get('prev_block_hash')) \
+        + bitcoin.rev_hex(res.get('merkle_root')) \
+        + bitcoin.int_to_hex(int(res.get('timestamp')), 4) \
+        + bitcoin.int_to_hex(int(res.get('bits')), 4) \
+        + bitcoin.int_to_hex(int(res.get('nonce')), 4)
     return s
 
 def deserialize_header(s, height):
     h = {}
     h['version'] = int.from_bytes(s[0:4], 'little')
-    h['prev_block_hash'] = hash_encode(s[4:36])
-    h['merkle_root'] = hash_encode(s[36:68])
+    h['prev_block_hash'] = bitcoin.hash_encode(s[4:36])
+    h['merkle_root'] = bitcoin.hash_encode(s[36:68])
     h['timestamp'] = int.from_bytes(s[68:72], 'little')
     h['bits'] = int.from_bytes(s[72:76], 'little')
     h['nonce'] = int.from_bytes(s[76:80], 'little')
@@ -105,7 +106,7 @@ def deserialize_header(s, height):
     return h
 
 def hash_header_hex(header_hex):
-    return hash_encode(Hash(bfh(header_hex)))
+    return bitcoin.hash_encode(bitcoin.Hash(bytes.fromhex(header_hex)))
 
 def hash_header(header):
     if header is None:
@@ -161,7 +162,7 @@ def verify_proven_chunk(chunk_base_height, chunk_data):
 
 # Copied from electrumx
 def root_from_proof(hash, branch, index):
-    hash_func = Hash
+    hash_func = bitcoin.Hash
     for elt in branch:
         if index & 1:
             hash = hash_func(elt + hash)
@@ -356,7 +357,7 @@ class Blockchain(util.PrintError):
 
     def save_header(self, header):
         delta = header.get('block_height') - self.base_height
-        data = bfh(serialize_header(header))
+        data = bytes.fromhex(serialize_header(header))
         assert delta == self.size()
         assert len(data) == HEADER_SIZE
         self.write(data, delta*HEADER_SIZE)

--- a/electroncash/cashacct.py
+++ b/electroncash/cashacct.py
@@ -40,7 +40,7 @@ from collections import defaultdict, namedtuple
 from typing import List, Tuple, Dict
 from . import bitcoin
 from . import util
-from .address import Address, OpCodes, Script, ScriptError, UnknownAddress
+from .address import Address, OpCodes, Script, UnknownAddress
 from .address import ScriptOutput as ScriptOutputBase
 from .transaction import BCDataStream, Transaction
 from . import verifier

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -45,7 +45,7 @@ from .i18n import _
 from .plugins import run_hook
 from .wallet import create_new_wallet, restore_wallet_from_text
 from .transaction import Transaction, multisig_script, OPReturn
-from .util import bfh, bh2u, format_satoshis, json_decode, print_error, to_bytes
+from .util import bfh, format_satoshis, json_decode, to_bytes
 from .paymentrequest import PR_PAID, PR_UNPAID, PR_UNKNOWN, PR_EXPIRED
 
 known_commands = {}

--- a/electroncash/contacts.py
+++ b/electroncash/contacts.py
@@ -28,7 +28,7 @@ import os
 import re
 import traceback
 from collections import namedtuple
-from typing import List, Dict, Generator
+from typing import List, Generator
 from . import dnssec
 from . import cashacct
 from . import util

--- a/electroncash/ecc_fast.py
+++ b/electroncash/ecc_fast.py
@@ -5,13 +5,10 @@
 # taken (with minor modifications) from pycoin
 # https://github.com/richardkiss/pycoin/blob/01b1787ed902df23f99a55deb00d8cd076a906fe/pycoin/ecdsa/native/secp256k1.py
 
-import os
-import sys
-import traceback
 import ecdsa
 from ctypes import (byref, c_size_t, create_string_buffer)
 
-from .util import print_error, print_msg
+from .util import print_msg
 from . import secp256k1
 
 

--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -36,7 +36,7 @@ from .address import Address, PublicKey
 from . import networks
 from .mnemonic import Mnemonic, Mnemonic_Electrum, seed_type_name, is_seed
 from .plugins import run_hook
-from .util import PrintError, InvalidPassword, hfu, bh2u, print_error
+from .util import PrintError, InvalidPassword, bh2u, print_error
 
 
 class KeyStore(PrintError):

--- a/electroncash/mnemonic.py
+++ b/electroncash/mnemonic.py
@@ -28,7 +28,6 @@
 import binascii
 import ecdsa
 import hashlib
-import hmac
 import math
 import os
 import pkgutil

--- a/electroncash/paymentrequest.py
+++ b/electroncash/paymentrequest.py
@@ -41,7 +41,6 @@ except ImportError:
     sys.exit("Error: could not find paymentrequest_pb2.py. Create it with 'protoc --proto_path=electroncash/ --python_out=electroncash/ electroncash/paymentrequest.proto'")
 
 from . import bitcoin
-from . import version
 from . import util
 from . import transaction
 from . import x509

--- a/electroncash/plot.py
+++ b/electroncash/plot.py
@@ -10,8 +10,6 @@ import matplotlib
 matplotlib.use('Qt5Agg')
 import matplotlib.pyplot as plt
 import matplotlib.dates as md
-from matplotlib.patches import Ellipse
-from matplotlib.offsetbox import AnchoredOffsetbox, TextArea, DrawingArea, HPacker
 
 
 def plot_history(wallet, history):

--- a/electroncash/qrreaders/osxqrdetect.py
+++ b/electroncash/qrreaders/osxqrdetect.py
@@ -33,7 +33,7 @@ if sys.platform != 'darwin':
 
 
 from . import MissingLib
-from ..util import print_error, is_verbose, _, PrintError
+from ..util import print_error, is_verbose, PrintError
 
 from .abstract_base import AbstractQrCodeReader, QrCodeResult
 

--- a/electroncash/rsakey.py
+++ b/electroncash/rsakey.py
@@ -25,7 +25,7 @@
 
 # This module uses functions from TLSLite (public domain)
 #
-# TLSLite Authors: 
+# TLSLite Authors:
 #   Trevor Perrin
 #   Martin von Loewis - python 3 port
 #   Yngve Pettersen (ported by Paul Sokolovsky) - TLS 1.2
@@ -36,8 +36,6 @@
 import os
 import math
 import hashlib
-
-from .pem import *
 
 
 def SHA1(x):
@@ -80,7 +78,7 @@ def numberToByteArray(n, howManyBytes=None):
     The returned bytearray may be smaller than howManyBytes, but will
     not be larger.  The returned bytearray will contain a big-endian
     encoding of the input integer (n).
-    """    
+    """
     if howManyBytes == None:
         howManyBytes = numBytes(n)
     b = bytearray(howManyBytes)
@@ -331,7 +329,7 @@ class RSAKey(object):
         @return: Whether the signature matches the passed-in data.
         """
         hashBytes = SHA1(bytearray(bytes))
-        
+
         # Try it with/without the embedded NULL
         prefixedHashBytes1 = self._addPKCS1SHA1Prefix(hashBytes, False)
         prefixedHashBytes2 = self._addPKCS1SHA1Prefix(hashBytes, True)
@@ -445,21 +443,21 @@ class RSAKey(object):
     # **************************************************************************
 
     def _addPKCS1SHA1Prefix(self, bytes, withNULL=True):
-        # There is a long history of confusion over whether the SHA1 
-        # algorithmIdentifier should be encoded with a NULL parameter or 
-        # with the parameter omitted.  While the original intention was 
+        # There is a long history of confusion over whether the SHA1
+        # algorithmIdentifier should be encoded with a NULL parameter or
+        # with the parameter omitted.  While the original intention was
         # apparently to omit it, many toolkits went the other way.  TLS 1.2
         # specifies the NULL should be included, and this behavior is also
         # mandated in recent versions of PKCS #1, and is what tlslite has
-        # always implemented.  Anyways, verification code should probably 
-        # accept both.  However, nothing uses this code yet, so this is 
+        # always implemented.  Anyways, verification code should probably
+        # accept both.  However, nothing uses this code yet, so this is
         # all fairly moot.
         if not withNULL:
             prefixBytes = bytearray(\
-            [0x30,0x1f,0x30,0x07,0x06,0x05,0x2b,0x0e,0x03,0x02,0x1a,0x04,0x14])            
+            [0x30,0x1f,0x30,0x07,0x06,0x05,0x2b,0x0e,0x03,0x02,0x1a,0x04,0x14])
         else:
             prefixBytes = bytearray(\
-            [0x30,0x21,0x30,0x09,0x06,0x05,0x2b,0x0e,0x03,0x02,0x1a,0x05,0x00,0x04,0x14])            
+            [0x30,0x21,0x30,0x09,0x06,0x05,0x2b,0x0e,0x03,0x02,0x1a,0x05,0x00,0x04,0x14])
         prefixedBytes = prefixBytes + bytes
         return prefixedBytes
 

--- a/electroncash/schnorr.py
+++ b/electroncash/schnorr.py
@@ -11,8 +11,6 @@ A Python-only Schnorr sign/verify is available as a fallback if secp256k1 is
 unavailable. Note that this is much less secure as it contains side channel
 vulnerabilities, and must not be used in an automated-signing environment.
 '''
-import os
-import sys
 import hmac, hashlib
 from ctypes import create_string_buffer, c_void_p, c_char_p, c_int, c_size_t, byref, cast
 
@@ -130,7 +128,7 @@ def sign(privkey, message_hash, *, ndata=None):
     `message_hash` should be the 32 byte sha256d hash of the tx input (or
     message) you want to sign
     '''
-   
+
     if ndata is not None:
        assert len(ndata) == 32
 
@@ -160,7 +158,7 @@ def sign(privkey, message_hash, *, ndata=None):
         # For pure python (not libsecp256k1), convert an empty ndata to bytes as the required format for concatenation inside the nonce function.
         if ndata is None:
             ndata = b''
-            
+
         secexp = int.from_bytes(privkey, 'big')
         if not 0 < secexp < order:
             raise ValueError('could not sign')

--- a/electroncash/secp256k1.py
+++ b/electroncash/secp256k1.py
@@ -9,9 +9,8 @@ respectively.
 import os
 import sys
 import ctypes
-from ctypes.util import find_library
 from ctypes import (
-    byref, c_byte, c_int, c_uint, c_char_p, c_size_t, c_void_p, create_string_buffer, CFUNCTYPE, POINTER
+    c_int, c_uint, c_char_p, c_size_t, c_void_p, POINTER
 )
 
 from .util import print_stderr

--- a/electroncash/slp/slp.py
+++ b/electroncash/slp/slp.py
@@ -5,7 +5,9 @@ from .. import util
 from ..transaction import Transaction
 from typing import List, Tuple, Set
 
-from .exceptions import *
+from .exceptions import (
+    Error, OpreturnError, InvalidOutputMessage, UnsupportedSlpTokenType,
+    OPReturnTooLarge, SerializingError)
 
 lokad_id = b"SLP\x00"  # aka protocol code (prefix) -- this appears after the 'OP_RETURN + OP_PUSH(4)' bytes in the ScriptOutput for *ALL* SLP scripts
 valid_token_types = frozenset((1, 65, 129))  # any token types not in this set will be rejected

--- a/electroncash/storage.py
+++ b/electroncash/storage.py
@@ -29,7 +29,7 @@ import json
 import copy
 import re
 import stat
-import hmac, hashlib
+import hashlib
 import base64
 import zlib
 

--- a/electroncash/tests/test_cashaddrenc.py
+++ b/electroncash/tests/test_cashaddrenc.py
@@ -23,7 +23,6 @@
 
 """Reference tests for cashaddr adresses"""
 
-import binascii
 import unittest
 import random
 from .. import cashaddr

--- a/electroncash/tests/test_mnemonic.py
+++ b/electroncash/tests/test_mnemonic.py
@@ -1,5 +1,4 @@
 import unittest
-from .. import keystore
 from .. import mnemonic
 from .. import old_mnemonic
 from ..util import bh2u

--- a/electroncash/tests/test_transaction.py
+++ b/electroncash/tests/test_transaction.py
@@ -1,5 +1,4 @@
 import unittest
-from pprint import pprint
 
 from .. import transaction
 from ..address import Address, ScriptOutput, PublicKey

--- a/electroncash/tests/test_wallet.py
+++ b/electroncash/tests/test_wallet.py
@@ -7,7 +7,6 @@ import json
 
 from io import StringIO
 from ..storage import WalletStorage, FINAL_SEED_VERSION
-from .. import wallet
 from ..wallet import create_new_wallet, restore_wallet_from_text
 from ..simple_config import SimpleConfig
 from ..address import Address

--- a/electroncash/tests/test_wallet_vertical.py
+++ b/electroncash/tests/test_wallet_vertical.py
@@ -2,7 +2,6 @@ import unittest
 from unittest import mock
 
 from ..address import Address
-from .. import bitcoin
 from .. import keystore
 from .. import mnemonic
 from .. import storage

--- a/electroncash/util.py
+++ b/electroncash/util.py
@@ -27,8 +27,6 @@ import inspect
 import itertools
 import json
 import os
-import queue
-import re
 import stat
 import subprocess
 import sys
@@ -37,7 +35,7 @@ import time
 import traceback
 import weakref
 from abc import ABC, abstractmethod
-from collections import defaultdict, OrderedDict
+from collections import defaultdict
 from datetime import datetime
 from decimal import Decimal as PyDecimal  # Qt 5.12 also exports Decimal
 from functools import lru_cache

--- a/electroncash/verifier.py
+++ b/electroncash/verifier.py
@@ -21,10 +21,10 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from abc import ABC, abstractmethod
-from .util import ThreadJob, bh2u
+from .util import ThreadJob
 from .bitcoin import Hash, hash_decode, hash_encode
 from . import networks
-from .transaction import Transaction
+
 
 class BadResponse(Exception): pass
 

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -40,7 +40,6 @@ import threading
 import time
 from collections import defaultdict, namedtuple
 from enum import Enum, auto
-from functools import partial
 from typing import Set, Tuple, Union
 
 from .i18n import ngettext
@@ -49,14 +48,13 @@ from .util import (NotEnoughFunds, ExcessiveFee, PrintError,
                    format_satoshis, format_time, finalization_print_error,
                    to_string, bh2u)
 
-from .address import Address, Script, ScriptOutput, PublicKey, OpCodes
+from .address import Address, Script, ScriptOutput, PublicKey
 from .version import PACKAGE_VERSION
 from .keystore import load_keystore, Hardware_KeyStore, Imported_KeyStore, BIP32_KeyStore, xpubkey_to_address
 from . import networks
 from . import keystore
 from .storage import multisig_type, WalletStorage
 
-from . import transaction
 from .transaction import Transaction, InputValueMissing
 from .plugins import run_hook
 from . import bitcoin

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -50,7 +50,7 @@ from .util import (NotEnoughFunds, ExcessiveFee, PrintError,
                    to_string, bh2u)
 
 from .address import Address, Script, ScriptOutput, PublicKey, OpCodes
-from .version import *
+from .version import PACKAGE_VERSION
 from .keystore import load_keystore, Hardware_KeyStore, Imported_KeyStore, BIP32_KeyStore, xpubkey_to_address
 from . import networks
 from . import keystore


### PR DESCRIPTION
This PR is a first pass at removing the most obviously unused imports. 

It also remove a few major cases of `from some_module import *`, which obfuscates the imports by dumping the entire namespace of another module into the current one, possibly shadowing previous imports.