### PR TITLE
Build: Allow to override Ubuntu mirror URL

### DIFF
--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -204,6 +204,11 @@ export GIT_DIR_NAME=`basename $GIT_REPO`
 export PACKAGE="ElectrumABC"
 export SCRIPTNAME="electrum-abc"
 export PYI_SKIP_TAG="${PYI_SKIP_TAG:-0}" # Set this to non-zero to make PyInstaller skip tagging the bootloader
+export DEFAULT_UBUNTU_MIRROR="http://archive.ubuntu.com/ubuntu/"
+export UBUNTU_MIRROR="${UBUNTU_MIRROR:-$DEFAULT_UBUNTU_MIRROR}"
+if [ "$UBUNTU_MIRROR" != "$DEFAULT_UBUNTU_MIRROR" ]; then
+    info "Picked up override from env: UBUNTU_MIRROR=${UBUNTU_MIRROR}"
+fi
 
 # Build a command line argument for docker, enabling interactive mode if stdin
 # is a tty and enabling tty in docker if stdout is a tty.

--- a/contrib/build-linux/appimage/Dockerfile_ub1804
+++ b/contrib/build-linux/appimage/Dockerfile_ub1804
@@ -1,11 +1,13 @@
 FROM ubuntu:18.04@sha256:2aeed98f2fa91c365730dc5d70d18e95e8d53ad4f1bbf4269c3bb625060383f0
 
+ARG UBUNTU_MIRROR=http://archive.ubuntu.com/ubuntu/
+
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 
-RUN echo deb mirror://mirrors.ubuntu.com/mirrors.txt bionic main restricted universe multiverse > /etc/apt/sources.list && \
-    echo deb mirror://mirrors.ubuntu.com/mirrors.txt bionic-updates main restricted universe multiverse >> /etc/apt/sources.list && \
-    echo deb mirror://mirrors.ubuntu.com/mirrors.txt bionic-backports main restricted universe multiverse >> /etc/apt/sources.list && \
-    echo deb mirror://mirrors.ubuntu.com/mirrors.txt bionic-security main restricted universe multiverse >> /etc/apt/sources.list && \
+RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/apt/sources.list && \
+    echo deb ${UBUNTU_MIRROR} bionic-updates main restricted universe multiverse >> /etc/apt/sources.list && \
+    echo deb ${UBUNTU_MIRROR} bionic-backports main restricted universe multiverse >> /etc/apt/sources.list && \
+    echo deb ${UBUNTU_MIRROR} bionic-security main restricted universe multiverse >> /etc/apt/sources.list && \
     apt-get update -q && \
     apt-get install -qy \
         git=1:2.17.1-1ubuntu0.7 \

--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -53,6 +53,7 @@ CONTAINERNAME="electrumabc-appimage-builder-cont-$DOCKER_SUFFIX"
 info "Creating docker image ..."
 $SUDO docker build -t $IMGNAME \
     -f contrib/build-linux/appimage/Dockerfile_$DOCKER_SUFFIX \
+    --build-arg UBUNTU_MIRROR=$UBUNTU_MIRROR \
     contrib/build-linux/appimage \
     || fail "Failed to create docker image"
 

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -58,6 +58,7 @@ info "Creating docker image ..."
 $SUDO docker build -t $IMGNAME \
             --build-arg USER_ID=$USER_ID \
             --build-arg GROUP_ID=$GROUP_ID \
+            --build-arg UBUNTU_MIRROR=$UBUNTU_MIRROR \
             contrib/build-wine/docker \
     || fail "Failed to create docker image"
 

--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -1,8 +1,14 @@
 FROM ubuntu:18.04@sha256:5f4bdc3467537cbbe563e80db2c3ec95d548a9145d64453b06939c4592d67b6d
 
+ARG UBUNTU_MIRROR=http://archive.ubuntu.com/ubuntu/
+
 ENV LC_ALL=C.UTF-8 LANG=C.UTF-8
 
-RUN dpkg --add-architecture i386 && \
+RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/apt/sources.list && \
+    echo deb ${UBUNTU_MIRROR} bionic-updates main restricted universe multiverse >> /etc/apt/sources.list && \
+    echo deb ${UBUNTU_MIRROR} bionic-backports main restricted universe multiverse >> /etc/apt/sources.list && \
+    echo deb ${UBUNTU_MIRROR} bionic-security main restricted universe multiverse >> /etc/apt/sources.list && \
+    dpkg --add-architecture i386 && \
     apt-get update -q && \
     apt-get install -qy \
         wget=1.19.4-1ubuntu2.2 \


### PR DESCRIPTION
The default Ubuntu mirror (archive.ubuntu.com) is slow depending on the
location of the builder. This allows to override the Ubuntu mirror URL
by setting the `UBUNTU_MIRROR` environment variable.

This is a backport of https://github.com/Electron-Cash/Electron-Cash/pull/2151