### PR TITLE
[CI]optimize travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,35 @@
-os: linux
+
 dist: bionic
 language: python
-python:
-    - 3.6
-    - 3.7
-    - 3.8
+# Reduce the amount of downloaded data from 50MiB to 7MiB
+git:
+  depth: 1
+matrix:
+  include:
+    - python: 3.9
+      os: linux
+      env:
+        - RUN_COVERAGE=true
+        - MAKE_SECP=false
+
+    - python: 3.6
+      os: linux
+      env:
+        - RUN_COVERAGE=false
+        - MAKE_SECP=true
 install:
+  - if [ "$MAKE_SECP" == true ];
+    then
+        ./contrib/make_secp;
+    fi
   - pip install -r contrib/requirements/requirements-travis.txt
 cache:
   - pip
 script:
-    - tox
-    - coveralls
+  - if [ "$RUN_COVERAGE" == true ];
+    then
+        coverage run -m electroncash.tests;
+        coverage report --include="./electroncash*";
+    else
+        python -m electroncash.tests;
+    fi

--- a/contrib/requirements/requirements-travis.txt
+++ b/contrib/requirements/requirements-travis.txt
@@ -1,3 +1,12 @@
-tox
-coveralls
-tox-travis
+coverage
+pyaes>=0.1a1
+ecdsa>=0.9
+requests
+qrcode
+protobuf
+dnspython[DNSSEC]
+jsonrpclib-pelix
+PySocks>=1.6.6
+python-dateutil<2.9
+stem>=1.8.0
+certifi


### PR DESCRIPTION
Reduce the cloning depth.
Run coverage only once.
Test the latest released python version (3.9) and the oldest one we support (3.6).
Run one test one with the python ecdsa library and the other with libsecp256k1
Consistently use the recommended YML indentation of 2 spaces.