### PR TITLE
Performance tweak: Don't check is_mine when freezing coins

### DIFF
--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -561,19 +561,19 @@ class Abstract_Wallet(PrintError, SPVDelegate):
             return changed
 
     def invalidate_address_set_cache(self):
-        ''' This should be called from functions that add/remove addresses
+        """This should be called from functions that add/remove addresses
         from the wallet to ensure the address set caches are empty, in
         particular from ImportedWallets which may add/delete addresses
         thus the length check in is_mine() may not be accurate.
         Deterministic wallets can neglect to call this function since their
         address sets only grow and never shrink and thus the length check
-        of is_mine below is sufficient.'''
+        of is_mine below is sufficient."""
         self._recv_address_set_cached, self._change_address_set_cached = frozenset(), frozenset()
 
     def is_mine(self, address):
-        ''' Note this method assumes that the entire address set is
+        """Note this method assumes that the entire address set is
         composed of self.get_change_addresses() + self.get_receiving_addresses().
-        In subclasses, if that is not the case -- REIMPLEMENT this method! '''
+        In subclasses, if that is not the case -- REIMPLEMENT this method!"""
         assert not isinstance(address, str)
         # assumption here is get_receiving_addresses and get_change_addresses
         # are cheap constant-time operations returning a list reference.
@@ -594,7 +594,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         # addresses, it starts to add up siince is_mine() is called frequently
         # especially while downloading address history.
         return (address in self._recv_address_set_cached
-                    or address in self._change_address_set_cached)
+                or address in self._change_address_set_cached)
 
     def is_change(self, address):
         assert not isinstance(address, str)
@@ -2001,10 +2001,10 @@ class Abstract_Wallet(PrintError, SPVDelegate):
             return utxo in self.frozen_coins or utxo in self.frozen_coins_tmp
 
     def set_frozen_state(self, addrs, freeze):
-        ''' Set frozen state of the addresses to `freeze`, True or False. Note
+        """Set frozen state of the addresses to `freeze`, True or False. Note
         that address-level freezing is set/unset independent of coin-level
         freezing, however both must be satisfied for a coin to be defined as
-        spendable. '''
+        spendable."""
         if all(self.is_mine(addr) for addr in addrs):
             if freeze:
                 self.frozen_addresses |= set(addrs)
@@ -2016,8 +2016,8 @@ class Abstract_Wallet(PrintError, SPVDelegate):
             return True
         return False
 
-    def set_frozen_coin_state(self, utxos, freeze, *, temporary = False):
-        '''Set frozen state of the `utxos` to `freeze`, True or False. `utxos`
+    def set_frozen_coin_state(self, utxos, freeze, *, temporary=False):
+        """Set frozen state of the `utxos` to `freeze`, True or False. `utxos`
         is a (possibly mixed) list of either "prevout:n" strings and/or
         coin-dicts as returned from get_utxos(). Note that if passing prevout:n
         strings as input, 'is_mine()' status is not checked for the specified
@@ -2034,13 +2034,13 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         Note that setting `freeze = False` effectively unfreezes both the
         temporary and the permanent frozen coin sets all in 1 call. Thus after a
         call to `set_frozen_coin_state(utxos, False), both the temporary and the
-        persistent frozen sets are cleared of all coins in `utxos`. '''
+        persistent frozen sets are cleared of all coins in `utxos`."""
         add_set = self.frozen_coins if not temporary else self.frozen_coins_tmp
         def add(utxo):
-            add_set.add( utxo )
+            add_set.add(utxo)
         def discard(utxo):
-            self.frozen_coins.discard( utxo )
-            self.frozen_coins_tmp.discard( utxo )
+            self.frozen_coins.discard(utxo)
+            self.frozen_coins_tmp.discard(utxo)
         apply_operation = add if freeze else discard
         original_size = len(self.frozen_coins)
         with self.lock:
@@ -2049,7 +2049,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                 if isinstance(utxo, str):
                     apply_operation(utxo)
                     ok += 1
-                elif isinstance(utxo, dict) and self.is_mine(utxo['address']):
+                elif isinstance(utxo, dict):
                     txo = "{}:{}".format(utxo['prevout_hash'], utxo['prevout_n'])
                     apply_operation(txo)
                     utxo['is_frozen_coin'] = bool(freeze)


### PR DESCRIPTION
This is a backport of https://github.com/Electron-Cash/Electron-Cash/commit/f3a8ce85c15e2e602776215d3d472e0f807f652d
> The check was to ensure that as little "junk" ends up in the frozen coin
> set as possible.  However currently all code paths that lead to
> `set_frozen_coin_state` always freeze coins in the wallet and never any
> non-wallet coins.
> 
> Since the `is_mine` check is not free, and since some users may be
> freezing lots of coins at once on large wallets, the `is_mine` check can
> be removed. This turns an O(N log M) (where N is the number of coins and
> M is the size of the address set) into a simple O(N) loop.
> 
> In my testing on a wallet with 40000 utxos and 1500 addresses,
> freezing/unfreezing went from 90ms to 45 ms. Not a huge savings but not
> zero either. Maybe it will make a difference to some plugin such as
> CashFusion.
> 
> Note that it's not a huge tragedy to freeze a coin that is not `is_mine`
> -- it will just take up a little extra space in the wallet file forever.
> However since ending up in such a situation is currently impossible in
> this codebase, it's better to not check `is_mine` on every iteration when
> freezing coins.
> 
> Partially addresses #2102.