### PR TITLE
Show CashAddr prefix

### DIFF
--- a/electroncash/address.py
+++ b/electroncash/address.py
@@ -389,7 +389,7 @@ class ScriptOutput(namedtuple("ScriptAddressTuple", "script")):
                 script.extend(Script.push_data(binascii.unhexlify(word)))
         return ScriptOutput.protocol_factory(bytes(script))
 
-    def to_ui_string(self,ignored=None):
+    def to_ui_string(self, ignored=None):
         '''Convert to user-readable OP-codes (plus pushdata as text if possible)
         eg OP_RETURN (12) "Hello there!"
         '''
@@ -425,6 +425,9 @@ class ScriptOutput(namedtuple("ScriptAddressTuple", "script")):
             else: # isinstance(op, int):
                 parts.append(lookup(op))
         return ', '.join(parts)
+
+    def to_full_ui_string(self):
+        return self.to_ui_string()
 
     def to_script(self):
         return self.script

--- a/electroncash/address.py
+++ b/electroncash/address.py
@@ -485,14 +485,14 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
     ADDR_P2SH = 1
 
     # Address formats
-    FMT_CASHADDR = 0
+    FMT_CASHADDR_BCH = 0
     FMT_LEGACY = 1
     FMT_BITPAY = 2   # Supported temporarily only for compatibility
 
     _NUM_FMTS = 3  # <-- Be sure to update this if you add a format above!
 
     # Default to CashAddr
-    FMT_UI = FMT_CASHADDR
+    FMT_UI = FMT_CASHADDR_BCH
 
     def __new__(cls, hash160, kind):
         assert kind in (cls.ADDR_P2PKH, cls.ADDR_P2SH)
@@ -504,7 +504,7 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
 
     @classmethod
     def show_cashaddr(cls, on):
-        cls.FMT_UI = cls.FMT_CASHADDR if on else cls.FMT_LEGACY
+        cls.FMT_UI = cls.FMT_CASHADDR_BCH if on else cls.FMT_LEGACY
 
     @classmethod
     def from_cashaddr_string(cls, string, *, net=None):
@@ -622,7 +622,7 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
 
         try:
             cached = None
-            if fmt == self.FMT_CASHADDR:
+            if fmt == self.FMT_CASHADDR_BCH:
                 cached = self.to_cashaddr(net=net)
                 return cached
 
@@ -650,7 +650,7 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
         '''Convert to text, with a URI prefix for cashaddr format.'''
         if net is None: net = networks.net
         text = self.to_string(fmt, net=net)
-        if fmt == self.FMT_CASHADDR:
+        if fmt == self.FMT_CASHADDR_BCH:
             text = ':'.join([net.CASHADDR_PREFIX, text])
         return text
 

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -170,7 +170,7 @@ class Commands:
         except Exception as e:
             raise AddressError(f'Invalid address: {address}') from e
         return {
-            'cashaddr' : addr.to_full_string(Address.FMT_CASHADDR),
+            'cashaddr' : addr.to_full_string(Address.FMT_CASHADDR_BCH),
             'legacy'   : addr.to_full_string(Address.FMT_LEGACY),
         }
 

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -148,7 +148,10 @@ class Commands:
                 for i in range(0,len(l)): l[i] = DoChk(l[i]) # recurse
                 return l
             def EncodeNamedTupleObject(nt):
-                if hasattr(nt, 'to_ui_string'): return nt.to_ui_string()
+                if hasattr(nt, 'to_full_ui_string'):
+                    return nt.to_full_ui_string()
+                if hasattr(nt, 'to_ui_string'):
+                    return nt.to_ui_string()
                 return nt
 
             if isinstance(v, tuple): v = EncodeNamedTupleObject(v)
@@ -288,7 +291,7 @@ class Commands:
         for i in l:
             v = i["value"]
             i["value"] = str(PyDecimal(v)/COIN) if v is not None else None
-            i["address"] = i["address"].to_ui_string()
+            i["address"] = i["address"].to_full_ui_string()
         return l
 
     @command('n')
@@ -665,7 +668,7 @@ class Commands:
                 continue
             if funded and self.wallet.is_empty(addr):
                 continue
-            item = addr.to_ui_string()
+            item = addr.to_full_ui_string()
             if labels or balance:
                 item = (item,)
             if balance:
@@ -720,7 +723,7 @@ class Commands:
             PR_PAID: 'Paid',
             PR_EXPIRED: 'Expired',
         }
-        out['address'] = out.get('address').to_ui_string()
+        out['address'] = out.get('address').to_full_ui_string()
         out[f'amount ({BASE_UNIT_8})'] = format_satoshis(out.get('amount'))
         out['status'] = pr_str[out.get('status', PR_UNKNOWN)]
         return out
@@ -757,13 +760,13 @@ class Commands:
     @command('w')
     def createnewaddress(self):
         """Create a new receiving address, beyond the gap limit of the wallet"""
-        return self.wallet.create_new_address(False).to_ui_string()
+        return self.wallet.create_new_address(False).to_full_ui_string()
 
     @command('w')
     def getunusedaddress(self):
         """Returns the first unused address of the wallet, or None if all addresses are used.
         An address is considered as used if it has received a transaction, or if it is used in a payment request."""
-        return self.wallet.get_unused_address().to_ui_string()
+        return self.wallet.get_unused_address().to_full_ui_string()
 
     @command('w')
     def addrequest(self, amount, memo='', expiration=None, force=False, payment_url=None, index_url=None):

--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -168,7 +168,7 @@ class Imported_KeyStore(Software_KeyStore):
         if not self._sorted:
             addresses = [pubkey.address for pubkey in self.keypairs]
             self._sorted = sorted(addresses,
-                                  key=lambda address: address.to_ui_string())
+                                  key=lambda address: address.to_full_ui_string())
         return self._sorted
 
     def address_to_pubkey(self, address):

--- a/electroncash/paymentrequest.py
+++ b/electroncash/paymentrequest.py
@@ -258,7 +258,7 @@ class PaymentRequest:
     def get_address(self):
         o = self.outputs[0]
         assert o[0] == TYPE_ADDRESS
-        return o[1].to_ui_string()
+        return o[1].to_full_ui_string()
 
     def get_requestor(self):
         return self.requestor if self.requestor else self.get_address()
@@ -858,7 +858,7 @@ class PaymentRequest_BitPay20(PaymentRequest, PrintError):
                 else:
                     # TODO: Fixme -- for now this branch will always be taken because we turned off key download in _get_signing_keys() above
                     self.print_error('Warning: Could not verify whether signing public key is valid:', pubkey.hex(), "(PGP verification is currently disabled)")
-                self.requestor = sig_addr.to_ui_string()
+                self.requestor = sig_addr.to_full_ui_string()
                 break
         else:
             self.error = 'failed to verify signature against retrieved keys'

--- a/electroncash/rpa/paycode.py
+++ b/electroncash/rpa/paycode.py
@@ -199,7 +199,7 @@ def generate_transaction_from_paycode(wallet, config, amount, rpa_paycode=None, 
     while not tx_matches_paycode_prefix:
 
         # Construct the transaction, initially with a dummy destination
-        rpa_dummy_address = wallet.dummy_address().to_string(Address.FMT_CASHADDR)
+        rpa_dummy_address = wallet.dummy_address().to_string(Address.FMT_CASHADDR_BCH)
         unsigned = True
         tx = _mktx(wallet, config, [(rpa_dummy_address, amount)], tx_fee, change_addr, domain, nocheck, unsigned,
                    password, locktime, op_return, op_return_raw)
@@ -229,7 +229,7 @@ def generate_transaction_from_paycode(wallet, config, amount, rpa_paycode=None, 
         # Get the real destination for the transaction
         rpa_destination_address = _generate_address_from_pubkey_and_secret(bytes.fromhex(paycode_field_spend_pubkey),
                                                                            shared_secret).to_string(
-            Address.FMT_CASHADDR)
+            Address.FMT_CASHADDR_BCH)
 
         # Swap the dummy destination for the real destination
         tx.rpa_paycode_swap_dummy_for_destination(rpa_dummy_address, rpa_destination_address)
@@ -273,7 +273,7 @@ def extract_private_key_from_transaction(wallet, raw_tx, password=None):
     output_addresses = []
     outputs = unpacked_tx["outputs"]
     for i in outputs:
-        output_addresses.append(i['address'].to_string(Address.FMT_CASHADDR))
+        output_addresses.append(i['address'].to_string(Address.FMT_CASHADDR_BCH))
 
     # Variables for looping
     number_of_inputs = len(unpacked_tx["inputs"])
@@ -314,7 +314,7 @@ def extract_private_key_from_transaction(wallet, raw_tx, password=None):
 
         # Get the destination address for the transaction
         destination = _generate_address_from_pubkey_and_secret(bytes.fromhex(spendpubkey), shared_secret).to_string(
-            Address.FMT_CASHADDR)
+            Address.FMT_CASHADDR_BCH)
 
         # Fetch our own private (spend) key out of the wallet.
         spendpubkey = wallet.derive_pubkeys(0, 1)

--- a/electroncash/transaction.py
+++ b/electroncash/transaction.py
@@ -524,7 +524,7 @@ class Transaction:
             loop_iteration_address = loop_iteration_output[1]
 
             # Compare the address to see if its the one we need to swap.  Note: 0 for the to_string = CASHADDR format
-            if loop_iteration_address.to_string(Address.FMT_CASHADDR) == rpa_dummy_address:
+            if loop_iteration_address.to_string(Address.FMT_CASHADDR_BCH) == rpa_dummy_address:
                 # Do the swap
                 rpa_replacement_address = Address.from_string(rpa_destination_address)
                 rpa_replacement_output = list(loop_iteration_output)

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -1678,9 +1678,9 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                     if x['type'] == 'coinbase': continue
                     addr = x.get('address')
                     if addr == None: continue
-                    input_addresses.append(addr.to_ui_string())
+                    input_addresses.append(addr.to_full_ui_string())
                 for _type, addr, v in tx.outputs():
-                    output_addresses.append(addr.to_ui_string())
+                    output_addresses.append(addr.to_full_ui_string())
                 item['input_addresses'] = input_addresses
                 item['output_addresses'] = output_addresses
             if fx is not None:
@@ -2360,10 +2360,9 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         if not r:
             return
         out = copy.copy(r)
-        addr_text = addr.to_ui_string()
-        amount_text = format_satoshis(r['amount'])
-        out['URI'] = '{}:{}?amount={}'.format(networks.net.CASHADDR_PREFIX,
-                                              addr_text, amount_text)
+        addr_text = addr.to_full_ui_string()
+        amount_text = format_satoshis(r['amount'])  # fixme: this should not be localized
+        out['URI'] = '{}?amount={}'.format(addr_text, amount_text)
         status, conf = self.get_request_status(addr)
         out['status'] = status
         if conf is not None:
@@ -2492,7 +2491,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                 f.write(pr.SerializeToString())
             # reload
             req = self.get_payment_request(addr, config)
-            req['address'] = req['address'].to_ui_string()
+            req['address'] = req['address'].to_full_ui_string()
             with open(os.path.join(path, key + '.json'), 'w', encoding='utf-8') as f:
                 f.write(json.dumps(req))
 
@@ -2834,7 +2833,7 @@ class ImportedAddressWallet(ImportedWalletBase):
     def get_addresses(self, include_change=False):
         if not self._sorted:
             self._sorted = sorted(self.addresses,
-                                  key=lambda addr: addr.to_ui_string())
+                                  key=lambda addr: addr.to_full_ui_string())
         return self._sorted
 
     def import_address(self, address):
@@ -2925,7 +2924,7 @@ class ImportedPrivkeyWallet(ImportedWalletBase):
         self.cashacct.save()
         self.save_addresses()
         self.storage.write()  # no-op if above already wrote
-        return pubkey.address.to_ui_string()
+        return pubkey.address.to_full_ui_string()
 
     def export_private_key(self, address, password):
         '''Returned in WIF format.'''

--- a/electroncash/web.py
+++ b/electroncash/web.py
@@ -41,15 +41,15 @@ DEFAULT_EXPLORER = "Blockchair.com"
 
 mainnet_block_explorers = {
     'Blockchair.com': ('https://blockchair.com/bitcoin-abc',
-                       Address.FMT_CASHADDR,
+                       Address.FMT_CASHADDR_BCH,
                        {'tx': 'transaction', 'addr': 'address',
                         'block': 'block'}),
     'ViaBTC.com': ('https://explorer.viawallet.com/bha',
-                   Address.FMT_CASHADDR,
+                   Address.FMT_CASHADDR_BCH,
                    {'tx': 'tx', 'addr': 'address',
                     'block': 'block'}),
     'BitcoinABC.org': ('https://explorer.bitcoinabc.org',
-                       Address.FMT_CASHADDR,
+                       Address.FMT_CASHADDR_BCH,
                        {'tx': 'tx',
                         'addr': 'address',
                         'block': 'block-height'}),
@@ -59,7 +59,7 @@ DEFAULT_EXPLORER_TESTNET = 'BitcoinABC.org'
 
 testnet_block_explorers = {
     'BitcoinABC.org': ('https://texplorer.bitcoinabc.org/',
-                       Address.FMT_CASHADDR,
+                       Address.FMT_CASHADDR_BCH,
                        {'tx': 'tx', 'addr': 'address',
                         'block': 'block-height'}),
 }

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -935,16 +935,29 @@ class ElectrumGui(QObject, PrintError):
                 self.tray.showMessage(f"{PROJECT_NAME}", message,
                                       QSystemTrayIcon.Information, 20000)
 
-    def is_cashaddr(self):
-        return bool(self.config.get('show_cashaddr', True))
+    def is_cashaddr(self) -> bool:
+        return bool(self.get_address_format() == Address.FMT_CASHADDR_BCH)
 
-    def toggle_cashaddr(self, on = None):
+    def get_address_format(self) -> str:
+        return self.config.get('address_format', Address.FMT_CASHADDR_BCH)
+
+    def toggle_cashaddr(self):
+        """switch between available address formats"""
+        Address.toggle_address_format()
+        self.config.set_key('address_format', Address.FMT_UI)
+        self.cashaddr_toggled_signal.emit()
+
+    def use_cashaddr_bch(self, on):
+        """toggle between Address.FMT_CASHADDR_BCH  and FMT_LEGACY"""
+        self.print_error("use_cashaddr_bch is deprecated")
         was = self.is_cashaddr()
         if on is None:
             on = not was
         else:
             on = bool(on)
-        self.config.set_key('show_cashaddr', on)
+        self.config.set_key(
+            'address_format',
+            Address.FMT_CASHADDR_BCH if on else Address.FMT_LEGACY)
         Address.show_cashaddr(on)
         if was != on:
             self.cashaddr_toggled_signal.emit()

--- a/electroncash_gui/qt/address_list.py
+++ b/electroncash_gui/qt/address_list.py
@@ -194,7 +194,7 @@ class AddressList(MyTreeWidget):
                 else:
                     is_hidden = self.wallet.is_used(address)
                 balance = sum(self.wallet.get_addr_balance(address))
-                address_text = address.to_ui_string()
+                address_text = address.to_full_ui_string()
                 # Cash Accounts
                 ca_info, ca_list = None, ca_by_addr.get(address)
                 if ca_list:
@@ -335,10 +335,10 @@ class AddressList(MyTreeWidget):
             if col > -1:
                 texts, alt_copy, alt_copy_text = None, None, None
                 if col == 0: # address column
-                    texts = [a.to_ui_string() for a in addrs]
+                    texts = [a.to_full_ui_string() for a in addrs]
                     # Add additional copy option: "Address, Balance (n)"
                     alt_copy = _("Copy {}").format(_("Address") + ", " + _("Balance")) + f" ({len(addrs)})"
-                    alt_copy_text = "\n".join([a.to_ui_string() + ", " + self.parent.format_amount(sum(self.wallet.get_addr_balance(a)))
+                    alt_copy_text = "\n".join([a.to_full_ui_string() + ", " + self.parent.format_amount(sum(self.wallet.get_addr_balance(a)))
                                               for a in addrs])
                 else:
                     texts = [i.text(col).strip() for i in selected]
@@ -443,7 +443,7 @@ class AddressList(MyTreeWidget):
         Kicked off by a get_minimal_chash() call that results in a cache miss. '''
         if self.cleaned_up:
             return
-        items = self.findItems(ca_info.address.to_ui_string(), Qt.MatchContains|Qt.MatchWrap|Qt.MatchRecursive, 0) or []
+        items = self.findItems(ca_info.address.to_full_ui_string(), Qt.MatchContains|Qt.MatchWrap|Qt.MatchRecursive, 0) or []
         for item in items:  # really items should contain just 1 element...
             ca_list = item.data(0, self.DataRoles.cash_accounts) or []
             ca_info_default = self._ca_get_default(ca_list)

--- a/electroncash_gui/qt/address_list.py
+++ b/electroncash_gui/qt/address_list.py
@@ -297,7 +297,7 @@ class AddressList(MyTreeWidget):
             if col == 0:
                 copy_text = addr.to_full_ui_string()
                 if Address.FMT_UI == Address.FMT_LEGACY:
-                    alt_copy_text, alt_column_title = addr.to_full_string(Address.FMT_CASHADDR), _('Cash Address')
+                    alt_copy_text, alt_column_title = addr.to_full_string(Address.FMT_CASHADDR_BCH), _('Cash Address')
                 else:
                     alt_copy_text, alt_column_title = addr.to_full_string(Address.FMT_LEGACY), _('Legacy Address')
             else:

--- a/electroncash_gui/qt/bip38_importer.py
+++ b/electroncash_gui/qt/bip38_importer.py
@@ -181,7 +181,7 @@ class Bip38Importer(WindowModalDialog, util.PrintError):
         self.wif_lbl.setText((is_ok and self.decoded_wif) or bad_txt)
         # set adr_lbl font
         f = self.adr_lbl.font(); f.setFamily(MONOSPACE_FONT if is_ok else QFont().family()); f.setItalic(not is_ok); self.adr_lbl.setFont(f)
-        self.adr_lbl.setText((is_ok and self.decoded_address.to_ui_string()) or bad_txt)
+        self.adr_lbl.setText((is_ok and self.decoded_address.to_full_ui_string()) or bad_txt)
 
         self.ok.setEnabled(isinstance(self.decoded_address, address.Address))
         self.ok.setText(_('OK') if cur+1 == num else _("Next"))

--- a/electroncash_gui/qt/cashacctqt.py
+++ b/electroncash_gui/qt/cashacctqt.py
@@ -459,12 +459,12 @@ class InfoGroupBox(PrintError, QGroupBox):
                 addr_lbl = ButtonAssociatedLabel('', button=rb)
                 if is_valid:
                     if is_mine:
-                        addr_lbl.setText(f'<a href="{info.address.to_ui_string()}"><pre>{info.address.to_ui_string()}</pre></a>')
+                        addr_lbl.setText(f'<a href="{info.address.to_full_ui_string()}"><pre>{info.address.to_full_ui_string()}</pre></a>')
                         addr_lbl.linkActivated.connect(view_addr_link_activated)
                         addr_lbl.setToolTip(_('Wallet') + ' - ' + (_('Change Address') if is_change else _('Receiving Address')))
                         addr_lbl.setButton(None)  # disable click to select
                     else:
-                        addr_lbl.setText(f'<pre>{info.address.to_ui_string()}</pre>')
+                        addr_lbl.setText(f'<pre>{info.address.to_full_ui_string()}</pre>')
                 else:
                     addr_lbl.setText('<i>' + _('Unsupported Account Type') + '</i>')
                     addr_lbl.setToolTip(rb.toolTip())
@@ -852,7 +852,7 @@ def cash_account_detail_dialog(parent : MessageBoxMixin,  # Should be an Electru
                                     parent.copy_to_clipboard(text=ca_string_em, tooltip=_('Cash Account copied to clipboard'), widget=copy_but) )
     grid.addWidget(copy_name_but, 0, 2, 1, 1)
     # address label
-    addr_lbl = QLabel(f'<span style="white-space:nowrap; font-size:15pt;"><a href="{info.address.to_ui_string()}"><pre>{info.address.to_ui_string()}</pre></a></span>')
+    addr_lbl = QLabel(f'<span style="white-space:nowrap; font-size:15pt;"><a href="{info.address.to_full_ui_string()}"><pre>{info.address.to_full_ui_string()}</pre></a></span>')
     addr_lbl.linkActivated.connect(open_link)
     grid.addWidget(addr_lbl, 1, 1, 1, 1)
     # copy address label
@@ -860,7 +860,7 @@ def cash_account_detail_dialog(parent : MessageBoxMixin,  # Should be an Electru
     copy_addr_but.setIcon(QIcon(":icons/copy.png"))
     button_make_naked(copy_addr_but)
     copy_addr_but.setToolTip(_("Copy {}").format(_("Address")))
-    copy_addr_but.clicked.connect(lambda ignored=None, text=info.address.to_ui_string(), copy_but=copy_addr_but:
+    copy_addr_but.clicked.connect(lambda ignored=None, text=info.address.to_full_ui_string(), copy_but=copy_addr_but:
                                     parent.copy_to_clipboard(text=text, tooltip=_('Address copied to clipboard'), widget=copy_but) )
     grid.addWidget(copy_addr_but, 1, 2, 1, 1)
 

--- a/electroncash_gui/qt/contact_list.py
+++ b/electroncash_gui/qt/contact_list.py
@@ -353,7 +353,7 @@ class ContactList(PrintError, MyTreeWidget):
                 continue
             wallet_cashaccts.append(Contact(
                 name = name,
-                address = ca_info.address.to_ui_string(),
+                address = ca_info.address.to_full_ui_string(),
                 type = 'cashacct_W'
             ))
         # Add the [Pend] pseudo-contacts
@@ -366,7 +366,7 @@ class ContactList(PrintError, MyTreeWidget):
             name, address = tup
             wallet_cashaccts.append(Contact(
                 name = name,
-                address = address.to_ui_string(),
+                address = address.to_full_ui_string(),
                 type = 'cashacct_T'
             ))
         return wallet_cashaccts
@@ -411,7 +411,7 @@ class ContactList(PrintError, MyTreeWidget):
                 try:
                     # try and re-parse and re-display the address based on current UI string settings
                     addy = Address.from_string(address)
-                    address = addy.to_ui_string()
+                    address = addy.to_full_ui_string()
                     label_key = addy.to_storage_string()
                     del addy
                 except:
@@ -475,7 +475,7 @@ class ContactList(PrintError, MyTreeWidget):
         )
         if items:
             info, min_chash, name = items[0]
-            self.parent.set_contact(name, info.address.to_ui_string(), typ='cashacct')
+            self.parent.set_contact(name, info.address.to_full_ui_string(), typ='cashacct')
             run_hook('update_contacts_tab', self)
 
     def ca_update_potentially_unconfirmed_registrations(self, d : Dict[str, Tuple[str, Address]]):

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -3980,14 +3980,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         self.gui_object.toggle_cashaddr()
         self.statusBar().showMessage(self.cashaddr_status_tip(), 2000)
 
-    def toggle_cashaddr_settings(self, state):
-        self.gui_object.toggle_cashaddr(state == Qt.Checked)
-
-    def toggle_cashaddr(self, on):
-        self.print_error('*** WARNING ElectrumWindow.toggle_cashaddr: This function is deprecated. Please do not call it!')
-        self.gui_object.toggle_cashaddr(on)
-
-
     def settings_dialog(self):
         class SettingsModalDialog(WindowModalDialog):
             shown_signal = pyqtSignal()
@@ -4351,12 +4343,16 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         address_w.setToolTip(_('Select between Cash Address and Legacy formats for addresses'))
         hbox = QHBoxLayout(address_w)
         cashaddr_cbox = QComboBox()
-        cashaddr_cbox.addItem(QIcon(':icons/tab_converter.svg'), _("CashAddr"), Address.FMT_CASHADDR_BCH)
-        cashaddr_cbox.addItem(QIcon(':icons/tab_converter_bw.svg'), _("Legacy"), Address.FMT_LEGACY)
+        cashaddr_cbox.addItem(QIcon(':icons/tab_converter.svg'),
+                              _("CashAddr") + " BCH",
+                              Address.FMT_CASHADDR_BCH)
+        cashaddr_cbox.addItem(QIcon(':icons/tab_converter_bw.svg'),
+                              _("Legacy"),
+                              Address.FMT_LEGACY)
         cashaddr_cbox.setCurrentIndex(0 if self.gui_object.is_cashaddr() else 1)
         def cashaddr_cbox_handler(ignored_param):
-            fmt = int(cashaddr_cbox.currentData())
-            self.gui_object.toggle_cashaddr(fmt == Address.FMT_CASHADDR_BCH)
+            fmt = cashaddr_cbox.currentData()
+            self.gui_object.use_cashaddr_bch(fmt == Address.FMT_CASHADDR_BCH)
         cashaddr_cbox.currentIndexChanged.connect(cashaddr_cbox_handler)
         hbox.addWidget(cashaddr_cbox)
         toggle_cashaddr_control = QCheckBox(_('Hide status button'))

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -2495,7 +2495,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         legacy_address.setReadOnly(True)
 
         widgets = [
-            (cash_address, Address.FMT_CASHADDR),
+            (cash_address, Address.FMT_CASHADDR_BCH),
             (legacy_address, Address.FMT_LEGACY),
         ]
 
@@ -4351,12 +4351,12 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         address_w.setToolTip(_('Select between Cash Address and Legacy formats for addresses'))
         hbox = QHBoxLayout(address_w)
         cashaddr_cbox = QComboBox()
-        cashaddr_cbox.addItem(QIcon(':icons/tab_converter.svg'), _("CashAddr"), Address.FMT_CASHADDR)
+        cashaddr_cbox.addItem(QIcon(':icons/tab_converter.svg'), _("CashAddr"), Address.FMT_CASHADDR_BCH)
         cashaddr_cbox.addItem(QIcon(':icons/tab_converter_bw.svg'), _("Legacy"), Address.FMT_LEGACY)
         cashaddr_cbox.setCurrentIndex(0 if self.gui_object.is_cashaddr() else 1)
         def cashaddr_cbox_handler(ignored_param):
             fmt = int(cashaddr_cbox.currentData())
-            self.gui_object.toggle_cashaddr(fmt == Address.FMT_CASHADDR)
+            self.gui_object.toggle_cashaddr(fmt == Address.FMT_CASHADDR_BCH)
         cashaddr_cbox.currentIndexChanged.connect(cashaddr_cbox_handler)
         hbox.addWidget(cashaddr_cbox)
         toggle_cashaddr_control = QCheckBox(_('Hide status button'))

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -733,7 +733,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             desc, address = tup
             if (desc and address and isinstance(desc, str) and isinstance(address, Address)
                     and desc not in d and not desc.lower().startswith(spv_prefix.lower())):
-                d[desc] = address.to_ui_string()
+                d[desc] = address.to_full_ui_string()
         def do_payto(desc):
             addr = d[desc]
             # The message is intentionally untranslated, leave it like that
@@ -2584,7 +2584,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
     def remove_address(self, addr):
         if self.question(_("Do you want to remove {} from your wallet?"
-                           .format(addr.to_ui_string()))):
+                           .format(addr.to_full_ui_string()))):
             self.wallet.delete_address(addr)
             self.update_tabs()
             self.update_status()
@@ -2676,7 +2676,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 self.contact_list.update() # Displays original
                 return
             info, label = tup
-            address = info.address.to_ui_string()
+            address = info.address.to_full_ui_string()
             contact = Contact(name=label, address=address, type=typ)
         elif not Address.is_valid(address):
             # Bad 'address' code path
@@ -2745,7 +2745,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         grid.addWidget(QLabel(_("Requestor") + ':'), 0, 0)
         grid.addWidget(QLabel(pr.get_requestor()), 0, 1)
         grid.addWidget(QLabel(_("Amount") + ':'), 1, 0)
-        outputs_str = '\n'.join(map(lambda x: self.format_amount(x[2])+ self.base_unit() + ' @ ' + x[1].to_ui_string(), pr.get_outputs()))
+        outputs_str = '\n'.join(map(lambda x: self.format_amount(x[2])+ self.base_unit() + ' @ ' + x[1].to_full_ui_string(), pr.get_outputs()))
         grid.addWidget(QLabel(outputs_str), 1, 1)
         expires = pr.get_expiration_date()
         grid.addWidget(QLabel(_("Memo") + ':'), 2, 0)
@@ -3202,7 +3202,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         layout.setRowStretch(2,3)
 
         address_e = QLineEdit()
-        address_e.setText(address.to_ui_string() if address else '')
+        address_e.setText(address.to_full_ui_string() if address else '')
         layout.addWidget(QLabel(_('Address')), 2, 0)
         layout.addWidget(address_e, 2, 1)
 
@@ -3545,7 +3545,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
                 except InvalidPassword:
                     # See #921 -- possibly a corrupted wallet or other strangeness
                     privkey = 'INVALID_PASSWORD'
-                private_keys[addr.to_ui_string()] = privkey
+                private_keys[addr.to_full_ui_string()] = privkey
                 strong_d = weak_d()
                 try:
                     if strong_d and not stop:
@@ -5062,7 +5062,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             le.addWidget(help_but)
             name = line_dialog(self.top_level_window(),
                                _("Register A New Cash Account"),
-                               (_("You are registering a new <a href='ca'>Cash Account</a> for your address <a href='addr'><b><pre>{address}</pre></b></a>").format(address=addr.to_ui_string())
+                               (_("You are registering a new <a href='ca'>Cash Account</a> for your address <a href='addr'><b><pre>{address}</pre></b></a>").format(address=addr.to_full_ui_string())
                                 + _("The current block height is <b><i>{block_height}</i></b>, so the new cash account will likely look like: <b><u><i>AccountName<i>#{number}</u></b>.")
                                 .format(block_height=lh or '???', number=max(cashacct.bh2num(lh or 0)+1, 0) or '???')
                                 + "<br><br><br>" + _("Specify the <b>account name</b> below (limited to 99 characters):") ),
@@ -5104,7 +5104,7 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
         # Set a default description -- this we allow them to edit
         self.message_e.setText(
             _("Cash Accounts Registration: '{name}' -> {address}").format(
-                name=name, address=addr.to_ui_string()
+                name=name, address=addr.to_full_ui_string()
             )
         )
 

--- a/electroncash_gui/qt/paytoedit.py
+++ b/electroncash_gui/qt/paytoedit.py
@@ -356,7 +356,7 @@ class PayToEdit(PrintError, ScanQRTextEdit):
         if isinstance(address, str):
             address_str = address
         elif isinstance(address, Address):
-            address_str = address.to_ui_string()
+            address_str = address.to_full_ui_string()
         else:
             raise RuntimeError('unknown address type')
 
@@ -410,7 +410,7 @@ class PayToEdit(PrintError, ScanQRTextEdit):
                 parts = [ca_string]  # strip down to JUST ca_string
             ca_info = wallet.cashacct.get_verified(ca_string)
             if ca_info:
-                resolved = wallet.cashacct.fmt_info(ca_info) + " " + ca_info.emoji + " <" + ca_info.address.to_ui_string() + ">"
+                resolved = wallet.cashacct.fmt_info(ca_info) + " " + ca_info.emoji + " <" + ca_info.address.to_full_ui_string() + ">"
                 lines[n] = line = resolved + " ".join(parts[1:])  # rewrite line, putting the resolved cash account + <address> at the beginning, amount at the end (if any)
             else:
                 lines[n] = line = " ".join(parts)  # rewrite line, possibly stripping <> address here

--- a/electroncash_gui/qt/request_list.py
+++ b/electroncash_gui/qt/request_list.py
@@ -128,7 +128,7 @@ class RequestList(MyTreeWidget):
             signature = req.get('sig')
             requestor = req.get('name', '')
             amount_str = self.parent.format_amount(amount) if amount else ""
-            item = QTreeWidgetItem([date, address.to_ui_string(), '', message,
+            item = QTreeWidgetItem([date, address.to_full_ui_string(), '', message,
                                     amount_str, _(pr_tooltips.get(status,''))])
             item.setData(0, Qt.UserRole, address)
             if signature is not None:

--- a/electroncash_gui/qt/transaction_dialog.py
+++ b/electroncash_gui/qt/transaction_dialog.py
@@ -623,12 +623,12 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
                 if self.wallet.is_change(addr):
                     chg_ct += 1
                     chg2 = QTextCharFormat(chg)
-                    chg2.setAnchorHref(addr.to_ui_string())
+                    chg2.setAnchorHref(addr.to_full_ui_string())
                     return chg2
                 else:
                     rec_ct += 1
                     rec2 = QTextCharFormat(rec)
-                    rec2.setAnchorHref(addr.to_ui_string())
+                    rec2.setAnchorHref(addr.to_full_ui_string())
                     return rec2
             return ext
 
@@ -659,7 +659,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
                 if addr is None:
                     addr_text = _('unknown')
                 else:
-                    addr_text = addr.to_ui_string()
+                    addr_text = addr.to_full_ui_string()
                 cursor.insertText(addr_text, text_format(addr))
                 if x.get('value'):
                     cursor.insertText(format_amount(x['value']), ext)
@@ -705,7 +705,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
             # Format Cash Accounts address *in* script to be highlighted with
             # our preferred yellow/green for change/receiving and also
             # linkify it.
-            addrstr = addr.to_ui_string()
+            addrstr = addr.to_full_ui_string()
             my_addr_in_script_str = my_addr_in_script and my_addr_in_script.to_ui_string()
             idx = my_addr_in_script_str and addrstr.find(my_addr_in_script_str)
             if idx is not None and idx > -1:
@@ -832,8 +832,8 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
         menu.exec_(global_pos)
 
     def _add_addr_to_io_menu_lists_for_widget(self, addr, show_list, copy_list, widget):
-        if hasattr(addr, 'to_ui_string'):
-            addr_text = addr.to_ui_string()
+        if hasattr(addr, 'to_full_ui_string'):
+            addr_text = addr.to_full_ui_string()
             if isinstance(addr, Address) and self.wallet.is_mine(addr):
                 show_list += [ ( _("Address Details"), lambda: self._open_internal_link(addr_text) ) ]
                 addr_URL = web.BE_URL(self.main_window.config, 'addr', addr)
@@ -875,7 +875,7 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
                 value_fmtd = self.main_window.format_amount(value)
                 copy_list += [ ( _("Copy Amount"), lambda: self._copy_to_clipboard(value_fmtd, o_text) ) ]
             if ca_script:
-                copy_list += [ ( _("Copy Address (Embedded)"), lambda: self._copy_to_clipboard(ca_script.address.to_ui_string(), o_text) ) ]
+                copy_list += [ ( _("Copy Address (Embedded)"), lambda: self._copy_to_clipboard(ca_script.address.to_full_ui_string(), o_text) ) ]
                 if ca_script.is_complete() and self.tx_hash:
                     text_getter = lambda: self.wallet.cashacct.fmt_info(cashacct.Info.from_script(ca_script, self.tx_hash), emoji=True)
                     text_getter()  # go out to network to cache the shortest encoding for cash account name ahead of time...

--- a/electroncash_gui/qt/util.py
+++ b/electroncash_gui/qt/util.py
@@ -505,7 +505,7 @@ class ChoicesLayout(object):
 
 def address_combo(addresses):
     addr_combo = QComboBox()
-    addr_combo.addItems(addr.to_ui_string() for addr in addresses)
+    addr_combo.addItems(addr.to_full_ui_string() for addr in addresses)
     addr_combo.setCurrentIndex(0)
 
     hbox = QHBoxLayout()

--- a/electroncash_gui/qt/utxo_list.py
+++ b/electroncash_gui/qt/utxo_list.py
@@ -243,7 +243,7 @@ class UTXOList(MyTreeWidget):
                     # Determine the "alt copy text" "Legacy Address" or "Cash Address"
                     copy_text = addr.to_full_ui_string()
                     if Address.FMT_UI == Address.FMT_LEGACY:
-                        alt_copy_text, alt_column_title = addr.to_full_string(Address.FMT_CASHADDR), _('Cash Address')
+                        alt_copy_text, alt_column_title = addr.to_full_string(Address.FMT_CASHADDR_BCH), _('Cash Address')
                     else:
                         alt_copy_text, alt_column_title = addr.to_full_string(Address.FMT_LEGACY), _('Legacy Address')
                     ca_info = item.data(0, self.DataRoles.cash_account)  # may be None

--- a/electroncash_gui/qt/utxo_list.py
+++ b/electroncash_gui/qt/utxo_list.py
@@ -126,7 +126,7 @@ class UTXOList(MyTreeWidget):
             self.utxos = self.wallet.get_utxos(exclude_slp=False)
         for x in self.utxos:
             address = x['address']
-            address_text = address.to_ui_string()
+            address_text = address.to_full_ui_string()
             ca_info = None
             ca_list = ca_by_addr.get(address)
             tool_tip0 = None

--- a/electroncash_gui/text.py
+++ b/electroncash_gui/text.py
@@ -154,7 +154,7 @@ class ElectrumGui:
         self.stdscr.addstr(self.maxy -1, self.maxx-30, ' '.join([_("Settings"), _("Network"), _("Quit")]))
 
     def print_receive(self):
-        addr = self.wallet.get_receiving_address().to_ui_string()
+        addr = self.wallet.get_receiving_address().to_full_ui_string()
         self.stdscr.addstr(2, 1, "Address: "+addr)
         self.print_qr(addr)
 

--- a/electroncash_plugins/keepkey/keepkey.py
+++ b/electroncash_plugins/keepkey/keepkey.py
@@ -458,7 +458,7 @@ class KeepKeyPlugin(HW_PluginBase):
                 txoutputtype.op_return_data = validate_op_return_output_and_get_data(o, max_pushes=1)
             elif _type == TYPE_ADDRESS:
                 txoutputtype.script_type = self.types.PAYTOADDRESS
-                txoutputtype.address = address.to_full_string(Address.FMT_CASHADDR, net=networks.MainNet)
+                txoutputtype.address = address.to_full_string(Address.FMT_CASHADDR_BCH, net=networks.MainNet)
             return txoutputtype
 
         outputs = []

--- a/electroncash_plugins/ledger/auth2fa.py
+++ b/electroncash_plugins/ledger/auth2fa.py
@@ -105,7 +105,7 @@ class LedgerAuthDialog(QDialog):
 
                 # We also show the UI address if it is different
                 if networks.net.TESTNET or not Address.FMT_UI == Address.FMT_LEGACY:
-                    addressstr = address.to_ui_string() + '\n' + addressstr
+                    addressstr = address.to_full_ui_string() + '\n' + addressstr
 
                 self.addrtext.setHtml(str(addressstr))
             else:

--- a/electroncash_plugins/ledger/ledger.py
+++ b/electroncash_plugins/ledger/ledger.py
@@ -278,7 +278,7 @@ class Ledger_KeyStore(Hardware_KeyStore):
 
     def cashaddr_alert(self):
         """Alert users about fw/sw updates for cashaddr."""
-        if Address.FMT_UI == Address.FMT_CASHADDR:
+        if Address.FMT_UI == Address.FMT_CASHADDR_BCH:
             # Do not warn if the device is HW1, they have no display anyway
             if not self.get_client_electrum().fw_supports_cashaddr() and not self.get_client_electrum().is_hw1():
                 self.handler.show_warning(MSG_NEEDS_FW_UPDATE_CASHADDR)
@@ -470,7 +470,7 @@ class Ledger_KeyStore(Hardware_KeyStore):
             # Sign all inputs
             inputIndex = 0
             self.get_client().enableAlternate2fa(False)
-            cashaddr = Address.FMT_UI == Address.FMT_CASHADDR
+            cashaddr = Address.FMT_UI == Address.FMT_CASHADDR_BCH
             if cashaddr and self.get_client_electrum().supports_cashaddr():
                 self.get_client().startUntrustedTransaction(True, inputIndex, chipInputs,
                                                             redeemScripts[inputIndex], cashAddr=True)
@@ -532,7 +532,7 @@ class Ledger_KeyStore(Hardware_KeyStore):
         self.cashaddr_alert()
         self.handler.show_message(_('Showing address on {}...').format(self.device))
         try:
-            if Address.FMT_UI == Address.FMT_CASHADDR and self.get_client_electrum().supports_cashaddr():
+            if Address.FMT_UI == Address.FMT_CASHADDR_BCH and self.get_client_electrum().supports_cashaddr():
                 client.getWalletPublicKey(address_path, showOnScreen=True, cashAddr=True)
             else:
                 client.getWalletPublicKey(address_path, showOnScreen=True)

--- a/electroncash_plugins/trezor/trezor.py
+++ b/electroncash_plugins/trezor/trezor.py
@@ -470,7 +470,7 @@ class TrezorPlugin(HW_PluginBase):
                     if client.atleast_version(2, 0, 8):
                         addr_format = address.FMT_UI
                     elif client.atleast_version(2, 0, 7):
-                        addr_format = address.FMT_CASHADDR
+                        addr_format = address.FMT_CASHADDR_BCH
                 else:
                     if client.atleast_version(1, 6, 2):
                         addr_format = address.FMT_UI

--- a/ios/ElectronCash/electroncash_gui/ios_native/addrconv.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/addrconv.py
@@ -14,22 +14,22 @@ from .custom_objc import *
 
 
 class AddrConvVC(AddrConvBase):
-      
+
     @objc_method
     def init(self) -> ObjCInstance:
         self = ObjCInstance(send_super(__class__, self, 'init'))
         if self:
             self.title = _("Address Converter")
         return self
-    
+
     @objc_method
     def dealloc(self) -> None:
         send_super(__class__, self, 'dealloc')
-    
+
     @objc_method
     def loadView(self) -> None:
         NSBundle.mainBundle.loadNibNamed_owner_options_("AddressConverter",self,None)
-        
+
     @objc_method
     def viewDidLoad(self) -> None:
         send_super(__class__, self, 'viewDidLoad')
@@ -38,19 +38,19 @@ class AddrConvVC(AddrConvBase):
         ats = NSMutableAttributedString.alloc().initWithAttributedString_(self.blurb.attributedText).autorelease()
         r = NSRange(0, ats.length())
         ats.addAttribute_value_range_(NSKernAttributeName, utils._kern, r)
-        
+
     @objc_method
     def viewWillAppear_(self, animated : bool) -> None:
         send_super(__class__, self, 'viewWillAppear:', animated, argtypes=[c_bool])
-        
+
         txt = _(
             "This tool helps convert between address formats for Bitcoin "
             "Cash addresses.\nYou are encouraged to use the 'Cash address' "
             "format."
             )
-        
+
         utils.uilabel_replace_attributed_text(self.blurb, txt.replace('\n','\n\n'), font = UIFont.italicSystemFontOfSize_(14.0))
-        
+
         self.address.attributedPlaceholder = NSAttributedString.alloc().initWithString_attributes_(
             _('Address to convert'),
             {
@@ -60,19 +60,19 @@ class AddrConvVC(AddrConvBase):
         self.addressTit.setText_withKerning_(_('Address'), utils._kern)
         self.cashTit.setText_withKerning_(_('Cash address'), utils._kern)
         self.legacyTit.setText_withKerning_(_('Legacy address'), utils._kern)
-        
+
         utils.uitf_redo_attrs(self.address)
-        
+
     @objc_method
     def textFieldShouldReturn_(self, tf) -> bool:
         #print("tf should return")
         tf.resignFirstResponder()
         return True
-    
+
     @objc_method
     def textFieldDidEndEditing_(self, tf) -> None:
         utils.uitf_redo_attrs(tf)
-    
+
     @objc_method
     def onBut_(self, but) -> None:
         def DoIt() -> None:
@@ -100,7 +100,7 @@ class AddrConvVC(AddrConvBase):
     def reader_didScanResult_(self, reader, result) -> None:
         utils.NSLog("Reader data = '%s'",str(result))
         result = str(result).strip()
-        
+
         if not self.doConversion_(result):
             title = _("Invalid QR Code")
             message = _("The QR code does not appear to be a valid BCH address.\nPlease try again.")
@@ -114,18 +114,18 @@ class AddrConvVC(AddrConvBase):
         else:
             self.address.text = result
             self.readerDidCancel_(reader)
-             
+
     @objc_method
     def readerDidCancel_(self, reader) -> None:
         if reader is not None: reader.stopScanning()
         if self.presentedViewController:
             self.dismissViewControllerAnimated_completion_(True, None)
-        
+
     @objc_method
     def onAddress_(self, tf) -> None:
         print("onAddress:",tf.text)
         self.doConversion_(tf.text)
-        
+
     @objc_method
     def doConversion_(self, text) -> bool:
         self.cash.text = ""
@@ -135,21 +135,21 @@ class AddrConvVC(AddrConvBase):
         self.qrButShowCash.enabled = False
         self.qrButShowLegacy.enabled = False
         text = text.strip()
-        
+
         addy = None
-        
+
         try:
             addy = Address.from_string(text)
         except:
             pass
 
         if addy:
-            self.cash.text = addy.to_full_string(Address.FMT_CASHADDR)
+            self.cash.text = addy.to_full_string(Address.FMT_CASHADDR_BCH)
             self.legacy.text = addy.to_full_string(Address.FMT_LEGACY)
             self.cpyCashBut.enabled = True
             self.cpyLegBut.enabled = True
             self.qrButShowCash.enabled = True
             self.qrButShowLegacy.enabled = True
-            
+
             return True
         return False


### PR DESCRIPTION
this is a small refactoring of Address formats and a change to always show the "bitcoincash:" prefix everywhere.