### PR TITLE
fix error when starting without cmd when no_secp

### DIFF
--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -982,7 +982,6 @@ def get_parser():
         # Qt High DPI scaling can not be disabled on macOS since it is never
         # explicitly enabled on macOS! (see gui/qt/__init__.py)
         parser_gui.add_argument("--qt_disable_highdpi", action="store_true", dest="qt_disable_highdpi", default=None, help="(Linux & Windows only) If using Qt gui, disable high DPI scaling")
-    parser_gui.add_argument("-R", "--relax_warnings", action="store_true", dest="relaxwarn", default=False, help="Disables certain warnings that might be annoying during development and/or testing")
     add_network_options(parser_gui)
     add_global_options(parser_gui)
     # daemon

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -623,7 +623,7 @@ class ElectrumGui(QObject, PrintError):
             try:
 
                 if not self.windows:
-                    self.warn_if_no_secp(relaxed=True)
+                    self.warn_if_no_secp()
 
                 try:
                     wallet = self.daemon.load_wallet(path, None)
@@ -791,7 +791,7 @@ class ElectrumGui(QObject, PrintError):
             return True
         return False
 
-    def warn_if_no_secp(self, parent=None, message=None, icon=QMessageBox.Warning, relaxed=False):
+    def warn_if_no_secp(self, parent=None, message=None, icon=QMessageBox.Warning):
         ''' Returns True if it DID warn: ie if there's no secp and ecc operations
         are slow, otherwise returns False if we have secp.
 
@@ -803,13 +803,8 @@ class ElectrumGui(QObject, PrintError):
         if has_secp:
             return False
 
-        # When relaxwarn is set return True without showing the warning
-        from electroncash import get_config
-        if relaxed and get_config().cmdline_options["relaxwarn"]:
-            return True
-
         # else..
-        howto_url='https://github.com/Electron-Cash/Electron-Cash/blob/master/contrib/secp_HOWTO.md#libsecp256k1-0-for-electron-cash'
+        howto_url = 'https://github.com/Bitcoin-ABC/ElectrumABC/blob/master/contrib/secp_HOWTO.md'
         message = message or _(
             f"{PROJECT_NAME} was unable to find the secp256k1 library on this "
             f"system. Elliptic curve cryptography operations will be performed"


### PR DESCRIPTION
In commit https://github.com/Bitcoin-ABC/ElectrumABC/pull/31/commits/00cb0b018f6edbc6a4e6f2d22ddbd509e5c8681e, I changed the way the program defaults to 'gui' when it is called without a command. This broke this special case when secp is not available, because the function showing the warning message relied on one of the default options set by the 'gui' subparser.

To fix this, I'm  simply removing the piece of code that requires --relax_warnings to be set by removing this options altogether. This reverts https://github.com/Electron-Cash/Electron-Cash/pull/1305.

Alternatively I could have kept the option and just fixed it by testing `"relaxwarn" is in cmdline_options`, but I don't like the idea of hiding annoying warnings. My plan is to hopefully figure out a way to get rid of the annoying warning by providing a proper python package for libsecp256k1, and make it a normal dependency that can be installed with `pip install`.

Test plan:

Without libsecp256k1 built, run `./electrum-abc` and check that it
starts with a warning instead of crashing.