### PR TITLE
don't use variables before they are imported

### DIFF
--- a/electrum-abc
+++ b/electrum-abc
@@ -40,8 +40,8 @@ if sys.platform == "win32" and hasattr(sys, 'frozen') and hasattr(sys, '_MEIPASS
 os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'] = 'python'
 
 if sys.version_info < (3, 6):
-    sys.exit(f"*** {PROJECT_NAME} support for Python 3.5 has been discontinued.\n"
-             f"*** Please run {PROJECT_NAME} with Python 3.6 or above.")
+    sys.exit(f"*** Support for Python 3.5 has been discontinued.\n"
+             f"*** Please run the application with Python 3.6 or above.")
 
 # from https://gist.github.com/tito/09c42fb4767721dc323d
 import threading


### PR DESCRIPTION
This is a minor bug, as it happened on exiting the application and only if run from the source package using an outdated python version.

It would be best to sort the imports to put them all before any actual code to avoid this kind of situation, but this will require more investigation and testing. Imports can cause code to be executed in python.

Also, running the script from the repository is not  a very good practice, as it incentivized some awkwardness in how the data files are organized (in the middle of the code). Forcing users to install the package (`pip install .`) before running it will be enforced sooner or later, and the python version checking can then be put in the `setup.py` file.