### PR TITLE
Adopt a new derivation path

### DIFF
--- a/electroncash/base_wizard.py
+++ b/electroncash/base_wizard.py
@@ -270,7 +270,7 @@ class BaseWizard(util.PrintError):
             # This is partially compatible with BIP45; assumes index=0
             default_derivation = "m/45'/0"
         else:
-            default_derivation = keystore.bip44_derivation_145(0)
+            default_derivation = keystore.bip44_derivation_bch(0)
         self.derivation_dialog(f, default_derivation)
 
     def derivation_dialog(self, f, default_derivation):
@@ -335,7 +335,7 @@ class BaseWizard(util.PrintError):
 
     def on_restore_bip39(self, seed, passphrase):
         f = lambda x: self.run('on_bip44', seed, passphrase, str(x))
-        self.derivation_dialog(f, keystore.bip44_derivation_145(0))
+        self.derivation_dialog(f, keystore.bip44_derivation_bch(0))
 
     def create_keystore(self, seed, passphrase):
         # auto-detect, prefers old, electrum, bip39 in that order. Since we

--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -752,16 +752,16 @@ is_private_key = lambda x: bitcoin.is_xprv(x) or is_private_key_list(x)
 is_bip32_key = lambda x: bitcoin.is_xprv(x) or bitcoin.is_xpub(x)
 
 
-def bip44_derivation_btc(account_id) -> str:
+def bip44_derivation_btc(account_id: int) -> str:
     """Return the BTC BIP44 derivation path for an account id.
     """
     coin = 1 if networks.net.TESTNET else 0
-    return f"m/44'/{coin}'/{int(account_id)}'"
+    return f"m/44'/{coin}'/{account_id}'"
 
 
-def bip44_derivation_bch(account_id) -> str:
+def bip44_derivation_bch(account_id: int) -> str:
     """Return the BCH derivation path."""
-    return f"m/44'/145'/{int(account_id)}'"
+    return f"m/44'/145'/{account_id}'"
 
 
 def bip39_normalize_passphrase(passphrase):

--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -752,16 +752,32 @@ is_private_key = lambda x: bitcoin.is_xprv(x) or is_private_key_list(x)
 is_bip32_key = lambda x: bitcoin.is_xprv(x) or bitcoin.is_xpub(x)
 
 
+def _bip44_derivation(coin: int, account_id: int) -> str:
+    return f"m/44'/{coin}'/{account_id}'"
+
+
 def bip44_derivation_btc(account_id: int) -> str:
     """Return the BTC BIP44 derivation path for an account id.
     """
     coin = 1 if networks.net.TESTNET else 0
-    return f"m/44'/{coin}'/{account_id}'"
+    return _bip44_derivation(coin, account_id)
 
 
 def bip44_derivation_bch(account_id: int) -> str:
     """Return the BCH derivation path."""
-    return f"m/44'/145'/{account_id}'"
+    return _bip44_derivation(145, account_id)
+
+
+def bip44_derivation_bcha(account_id: int) -> str:
+    """Return the BCHA BIP44 derivation path for an account id.
+    """
+    return _bip44_derivation(899, account_id)
+
+
+def bip44_derivation_bcha_tokens(account_id: int) -> str:
+    """Return the BIP44 derivation path for BCHA SLP tokens
+    """
+    return _bip44_derivation(1899, account_id)
 
 
 def bip39_normalize_passphrase(passphrase):
@@ -790,7 +806,7 @@ def from_seed(seed, passphrase, is_p2sh=None, *, seed_type='', derivation=None) 
         keystore.passphrase = passphrase
         bip32_seed = mnemo.bip39_mnemonic_to_seed(seed, passphrase)
         xtype = 'standard'  # bip43
-        derivation = derivation or bip44_derivation_bch(0)
+        derivation = derivation or bip44_derivation_bcha(0)
         keystore.add_xprv_from_seed(bip32_seed, xtype, derivation)
     else:
         raise InvalidSeed()

--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -752,13 +752,17 @@ is_private_key = lambda x: bitcoin.is_xprv(x) or is_private_key_list(x)
 is_bip32_key = lambda x: bitcoin.is_xprv(x) or bitcoin.is_xpub(x)
 
 
-def bip44_derivation(account_id):
-    bip  = 44
+def bip44_derivation_btc(account_id) -> str:
+    """Return the BTC BIP44 derivation path for an account id.
+    """
     coin = 1 if networks.net.TESTNET else 0
-    return "m/%d'/%d'/%d'" % (bip, coin, int(account_id))
+    return f"m/44'/{coin}'/{int(account_id)}'"
 
-def bip44_derivation_145(account_id):
-	return "m/44'/145'/%d'"% int(account_id)
+
+def bip44_derivation_bch(account_id) -> str:
+    """Return the BCH derivation path."""
+    return f"m/44'/145'/{int(account_id)}'"
+
 
 def bip39_normalize_passphrase(passphrase):
     """ This is called by some plugins """
@@ -786,7 +790,7 @@ def from_seed(seed, passphrase, is_p2sh=None, *, seed_type='', derivation=None) 
         keystore.passphrase = passphrase
         bip32_seed = mnemo.bip39_mnemonic_to_seed(seed, passphrase)
         xtype = 'standard'  # bip43
-        derivation = derivation or bip44_derivation_145(0)
+        derivation = derivation or bip44_derivation_bch(0)
         keystore.add_xprv_from_seed(bip32_seed, xtype, derivation)
     else:
         raise InvalidSeed()

--- a/electroncash/storage.py
+++ b/electroncash/storage.py
@@ -36,7 +36,7 @@ import zlib
 from .address import Address
 from .util import PrintError, profiler, standardize_path
 from .plugins import run_hook, plugin_loaders
-from .keystore import bip44_derivation
+from .keystore import bip44_derivation_btc
 from . import bitcoin
 
 
@@ -258,7 +258,7 @@ class WalletStorage(PrintError):
                 # save account, derivation and xpub at index 0
                 storage2.put('accounts', {'0': x})
                 storage2.put('master_public_keys', {"x/0'": xpub})
-                storage2.put('derivation', bip44_derivation(k))
+                storage2.put('derivation', bip44_derivation_btc(k))
                 storage2.upgrade()
                 storage2.write()
                 result.append(new_path)
@@ -342,7 +342,7 @@ class WalletStorage(PrintError):
 
         elif wallet_type in ['trezor', 'keepkey', 'ledger', 'digitalbitbox']:
             xpub = xpubs["x/0'"]
-            derivation = self.get('derivation', bip44_derivation(0))
+            derivation = self.get('derivation', bip44_derivation_btc(0))
             d = {
                 'type': 'hardware',
                 'hw_type': wallet_type,

--- a/electroncash/storage.py
+++ b/electroncash/storage.py
@@ -247,18 +247,18 @@ class WalletStorage(PrintError):
         elif wallet_type in ['bip44', 'trezor', 'keepkey', 'ledger', 'btchip', 'digitalbitbox']:
             mpk = storage.get('master_public_keys')
             for k in d.keys():
-                i = int(k)
+                bip44_account = int(k)
                 x = d[k]
                 if x.get("pending"):
                     continue
-                xpub = mpk["x/%d'"%i]
+                xpub = mpk[f"x/{bip44_account}'"]
                 new_path = storage.path + '.' + k
                 storage2 = WalletStorage(new_path)
                 storage2.data = copy.deepcopy(storage.data)
                 # save account, derivation and xpub at index 0
                 storage2.put('accounts', {'0': x})
                 storage2.put('master_public_keys', {"x/0'": xpub})
-                storage2.put('derivation', bip44_derivation_btc(k))
+                storage2.put('derivation', bip44_derivation_btc(bip44_account))
                 storage2.upgrade()
                 storage2.write()
                 result.append(new_path)

--- a/ios/ElectronCash/electroncash_gui/ios_native/newwallet.py
+++ b/ios/ElectronCash/electroncash_gui/ios_native/newwallet.py
@@ -665,7 +665,7 @@ class RestoreWallet1(NewWalletSeed2):
 
         if seed_type == 'bip39':
             # do bip39 stuff
-            default_derivation = keystore.bip44_derivation_145(0)
+            default_derivation = keystore.bip44_derivation_bch(0)
             test=bitcoin.is_bip32_derivation
             def onOk(text : str) -> None:
                 der = text.strip()


### PR DESCRIPTION
Use `m/44'/899'/0` when creating new wallets. Suggest this as the default when restoring a wallet from seed, but still show the BTC and BCH alternatives to help users restore old wallets. 

Add also a getter function for SLPA wallet derivation paths: `m/44'/1899'/0`.

Remove hardcoded derivation paths in strings.