### PR TITLE
Create new wallets in the default directory

### DIFF
--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -28,6 +28,7 @@ import ast
 import base64
 import datetime
 import json
+import os
 import queue
 import sys
 import time
@@ -1006,7 +1007,7 @@ def add_global_options(parser):
     group.add_argument("-v", "--verbose", action="store_true", dest="verbose", default=False, help="Show debugging information")
     group.add_argument("-D", "--dir", dest="data_path", help=f"{PROJECT_NAME} directory")
     group.add_argument("-P", "--portable", action="store_true", dest="portable", default=False, help="Use local 'electron_cash_data' directory")
-    group.add_argument("-w", "--wallet", dest="wallet_path", help="wallet path")
+    group.add_argument("-w", "--wallet", dest="wallet_path", help="wallet path", type=os.path.abspath)
     group.add_argument("-wp", "--walletpassword", dest="wallet_password", default=None, help="Supply wallet password")
     group.add_argument("--testnet", action="store_true", dest="testnet", default=False, help="Use Testnet")
     group.add_argument("--testnet4", action="store_true", dest="testnet4", default=False, help="Use Testnet4")

--- a/electroncash/simple_config.py
+++ b/electroncash/simple_config.py
@@ -211,10 +211,9 @@ class SimpleConfig(PrintError):
         is used.
         """
         # command line -w option
-        if self.get('wallet_path'):
-            return os.path.dirname(os.path.join(self.get('cwd', ''),
-                                                self.get('wallet_path')))
-        return os.path.join(self.path, "wallets")
+        path = self.get('wallet_path')
+        return os.path.dirname(path) if path else os.path.join(self.path,
+                                                               "wallets")
 
     def get_wallet_path(self):
         """Return the path of the current wallet.
@@ -226,7 +225,7 @@ class SimpleConfig(PrintError):
         """
         # command line -w option
         if self.get('wallet_path'):
-            return os.path.join(self.get('cwd', ''), self.get('wallet_path'))
+            return self.get('wallet_path')
 
         # path in config file
         path = self.get('default_wallet_path')

--- a/electroncash/simple_config.py
+++ b/electroncash/simple_config.py
@@ -202,9 +202,28 @@ class SimpleConfig(PrintError):
             return
         save_user_config(self.user_config, self.path)
 
-    def get_wallet_path(self):
-        """Set the path of the wallet."""
+    def get_new_wallet_directory(self):
+        """Return the path to the directory where new wallets are saved.
 
+        If the program was started with the wallet path (-w or --wallet
+        argument), the directory of that wallet is used.
+        Else, the default wallet directory inside the user data directory
+        is used.
+        """
+        # command line -w option
+        if self.get('wallet_path'):
+            return os.path.dirname(os.path.join(self.get('cwd', ''),
+                                                self.get('wallet_path')))
+        return os.path.join(self.path, "wallets")
+
+    def get_wallet_path(self):
+        """Return the path of the current wallet.
+
+        On program startup, this is either the wallet path specified on the
+        command line (-w or --wallet argument), or the wallet used the last
+        time the program was used, or by default a new wallet named
+        "default_wallet" in the user directory.
+        """
         # command line -w option
         if self.get('wallet_path'):
             return os.path.join(self.get('cwd', ''), self.get('wallet_path'))
@@ -218,14 +237,7 @@ class SimpleConfig(PrintError):
         util.assert_datadir_available(self.path)
         dirpath = os.path.join(self.path, "wallets")
         make_dir(dirpath)
-
         new_path = os.path.join(self.path, "wallets", "default_wallet")
-
-        # default path in pre 1.9 versions
-        old_path = os.path.join(self.path, "electrum.dat")
-        if os.path.exists(old_path) and not os.path.exists(new_path):
-            os.rename(old_path, new_path)
-
         return new_path
 
     def remove_from_recently_open(self, filename):

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -563,15 +563,15 @@ class ElectrumGui(QObject, PrintError):
         return w
 
     def get_wallet_folder(self):
-        ''' may raise FileNotFoundError '''
+        """Get path to directory containing the current wallet.
+        """
         return os.path.dirname(os.path.abspath(self.config.get_wallet_path()))
 
     def get_new_wallet_path(self):
-        ''' may raise FileNotFoundError '''
-        wallet_folder = self.get_wallet_folder()
+        """Return path to a new wallet file to be created."""
+        wallet_folder = self.config.get_new_wallet_directory()
         filename = get_new_wallet_name(wallet_folder)
-        full_path = os.path.join(wallet_folder, filename)
-        return full_path
+        return os.path.join(wallet_folder, filename)
 
     def on_focus_change(self, ignored, new_focus_widget):
         ''' Remember the last wallet window that was activated because

--- a/electrum-abc
+++ b/electrum-abc
@@ -373,7 +373,6 @@ if __name__ == '__main__':
     config_options = {key: config_options[key] for key in filter(f, config_options.keys())}
     if config_options.get('server'):
         config_options['auto_connect'] = False
-    config_options['cwd'] = os.getcwd()
 
     # fixme: this can probably be achieved with a runtime hook (pyinstaller)
     try:


### PR DESCRIPTION
The previous behavior was to create new wallets in the same directory as the current wallet, even if this wallet was a wallet open in an arbitrary external path.

This changes the behavior to use either the wallet path explicitely specified on the command line (-w or --wallet argument) or the default wallet directory in the user's data directory.

Minor improvements:
- remove an old unused piece of code providing compatibility with a wallet format used in 2013
- convert the command line argument --wallet to an absolute path and remove the need to store the current working directory in the configuration options