### PR TITLE
display amounts with thousands separators (localized)

### DIFF
--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -39,7 +39,7 @@ from functools import wraps
 from . import bitcoin
 from . import rpa
 from . import util
-from .constants import PROJECT_NAME, SCRIPT_NAME
+from .constants import PROJECT_NAME, SCRIPT_NAME, BASE_UNIT_8
 from .address import Address, AddressError
 from .bitcoin import hash_160, COIN, TYPE_ADDRESS
 from .i18n import _
@@ -723,7 +723,7 @@ class Commands:
             PR_EXPIRED: 'Expired',
         }
         out['address'] = out.get('address').to_ui_string()
-        out['amount (BCH)'] = format_satoshis(out.get('amount'))
+        out[f'amount ({BASE_UNIT_8})'] = format_satoshis(out.get('amount'))
         out['status'] = pr_str[out.get('status', PR_UNKNOWN)]
         return out
 
@@ -860,8 +860,9 @@ param_descriptions = {
     'pubkey': 'Public key',
     'message': 'Clear text message. Use quotes if it contains spaces.',
     'encrypted': 'Encrypted message',
-    'amount': 'Amount to be sent (in BCH). Type \'!\' to send the maximum available.',
-    'requested_amount': 'Requested amount (in BCH).',
+    'amount': f'Amount to be sent (in {BASE_UNIT_8}). Type \'!\' '
+              f'to send the maximum available.',
+    'requested_amount': f'Requested amount (in {BASE_UNIT_8}).',
     'outputs': 'list of ["address", amount]',
     'redeem_script': 'redeem script (hexadecimal)',
 }
@@ -876,7 +877,7 @@ command_options = {
     'entropy':     (None, "Custom entropy"),
     'expiration':  (None, "Time in seconds"),
     'expired':     (None, "Show only expired requests."),
-    'fee':         ("-f", "Transaction fee (in BCH)"),
+    'fee':         ("-f", f"Transaction fee (in {BASE_UNIT_8})"),
     'force':       (None, "Create new address beyond gap limit, if no more addresses are available."),
     'from_addr':   ("-F", "Source address (must be a wallet address; use sweep to spend from non-wallet address)."),
     'frozen':      (None, "Show only frozen addresses"),

--- a/electroncash/constants.py
+++ b/electroncash/constants.py
@@ -25,6 +25,11 @@ This directory is saved in the local directory containing the exe.
 BASE_UNITS: Mapping[str, int] = OrderedDict(
     (('BCHA', 8), ('mBCHA', 5), ('bits', 2)))
 """Ordered dict providing the location of the decimal place for all units."""
+"""Ordered dict providing the location of the decimal place for all
+conventional units."""
 
 INV_BASE_UNITS: Mapping[int, str] = {v: k for k, v in BASE_UNITS.items()}
 """Dict providing the unit string for a given decimal place."""
+
+BASE_UNIT_8 = INV_BASE_UNITS[8]
+"""Previous base unit ("bitcoin"), by convention 10^8 satoshis"""

--- a/electroncash/paymentrequest.py
+++ b/electroncash/paymentrequest.py
@@ -45,10 +45,10 @@ from . import util
 from . import transaction
 from . import x509
 from . import rsakey
-from .constants import PROJECT_NAME
 
 from .address import Address, PublicKey
 from .bitcoin import TYPE_ADDRESS
+from .constants import PROJECT_NAME, BASE_UNIT_8
 from .util import print_error, bh2u, bfh, PrintError
 from .util import FileImportFailed, FileImportFailedEncrypted
 from .transaction import Transaction
@@ -707,7 +707,7 @@ class PaymentRequest_BitPay20(PaymentRequest, PrintError):
                 time = dateutil.parser.parse(j['time']).timestamp(),
                 expires = dateutil.parser.parse(j['expires']).timestamp(),
                 network = j.get('network', 'main'),
-                currency = j.get('currency', 'BCH'),
+                currency = j.get('currency', f'{BASE_UNIT_8}'),
                 required_fee_rate = j.get('requiredFeeRate', 1),
             )
             self.outputs = []
@@ -888,7 +888,7 @@ class PaymentRequest_BitPay20(PaymentRequest, PrintError):
         h['Content-Type'] = 'application/verify-payment'
         unsigned_raw = unsigned_tx.serialize(True)
         body = {
-            'currency' : self.details.currency or 'BCH',
+            'currency' : self.details.currency or f'{BASE_UNIT_8}',
             'unsignedTransaction' : unsigned_raw,
             'weightedSize' : len(unsigned_raw)//2
         }
@@ -911,7 +911,7 @@ class PaymentRequest_BitPay20(PaymentRequest, PrintError):
         # Ok, all is valid -- now actually send the tx
         h['Content-Type'] = 'application/payment'
         body = {
-            'currency' : self.details.currency or 'BCH',
+            'currency' : self.details.currency or f'{BASE_UNIT_8}',
             'transactions' : [ raw_tx ]
         }
         try:

--- a/electroncash/tests/__main__.py
+++ b/electroncash/tests/__main__.py
@@ -15,7 +15,7 @@ from .test_simple_config import suite as test_simple_config_suite
 from .test_slp import SLPTests
 from .test_storage_upgrade import TestStorageUpgrade
 from .test_transaction import suite as test_transaction_suite
-from .test_util import TestUtil
+from .test_util import suite as test_util_suite
 from .test_wallet import suite as test_wallet_suite
 from .test_wallet_vertical import TestWalletKeystoreAddressIntegrity
 
@@ -38,7 +38,7 @@ def suite():
     test_suite.addTest(loadTests(SLPTests))
     test_suite.addTest(loadTests(TestStorageUpgrade))
     test_suite.addTest(test_transaction_suite())
-    test_suite.addTest(loadTests(TestUtil))
+    test_suite.addTest(test_util_suite())
     test_suite.addTest(test_wallet_suite())
     test_suite.addTest(loadTests(TestWalletKeystoreAddressIntegrity))
     return test_suite

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -1590,9 +1590,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         description_label.setBuddy(self.message_e)
         grid.addWidget(self.message_e, 2, 1, 1, -1)
 
-        msg_opreturn = ( _('OP_RETURN data (optional).') + '\n\n'
-                        + _('Posts a PERMANENT note to the BCH blockchain as part of this transaction.')
-                        + '\n\n' + _('If you specify OP_RETURN text, you may leave the \'Pay to\' field blank.') )
+        msg_opreturn = (_('OP_RETURN data (optional).') + '\n\n'
+                        + _(f'Posts a PERMANENT note to the {CURRENCY} '
+                            f'blockchain as part of this transaction.')
+                        + '\n\n' +
+                        _('If you specify OP_RETURN text, you may leave the'
+                          ' \'Pay to\' field blank.'))
         self.opreturn_label = HelpLabel(_('&OP_RETURN'), msg_opreturn)
         grid.addWidget(self.opreturn_label,  3, 0)
         self.message_opreturn_e = MyLineEdit()
@@ -2069,7 +2072,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                            len(segwits)).format(segwit_addresses='\n'.join(segwits))
             detail = _("Legacy '{prefix_char}...' p2sh address support in the Send tab is "
                        "restricted by default in order to prevent inadvertently "
-                       "sending BCH to Segwit BTC addresses.\n\n"
+                       f"sending {CURRENCY} to Segwit BTC addresses.\n\n"
                        "If you are an expert user, go to 'Preferences -> Transactions' "
                        "to enable the use of legacy p2sh addresses in the Send tab.").format(prefix_char=prefix_char)
             self.show_error(msg, detail_text=detail)

--- a/electroncash_plugins/fusion/fusion.py
+++ b/electroncash_plugins/fusion/fusion.py
@@ -32,6 +32,7 @@ This module has no GUI dependency.
 
 from electroncash import schnorr
 from electroncash.bitcoin import public_key_from_private_key
+from electroncash.constants import BASE_UNIT_8
 from electroncash.i18n import _, ngettext, pgettext
 from electroncash.util import format_satoshis, do_in_main_thread, PrintError, ServerError, TxHashMismatch, TimeoutException
 from electroncash.wallet import Standard_Wallet, Multisig_Wallet
@@ -1004,7 +1005,9 @@ class Fusion(threading.Thread, PrintError):
                 sum_in_str = format_satoshis(sum_in, num_zeros=8)
                 fee_str = str(total_fee)
                 feeloc = _('fee')
-                label = f"CashFusion {len(self.inputs)}⇢{len(self.outputs)}, {sum_in_str} BCH (−{fee_str} sats {feeloc})"
+                label = f"CashFusion {len(self.inputs)}⇢{len(self.outputs)}," \
+                        f" {sum_in_str} {BASE_UNIT_8} " \
+                        f"(−{fee_str} sats {feeloc})"
                 wallets = set(self.source_wallet_info.keys())
                 wallets.add(self.target_wallet)
                 if len(wallets) > 1:


### PR DESCRIPTION
This is useful when displaying amounts in mBCHA or in bits.

Add corresponding tests.

Also remove hardcoded "BCH" from strings (should have been in a separate PR, sorry )