### PR TITLE
Use faster JSON encoder settings when wallet is encrypted

### DIFF
--- a/electroncash/storage.py
+++ b/electroncash/storage.py
@@ -186,7 +186,9 @@ class WalletStorage(PrintError):
             return
         if not self.modified:
             return
-        s = json.dumps(self.data, indent=4, sort_keys=True)
+        s = json.dumps(self.data,
+                       indent=None if self.pubkey else 4,  # Fast settings if encrypted,
+                       sort_keys=not self.pubkey)          # readable settings otherwise.
         if self.pubkey:
             s = bytes(s, 'utf8')
             c = zlib.compress(s)


### PR DESCRIPTION
This is a backport of https://github.com/Electron-Cash/Electron-Cash/pull/2110

> The standard json module has an optimized C encoder, but that doesn't currently support indentation. So if you request indentation, it falls back on the slower Python encoder.
> 
> Readability doesn't matter for encrypted wallets, so I've disabled indentation when the wallet is encrypted. This speeds up storage.write by about 30%.