### PR TITLE
Cleanup exchanges

### DIFF
--- a/electroncash/exchange_rate.py
+++ b/electroncash/exchange_rate.py
@@ -160,16 +160,37 @@ class ExchangeBase(PrintError):
             t.start()
         return result
 
-    def history_ccys(self):
+    def history_ccys(self) -> List[str]:
+        """Return a list of currency codes for which this exchange
+        has an API to query the historical prices."""
         return []
 
-    def historical_rate(self, ccy, d_t):
+    def historical_rate(self, ccy: str, d_t: datetime):
         return self.history.get(ccy, {}).get(d_t.strftime('%Y-%m-%d'))
 
-    def get_currencies(self):
+    def get_rates(self, ccy: str) -> Dict[str, decimal.Decimal]:
+        """Return a dictionary of exchange rates.
+        The keys are currencies codes, and the values are decimal.Decimal
+        objects.
+        """
+        raise NotImplementedError(
+            "Exchange classes must implement this method")
+
+    def get_currencies(self) -> List[str]:
+        """Return a list of currency codes for which this exchange
+        has an API to query the current price."""
         rates = self.get_rates('')
         return sorted([str(a) for (a, b) in rates.items()
                        if b is not None and len(a) == 3])
+
+    def request_history(self, ccy: str) -> Dict[str, float]:
+        """Return a dict of historical rates for a given currency.
+        The dict key is a '%Y-%m-%d' date string, the value are
+        floating point numbers.
+        """
+        raise NotImplementedError(
+            "Exchange classes supporting historical exchange rates must "
+            "implement this method.")
 
 
 class CoinGecko(ExchangeBase):

--- a/electroncash/exchange_rate.py
+++ b/electroncash/exchange_rate.py
@@ -44,7 +44,8 @@ class ExchangeBase(PrintError):
         self.on_quotes = on_quotes
         self.on_history = on_history
 
-    def get_json(self, site, get_string):
+    @staticmethod
+    def get_json(site, get_string):
         # APIs must have https
         url = ''.join(['https://', site, get_string])
         response = requests.request(
@@ -54,7 +55,8 @@ class ExchangeBase(PrintError):
                                  str(response.status_code))
         return response.json()
 
-    def get_csv(self, site, get_string):
+    @staticmethod
+    def get_csv(site, get_string):
         url = ''.join(['https://', site, get_string])
         response = requests.request(
             'GET', url, headers={'User-Agent': f'{PROJECT_NAME}'})
@@ -289,11 +291,13 @@ class FxThread(ThreadJob):
         if not os.path.exists(self.cache_dir):
             os.mkdir(self.cache_dir)
 
-    def get_currencies(self, h):
+    @staticmethod
+    def get_currencies(h):
         d = get_exchanges_by_ccy(h)
         return sorted(d.keys())
 
-    def get_exchanges_by_ccy(self, ccy, h):
+    @staticmethod
+    def get_exchanges_by_ccy(ccy, h):
         d = get_exchanges_by_ccy(h)
         return d.get(ccy, [])
 


### PR DESCRIPTION
After enabling the fiat option again in #8, this PR cleans the exchanges.py module.
This is done in 3 commits:

1. mostly automated style improvement
   - sort the imports (standard libraries, than other libraries, than local modules) with [isort](https://pypi.org/project/isort/)
   - change a lambda function into a proper function
   - run auto-pep8
2. annotate a few static methods
3. document the important methods in the base class to make adding more exchanges easier