### PR TITLE
clean up more settings after importing the EC settings

### DIFF
--- a/electroncash/__init__.py
+++ b/electroncash/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from .version import PACKAGE_VERSION
 from .util import format_satoshis, print_msg, print_error, set_verbosity
 from .wallet import Synchronizer, Wallet
@@ -14,3 +16,5 @@ from .commands import Commands, known_commands
 from . import address
 from . import cashacct  # has a side-effect: registers itself with ScriptOut protocol system
 
+logging.basicConfig()
+root_logger = logging.getLogger(__name__)

--- a/electroncash/migrate_data.py
+++ b/electroncash/migrate_data.py
@@ -67,6 +67,36 @@ def safe_rm(path: str):
             f"Unable to delete path {path}.\n{str(e)}")
 
 
+def replace_src_dest_in_config(src: str, dest: str, config: dict):
+    """Replace all occurrences of the string src by the str dest in the
+    relevant values of the config dictionary.
+    """
+    # adjust all paths to point to the new user dir
+    for k, v in config.items():
+        if isinstance(v, str) and v.startswith(src):
+            config[k] = v.replace(src, dest)
+    # adjust paths in list of recently open wallets
+    if "recently_open" in config:
+        for idx, wallet in enumerate(config["recently_open"]):
+            config["recently_open"][idx] = wallet.replace(src, dest)
+
+
+def reset_server_config(config: dict):
+    # Reset server selection policy to make sure we don't start on the
+    # wrong chain.
+    config["whitelist_servers_only"] = DEFAULT_WHITELIST_SERVERS_ONLY
+    config["auto_connect"] = DEFAULT_AUTO_CONNECT
+    config["server"] = ""
+    config.pop("server_whitelist_added", None)
+    config.pop("server_whitelist_removed", None)
+    config.pop("server_blacklist", None)
+
+    # Delete rpcuser and password. These will be generated on
+    # the first connection with jsonrpclib.Server
+    config.pop("rpcuser", None)
+    config.pop("rpcpassword", None)
+
+
 def migrate_data_from_ec():
     """Copy the EC data dir the first time Electrum ABC is executed.
     This makes all the wallets and settings available to users.
@@ -91,26 +121,14 @@ def migrate_data_from_ec():
         recent_servers_file = os.path.join(dest, "recent-servers")
         safe_rm(recent_servers_file)
 
-        # update some parameters in config file
+        # update some parameters in mainnet config file
         config = read_user_config(dest)
         if config:
-            # Reset server selection policy to make sure we don't start on the
-            # wrong chain.
-            config["whitelist_servers_only"] = DEFAULT_WHITELIST_SERVERS_ONLY
-            config["auto_connect"] = DEFAULT_AUTO_CONNECT
-            config["server"] = ""
-            config.pop("server_whitelist_removed", None)
-            config.pop("server_whitelist_removed", None)
-            config.pop("server_blacklist", None)
+            reset_server_config(config)
 
             # Set a fee_per_kb adapted to the current mempool situation
             if "fee_per_kb" in config:
                 config["fee_per_kb"] = 80000
-
-            # Delete rpcuser and password. These will be generated on
-            # the first connection with jsonrpclib.Server
-            config.pop("rpcuser", None)
-            config.pop("rpcpassword", None)
 
             # Disable plugins that can not be selected in the Electrum ABC menu.
             config["use_labels"] = False
@@ -122,12 +140,16 @@ def migrate_data_from_ec():
             config["use_shuffle_deprecated"] = False
 
             # adjust all paths to point to the new user dir
-            for k, v in config.items():
-                if isinstance(v, str) and v.startswith(src):
-                    config[k] = v.replace(src, dest)
-            # adjust paths in list of recently open wallets
-            if "recently_open" in config:
-                for idx, wallet in enumerate(config["recently_open"]):
-                    config["recently_open"][idx] = wallet.replace(src, dest)
-
+            replace_src_dest_in_config(src, dest, config)
             save_user_config(config, dest)
+
+        # Testnet configuration
+        testnet_dir_path = os.path.join(dest, "testnet")
+        recent_tservers_file = os.path.join(testnet_dir_path, "recent-servers")
+        safe_rm(recent_tservers_file)
+
+        testnet_config = read_user_config(testnet_dir_path)
+        if testnet_config:
+            reset_server_config(testnet_config)
+            replace_src_dest_in_config(src, dest, testnet_config)
+            save_user_config(testnet_config, testnet_dir_path)


### PR DESCRIPTION
Don't keep the exchanges rate histories copied over from Electron Cash because they are BCH prices, not BCHA.
Clear the recent servers list, clear the list of black-/white-listed servers.
Also clean-up relevant testnet settings.