### PR TITLE
Lower the default feerate and cleanup code

### DIFF
--- a/electroncash/bitcoin.py
+++ b/electroncash/bitcoin.py
@@ -58,8 +58,6 @@ do_monkey_patching_of_python_ecdsa_internals_with_libsecp256k1()
 ################################## transactions
 
 FEE_STEP = 10000
-MAX_FEE_RATE = 20000
-FEE_TARGETS = [25, 10, 5, 2]
 
 COINBASE_MATURITY = 100
 COIN = 100000000

--- a/electroncash/daemon.py
+++ b/electroncash/daemon.py
@@ -305,7 +305,6 @@ class Daemon(DaemonThread):
         password = config_options.get('password')
         new_password = config_options.get('new_password')
         config = SimpleConfig(config_options)
-        config.fee_estimates = self.network.config.fee_estimates.copy()
         cmdname = config.get('cmd')
         cmd = known_commands[cmdname]
         if cmd.requires_wallet:

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -77,7 +77,6 @@ def _(message): return message
 
 TX_STATUS = [
     _('Unconfirmed parent'),
-    _('Low fee'),
     _('Unconfirmed'),
     _('Not Verified'),
 ]
@@ -881,13 +880,6 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                     status_enum = self.StatusEnum.Unconfirmed
                     if fee is None:
                         fee = self.tx_fees.get(tx_hash)
-                    if fee and self.network and self.network.config.has_fee_estimates():
-                        # NB: this branch will not be taken as has_fee_estimates()
-                        # will always return false since we disabled querying
-                        # the fee histogram as it's useless for BCH anyway.
-                        size = tx.estimated_size()
-                        fee_per_kb = fee * 1000 / size
-                        exp_n = self.network.config.reverse_dynfee(fee_per_kb)
             else:
                 status = _("Signed")
                 status_enum = self.StatusEnum.Signed
@@ -1731,17 +1723,8 @@ class Abstract_Wallet(PrintError, SPVDelegate):
             tx = self.transactions.get(tx_hash)
             if not tx:
                 return 3, 'unknown'
-            fee = self.tx_fees.get(tx_hash)
-            if fee and self.network and self.network.config.has_fee_estimates():
-                size = len(tx.raw) / 2
-                low_fee = int(self.network.config.dynfee(0) * size / 1000)
-                is_lowfee = fee < low_fee * 0.5
-            else:
-                is_lowfee = False
             if height < 0:
                 status = 0
-            elif height == 0 and is_lowfee:
-                status = 1
             elif height == 0:
                 status = 2
             else:

--- a/electroncash_gui/qt/fee_slider.py
+++ b/electroncash_gui/qt/fee_slider.py
@@ -17,7 +17,7 @@ class FeeSlider(QSlider):
         self.valueChanged.connect(self.moved)
 
     def moved(self, pos):
-        fee_rate = self.config.dynfee(pos) if self.dyn else self.config.static_fee(pos)
+        fee_rate = self.config.static_fee(pos)
         tooltip = self.get_tooltip(pos, fee_rate)
         QToolTip.showText(QCursor.pos(), tooltip, self)
         self.setToolTip(tooltip)
@@ -32,9 +32,6 @@ class FeeSlider(QSlider):
             tooltip = _(fee_levels[pos]) + '\n' + rate_str
         else:
             tooltip = _('Fixed rate: ') + rate_str
-            if self.config.has_fee_estimates():
-                i = self.config.reverse_dynfee(fee_rate)
-                #tooltip += '\n' + (_('Low fee') if i < 0 else 'Within %d blocks'%i)
         return tooltip
 
     def update(self):

--- a/ios/ElectronCash/electroncash_gui/ios_native/feeslider.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/feeslider.py
@@ -31,7 +31,7 @@ class FeeSlider(UISlider):
         self = ObjCInstance(send_super(__class__, self, 'init'))
         if self is not None: self.commonInit()
         return self
-    
+
     @objc_method
     def commonInit(self) -> None:
         self.dyn = False
@@ -42,14 +42,14 @@ class FeeSlider(UISlider):
                                             UIControlStateNormal)
         self.setThumbImage_forState_(UIImage.imageNamed_("slider_knob"), UIControlStateNormal)
         self.reset()
-    
+
     @objc_method
     def initWithCoder_(self, coder : ObjCInstance) -> ObjCInstance:
         #utils.NSLog("Fee Slider initWithCoder!")
         self = ObjCInstance(send_super(__class__, self, 'initWithCoder:', coder.ptr, argtypes=[objc_id]))
         if self is not None: self.commonInit()
         return self
-    
+
     @objc_method
     def dealloc(self) -> None:
         #utils.NSLog("Fee Slider dealloc!")
@@ -61,7 +61,7 @@ class FeeSlider(UISlider):
     @objc_method
     def onMoved(self) -> None:
         pos = int(self.value)
-        self.feeRate = int(config().dynfee(pos) if self.dyn else config().static_fee(pos))
+        self.feeRate = config().static_fee(pos))
         #tooltip = self.get_tooltip(pos, fee_rate)
         #QToolTip.showText(QCursor.pos(), tooltip, self)
         #self.setToolTip(tooltip)
@@ -78,9 +78,6 @@ class FeeSlider(UISlider):
             tooltip = fee_levels[pos] + '\n' + rate_str
         else:
             tooltip = 'Fixed rate: ' + rate_str
-            if config().has_fee_estimates():
-                i = config().reverse_dynfee(fee_rate)
-                #tooltip += '\n' + (_('Low fee') if i < 0 else 'Within %d blocks'%i)
         return ns_from_py(tooltip)
 
     @objc_method
@@ -89,6 +86,6 @@ class FeeSlider(UISlider):
         self.feeRate = int(config().fee_per_kb())
         pos = int(min(self.feeRate / self.feeStep, 9.0))
         self.minimumValue = 0.0
-        self.maximumValue = 9.0        
+        self.maximumValue = 9.0
         self.value = float(pos)
         #print("ToolTip: %s"%(str(self.getToolTip(pos, fee_rate))))

--- a/ios/ElectronCash/electroncash_gui/ios_native/gui.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/gui.py
@@ -363,7 +363,7 @@ class ElectrumGui(PrintError):
             self.daemon.network.register_callback(self.on_quotes, ['on_quotes'])
             interests = ['wallet_updated', 'blockchain_updated',
                          'new_transaction', 'status', 'banner', 'verified2',
-                         'fee', 'interfaces']
+                         'interfaces']
             # To avoid leaking references to "self" that prevent the
             # window from being GC-ed when closed, callbacks should be
             # methods of this class only, and specifically not be
@@ -544,9 +544,6 @@ class ElectrumGui(PrintError):
             wallet = args[0]
             if wallet is self.wallet:  # this should always be the case. But we check anyway in case in the future we support multiple wallets open at once.
                 self.refresh_components('history', 'addresses', 'helper')
-        elif event == 'fee':
-            # todo: handle fee stuff here
-            pass
         elif event in ('interfaces',):
             self.refresh_components('network')
         else:


### PR DESCRIPTION
Revert an experimental commit, cleanup the code  to entirely drop the dynamic fee machinery that does not work currently.
Lower the default fee to 10 sats/byte.