### PR TITLE
fix indirect imports broken by PR #6

### DIFF
--- a/electroncash_plugins/fusion/util.py
+++ b/electroncash_plugins/fusion/util.py
@@ -28,8 +28,9 @@
 Some pieces of fusion that can be reused in the server.
 """
 
-from electroncash.transaction import Transaction, TYPE_SCRIPT, TYPE_ADDRESS, get_address_from_output_script
+from electroncash.transaction import Transaction, get_address_from_output_script
 from electroncash.address import Address, ScriptOutput, hash160, OpCodes
+from electroncash.bitcoin import TYPE_SCRIPT, TYPE_ADDRESS
 
 from . import fusion_pb2 as pb
 from .protocol import Protocol

--- a/electroncash_plugins/fusion/validation.py
+++ b/electroncash_plugins/fusion/validation.py
@@ -35,7 +35,8 @@ from . import encrypt
 from .protocol import Protocol
 
 from electroncash.address import Address
-from electroncash.transaction import TYPE_ADDRESS, get_address_from_output_script
+from electroncash.bitcoin import TYPE_ADDRESS
+from electroncash.transaction import get_address_from_output_script
 import electroncash.schnorr as schnorr
 
 from google.protobuf.message import DecodeError


### PR DESCRIPTION
PR #6 used direct imports in the electroncash package, instead of import via `from .bitcoin import *`
Unfortunately the cashfusion_plugin package uses such indirect imports from modules that previously imported everything from bitcoin.py.

This broke the cashfusion and cashshuffle plugins

Fix the CashFusion plugin by importing directly from bitcoin.py. The CashShuffle plugin is removed in #36 

