### PR TITLE
trezor: use `init_device` instead of `ping` to check connection 

### DIFF
--- a/electroncash_plugins/trezor/clientbase.py
+++ b/electroncash_plugins/trezor/clientbase.py
@@ -125,8 +125,7 @@ class TrezorClientBase(PrintError):
             return True
 
         try:
-            res = self.client.ping("electrum pinging device")
-            assert res == "electrum pinging device"
+            self.client.init_device()
         except BaseException:
             return False
         return True


### PR DESCRIPTION
I submitted this same backport to Electron Cash.  I'm unsure of submitting it here because I don't know if Trezor supports BCHA.

This is a backport of https://github.com/spesmilo/electrum/pull/6471 from Electrum, that fixes [Trezor with autolock error](https://github.com/spesmilo/electrum/issues/6457).

I cannot test this because I don't have a Trezor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bitcoin-abc/electrumabc/25)
<!-- Reviewable:end -->
