### PR TITLE
Support arbitrary cashaddr prefixes as input for the address conversion tool

### DIFF
--- a/electroncash/tests/__main__.py
+++ b/electroncash/tests/__main__.py
@@ -1,5 +1,6 @@
 import unittest
 
+from .test_address import TestAddressFromString
 from .test_asert import Test_ASERTDaa
 from .test_bitcoin import suite as test_bitcoin_suite
 from .test_blockchain import TestBlockchain
@@ -23,6 +24,7 @@ from .test_wallet_vertical import TestWalletKeystoreAddressIntegrity
 def suite():
     test_suite = unittest.TestSuite()
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestAddressFromString))
     test_suite.addTest(loadTests(Test_ASERTDaa))
     test_suite.addTest(test_bitcoin_suite())
     test_suite.addTest(loadTests(TestBlockchain))

--- a/electroncash/tests/test_address.py
+++ b/electroncash/tests/test_address.py
@@ -1,0 +1,51 @@
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+"""Reference tests for Address objects"""
+
+import unittest
+from ..address import Address, AddressError
+
+LEGACY_ADDRESS = "1F6UYGAwkzZKqFwyiwc54b7SNvHsNgcZ6h"
+BCH_CASHADDR_NO_PREFIX = "qzdf44zy632zk4etztvmaqav0y2cest4evjvrwf70z"
+BCH_CASHADDR_WITH_PREFIX = "bitcoincash:" + BCH_CASHADDR_NO_PREFIX
+ECASH_CASHADDR_NO_PREFIX = "qzdf44zy632zk4etztvmaqav0y2cest4evtph9jyf4"
+ECASH_CASHADDR_WITH_PREFIX = "ecash:" + ECASH_CASHADDR_NO_PREFIX
+
+
+class TestAddressFromString(unittest.TestCase):
+    """Unit test class for parsing addressess from string."""
+    def _test_addr(self, addr: Address):
+        self.assertEqual(addr.to_full_string(fmt=Address.FMT_LEGACY),
+                         LEGACY_ADDRESS)
+        self.assertEqual(addr.to_full_string(fmt=Address.FMT_CASHADDR_BCH),
+                         BCH_CASHADDR_WITH_PREFIX)
+
+    def test_from_legacy(self):
+        self._test_addr(Address.from_string(LEGACY_ADDRESS))
+
+    def test_from_bch_cashaddr(self):
+        self._test_addr(Address.from_string(BCH_CASHADDR_WITH_PREFIX))
+        self._test_addr(Address.from_string(BCH_CASHADDR_NO_PREFIX))
+        self._test_addr(Address.from_string(BCH_CASHADDR_WITH_PREFIX.upper()))
+        self._test_addr(Address.from_string(BCH_CASHADDR_NO_PREFIX.upper()))
+
+    def test_from_cashaddr_arbitrary_prefix(self):
+        self._test_addr(Address.from_string(ECASH_CASHADDR_WITH_PREFIX,
+                                            support_arbitrary_prefix=True))
+        with self.assertRaises(AddressError):
+            # default (support_arbitrary_prefix=False) is to not support
+            # unusual prefixes
+            Address.from_string(ECASH_CASHADDR_WITH_PREFIX)
+        with self.assertRaises(AddressError):
+            # unusual prefixes are only supported if the prefix is specified
+            Address.from_string(ECASH_CASHADDR_NO_PREFIX,
+                                support_arbitrary_prefix=True)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -2502,7 +2502,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         def convert_address():
             try:
-                addr = Address.from_string(source_address.text().strip())
+                addr = Address.from_string(source_address.text().strip(),
+                                           support_arbitrary_prefix=True)
             except:
                 addr = None
             for widget, fmt in widgets:


### PR DESCRIPTION
This will make it possible for users to convert addresses with unusual prefixes, such as the "ecash:" addresses generated by [Stamp](https://getstamp.io/) and [Mercury Messenger](https://www.mercurymessenger.io), in order to fund their user account.

This PR only enables arbitrary prefixes for converting addresses. If we decide to support more prefixes in the "Send" tab, it will require a safer approach using a whitelist of prefixes. In the long run it would be good to be able to disable support for the bitcoincash: prefix to reduce the risk of sending BCHA to BCH wallets.