### PR TITLE
use satoshis as unit in URIs and QR-codes

### DIFF
--- a/electroncash/web.py
+++ b/electroncash/web.py
@@ -118,7 +118,8 @@ def create_URI(addr, amount, message, *, op_return=None, op_return_raw=None, net
         scheme, path = addr.to_URI_components(net=net)
     query = []
     if amount:
-        query.append('amount=%s'%format_satoshis_plain(amount))
+        # URI and QR-codes use Satoshis as unit
+        query.append(f'amount={amount}')
     if message:
         query.append('message=%s'%urllib.parse.quote(message))
     if op_return:


### PR DESCRIPTION
This is a deviation from BIP 21, but it makes more sense to encode an integer amount as an integer in a URI, rather than a Decimal value. The should be no consideration for human readability / understanding when building a URI.
This aligns ElectrumABC's behavior with Cashew, Stamp and CashTab. 

Test plan:

Create a receive request with a value of 0.001 BCHA, scan it with
CashTab, verify the amount is understood by CashTab and is encoded as
100000 in the URI.