### PR TITLE
fix broken old wallets

### DIFF
--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -507,10 +507,10 @@ class Old_KeyStore(Deterministic_KeyStore):
         return self.get_pubkey_from_mpk(self.mpk, for_change, n)
 
     def get_private_key_from_stretched_exponent(self, for_change, n, secexp):
-        order = ecdsa.generator_secp256k1.order()
+        order = ecdsa.ecdsa.generator_secp256k1.order()
         secexp = (secexp + self.get_sequence(self.mpk, for_change, n)) % order
         pk = ecdsa.util.number_to_string(
-            secexp, ecdsa.generator_secp256k1.order())
+            secexp, ecdsa.ecdsa.generator_secp256k1.order())
         return pk
 
     def get_private_key(self, sequence, password):


### PR DESCRIPTION
This fixes a collateral damage of PR #6, when I made the imports more explicit.
`generator_secp256k1` used to be imported indirectly via `from bitcoin import *`,
and I did not correctly adjust the import when I imported `ecdsa` directly
in `keystore.py`

If affects old wallets created before 2014, for Electrum 4.3.1.

TODO: find an old wallet and add a test