### PR TITLE
Modify the crash reporter dialog

### DIFF
--- a/electroncash/constants.py
+++ b/electroncash/constants.py
@@ -4,8 +4,12 @@ from collections import OrderedDict
 PROJECT_NAME: str = "Electrum ABC"
 PROJECT_NAME_NO_SPACES = "ElectrumABC"
 SCRIPT_NAME: str = "electrum-abc"
-REPOSITORY_URL: str = "https://github.com/Bitcoin-ABC/ElectrumABC"
-RELEASES_JSON_URL: str = "https://raw.github.com/Bitcoin-ABC/ElectrumABC/master/contrib/update_checker/releases.json"
+REPOSITORY_OWNER: str = "Bitcoin-ABC"
+REPOSITORY_NAME: str = "ElectrumABC"
+REPOSITORY_URL: str = f"https://github.com/{REPOSITORY_OWNER}/{REPOSITORY_NAME}"
+RELEASES_JSON_URL: str = f"https://raw.github.com/{REPOSITORY_OWNER}/" \
+                         f"{REPOSITORY_NAME}/master/contrib/update_checker" \
+                         f"/releases.json"
 
 POSIX_DATA_DIR: str = ".electrum-abc"
 """This is the name of the directory where the wallets, recent server lists

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -70,7 +70,7 @@ from . import icons # This needs to be imported once app-wide then the :icons/ n
 from .util import *   # * needed for plugins
 from .main_window import ElectrumWindow
 from .network_dialog import NetworkDialog
-from .exception_window import Exception_Hook
+from .exception_window import ExceptionHook
 from .update_checker import UpdateChecker
 
 
@@ -1017,8 +1017,8 @@ class ElectrumGui(QObject, PrintError):
         self.app.lastWindowClosed.connect(self._quit_after_last_window)
 
         def clean_up():
-            # Just in case we get an exception as we exit, uninstall the Exception_Hook
-            Exception_Hook.uninstall()
+            # Just in case we get an exception as we exit, uninstall the ExceptionHook
+            ExceptionHook.uninstall()
             # Shut down the timer cleanly
             self.timer.stop()
             self.gc_timer.stop()
@@ -1029,7 +1029,7 @@ class ElectrumGui(QObject, PrintError):
             self.tray.hide()
         self.app.aboutToQuit.connect(clean_up)
 
-        Exception_Hook(self.config) # This wouldn't work anyway unless the app event loop is active, so we must install it once here and no earlier.
+        ExceptionHook(self.config) # This wouldn't work anyway unless the app event loop is active, so we must install it once here and no earlier.
         # main loop
         self.app.exec_()
         # on some platforms the exec_ call may not return, so use clean_up()

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -779,7 +779,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         msg = ' '.join([
             _("Please report any bugs as issues on github:<br/>"),
             f"<a href=\"{REPOSITORY_URL}/issues\">"
-            f"https://github.com/PiRK/ElectrumBCHA/issues</a><br/><br/>",
+            f"{REPOSITORY_URL}/issues</a><br/><br/>",
             _(f"Before reporting a bug, upgrade to the most recent version of "
               f"{PROJECT_NAME} (latest release or git HEAD), and include the "
               f"version number in your report."),


### PR DESCRIPTION
This PR is a major change of the crash report dialog, to stop sending Electrum ABC error messages to Electron Cash.

Instead of using a server to gather the errors and create the issues on github, just send the users to the github page with a new issue pre-filled. 
This is an improvement of the codebase, but will probably reduce the effectiveness of bug reporting, because it requires users to submit a bug report semi-automatically. But for now it seems like a reasonable trade-off, compared with setting up a server to automate the reporting.

