### PR TITLE
Sanitize host names when building certificate file names

### DIFF
--- a/contrib/deterministic-build/requirements.txt
+++ b/contrib/deterministic-build/requirements.txt
@@ -65,6 +65,9 @@ jsonrpclib-pelix==0.4.2 \
 mnemonic==0.19 \
     --hash=sha256:4e37eb02b2cbd56a0079cabe58a6da93e60e3e4d6e757a586d9f23d96abea931 \
     --hash=sha256:a8d78c5100acfa7df9bab6b9db7390831b0e54490934b718ff9efd68f0d731a6
+pathvalidate==2.3.1 \
+    --hash=sha256:1be91f23dd1fb5002ad2b52cb4e7396deb56092ef29a7facb6e4032c5a444f8a \
+    --hash=sha256:4a84300ec54e00db7bbfbbd65b8f138c44340fac1850d7731228d3b9d6bfa4c5
 protobuf==3.14.0 \
     --hash=sha256:0e247612fadda953047f53301a7b0407cb0c3cb4ae25a6fde661597a04039b3c \
     --hash=sha256:0fc96785262042e4863b3f3b5c429d4636f10d90061e1840fce1baaf59b1a836 \

--- a/contrib/requirements/requirements.txt
+++ b/contrib/requirements/requirements.txt
@@ -11,3 +11,4 @@ python-dateutil<2.9
 stem>=1.8.0
 certifi
 mnemonic==0.19
+pathvalidate

--- a/electroncash/interface.py
+++ b/electroncash/interface.py
@@ -36,6 +36,8 @@ import traceback
 from typing import Optional, Tuple
 from collections import namedtuple
 
+from pathvalidate import sanitize_filename
+
 from .util import print_error
 from .utils import Event
 
@@ -169,7 +171,7 @@ class TcpConnection(threading.Thread, util.PrintError):
             # Try with CA first, since they are preferred over self-signed certs
             # and are always accepted (even if a previous pinned self-signed
             # cert exists).
-            cert_path = os.path.join(self.config_path, 'certs', self.host)
+            cert_path = os.path.join(self.config_path, 'certs', sanitize_filename(self.host, replacement_text='_'))
             has_pinned_self_signed = os.path.exists(cert_path)
             s, give_up = self._get_socket_and_verify_ca_cert(suppress_errors=has_pinned_self_signed)
             if s:


### PR DESCRIPTION
> Introduces a new dependency on `pathvalidate` (https://pypi.org/project/pathvalidate/)
> which is used to sanitize certificate file names.
> 
> Previously it was possible to to generate bad filenames, for example
> by connecting directly to an IPV6 address.
> 

This is a backport of https://github.com/Electron-Cash/Electron-Cash/pull/2140

fixes  https://github.com/Electron-Cash/Electron-Cash/issues/2137