### PR TITLE
Add a checkpoint after the November 15th 2020 hard fork

### DIFF
--- a/electroncash/asert_daa.py
+++ b/electroncash/asert_daa.py
@@ -72,6 +72,7 @@ class ASERTDaa:
 
     MAX_TARGET = bits_to_target(MAX_BITS)
 
+    # If left as none, blockchain.py will calculate this at runtime as we read headers.
     anchor: Optional[Anchor] = None
 
     def __init__(self, is_testnet=False):

--- a/electroncash/blockchain.py
+++ b/electroncash/blockchain.py
@@ -423,19 +423,25 @@ class Blockchain(util.PrintError):
 
         return blocks1['block_height']
 
-    _cached_asert_anchor: Optional[asert_daa.Anchor] = None  # cached Anchor, per-Blockchain instance
+    # cached Anchor, per-Blockchain instance, only used if the checkpoint for
+    # this network is *behind* the anchor block
+    _cached_asert_anchor: Optional[asert_daa.Anchor] = None
+
     def get_asert_anchor(self, prevheader, mtp, chunk=None):
+        """Returns the asert_anchor either from Networks.net if hardcoded or
+        calculated in realtime if not."""
         if networks.net.asert_daa.anchor is not None:
             # Checkpointed (hard-coded) value exists, just use that
             return networks.net.asert_daa.anchor
+        # Bug note: The below does not work if we don't have all the intervening
+        # headers -- therefore this execution path should only be taken for networks
+        # where the checkpoint block is before the anchor block.  This means that
+        # adding a checkpoint after the anchor block without setting the anchor
+        # block in networks.net.asert_daa.anchor will result in bugs.
         if (self._cached_asert_anchor is not None
                 and self._cached_asert_anchor.height <= prevheader['block_height']):
             return self._cached_asert_anchor
-        # ****
-        # This may be slow -- we really should be leveraging the hard-coded
-        # checkpointed value. TODO: add hard-coded value to networks.py after
-        # Nov. 15th 2020 HF to ASERT DAA
-        # ****
+
         anchor = prevheader
         activation_mtp = networks.net.asert_daa.MTP_ACTIVATION_TIME
         while mtp >= activation_mtp:

--- a/electroncash/networks.py
+++ b/electroncash/networks.py
@@ -70,8 +70,8 @@ class MainNet(AbstractNet):
     #    network.synchronous_get(("blockchain.block.header", [height, height]))
     #
     # Consult the ElectrumX documentation for more details.
-    VERIFICATION_BLOCK_MERKLE_ROOT = "575401e2c601590926742fc806339d99dfdbd65b867231c3d799ea9a22cf9355"
-    VERIFICATION_BLOCK_HEIGHT = 645000
+    VERIFICATION_BLOCK_MERKLE_ROOT = "d0d925862df595918416020caf5467b7ae67ae8f807daf60626c36755b62f9a2"
+    VERIFICATION_BLOCK_HEIGHT = 661648
     asert_daa = ASERTDaa(is_testnet=False)
     # Note: We *must* specify the anchor if the checkpoint is after the anchor, due to the way
     # blockchain.py skips headers after the checkpoint.  So all instances that have a checkpoint

--- a/electroncash/networks.py
+++ b/electroncash/networks.py
@@ -24,7 +24,7 @@
 
 import json, pkgutil
 
-from .asert_daa import ASERTDaa
+from .asert_daa import ASERTDaa, Anchor
 
 def _read_json_dict(filename):
     try:
@@ -36,7 +36,6 @@ def _read_json_dict(filename):
 
 class AbstractNet:
     TESTNET = False
-    asert_daa = ASERTDaa()
     LEGACY_POW_TARGET_TIMESPAN = 14 * 24 * 60 * 60   # 2 weeks
     LEGACY_POW_TARGET_INTERVAL = 10 * 60  # 10 minutes
     LEGACY_POW_RETARGET_BLOCKS = LEGACY_POW_TARGET_TIMESPAN // LEGACY_POW_TARGET_INTERVAL  # 2016 blocks
@@ -73,6 +72,11 @@ class MainNet(AbstractNet):
     # Consult the ElectrumX documentation for more details.
     VERIFICATION_BLOCK_MERKLE_ROOT = "575401e2c601590926742fc806339d99dfdbd65b867231c3d799ea9a22cf9355"
     VERIFICATION_BLOCK_HEIGHT = 645000
+    asert_daa = ASERTDaa(is_testnet=False)
+    # Note: We *must* specify the anchor if the checkpoint is after the anchor, due to the way
+    # blockchain.py skips headers after the checkpoint.  So all instances that have a checkpoint
+    # after the anchor must specify the anchor as well.
+    asert_daa.anchor = Anchor(height=661647, bits=402971390, prev_time=1605447844)
 
     # Version numbers for BIP32 extended keys
     # standard: xprv, xpub
@@ -88,6 +92,7 @@ class MainNet(AbstractNet):
 class TestNet(AbstractNet):
     TESTNET = True
     asert_daa = ASERTDaa()
+
     WIF_PREFIX = 0xef
     ADDRTYPE_P2PKH = 111
     ADDRTYPE_P2PKH_BITPAY = 111  # Unsure


### PR DESCRIPTION
This will remove all risks of Electrum ABC accidentally connecting to the BCH network if the server settings are modified.
Coins can still be split by running both Electrum ABC and Electron Cash at the same time.