### PR TITLE
Zbar: Update to git master to fix build with autoconf 2.70

### DIFF
--- a/contrib/build-linux/appimage/Dockerfile_ub1604
+++ b/contrib/build-linux/appimage/Dockerfile_ub1604
@@ -22,6 +22,7 @@ RUN apt-get update -q && \
         swig=3.0.8-0ubuntu3 \
         software-properties-common=0.96.20.10 \
         libxkbcommon-x11-0=0.5.0-1ubuntu2.1 \
+        autopoint=0.19.7-2ubuntu3.1 \
         && \
     add-apt-repository ppa:git-core/ppa && \
     apt-get update -q && \

--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -22,7 +22,8 @@ RUN apt-get update -q && \
         libtool=2.4.6-2 \
         gettext=0.19.8.1-6 \
         mingw-w64-tools=5.0.3-1 \
-        win-iconv-mingw-w64-dev=0.0.8-2
+        win-iconv-mingw-w64-dev=0.0.8-2 \
+        autopoint=0.19.8.1-6ubuntu0.3
 
 RUN wget -nc https://dl.winehq.org/wine-builds/Release.key && \
         echo "c51bcb8cc4a12abfbd7c7660eaf90f49674d15e222c262f27e6c96429111b822 Release.key" | sha256sum -c - && \


### PR DESCRIPTION
See mchehab/zbar#132

This needs autopoint to be installed.

This is a backport of https://github.com/Electron-Cash/Electron-Cash/pull/2143
