### PR TITLE
Warn if legacy

### DIFF
--- a/electroncash/address.py
+++ b/electroncash/address.py
@@ -659,6 +659,28 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
         if net is None: net = networks.net
         return [addr.to_string(fmt, net=net) for addr in addrs]
 
+    @staticmethod
+    def is_legacy(address: str, net=None) -> bool:
+        """Find if the string of the address is in legacy format"""
+        if net is None:
+            net = networks.net
+        try:
+            raw = Base58.decode_check(address)
+        except Base58Error:
+            return False
+
+        if len(raw) != 21:
+            return False
+
+        verbyte = raw[0]
+        legacy_formats = (
+            net.ADDRTYPE_P2PKH,
+            net.ADDRTYPE_P2PKH_BITPAY,
+            net.ADDRTYPE_P2SH,
+            net.ADDRTYPE_P2SH_BITPAY,
+        )
+        return verbyte in legacy_formats
+
     def to_cashaddr(self, *, net=None):
         if net is None: net = networks.net
         if self.kind == self.ADDR_P2PKH:

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -2078,6 +2078,53 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             return False
         return True
 
+    def _warn_if_legacy_address(self):
+        """Show a warning if self.payto_e has legacy addresses, since the user
+        might be trying to send BTC instead of BCHA."""
+        warn_legacy_address = bool(self.config.get("warn_legacy_address", True))
+        if not warn_legacy_address:
+            return
+        for line in self.payto_e.lines():
+            line = line.strip()
+            if line.lower().startswith(networks.net.CASHADDR_PREFIX + ":"):
+                line = line.split(":", 1)[1]  # strip "bitcoincash:" prefix
+            if "," in line:
+                # if address, amount line, strip address out and ignore rest
+                line = line.split(",", 1)[0]
+            line = line.strip()
+            if Address.is_legacy(line):
+                msg1 = (
+                    _("You are about to send eCash (BCHA) to a legacy address.")
+                    + "<br><br>"
+                    + _(
+                        "Legacy addresses are deprecated for eCash "
+                        "(BCHA), and used by Bitcoin (BTC)."
+                    )
+                )
+                msg2 = _(
+                    "Proceed if what you are intending to do is sending "
+                    "eCash (BCHA)."
+                )
+                msg3 = _(
+                    "If you are intending to send BTC, close the "
+                    "application and use a BTC wallet instead.  Electrum ABC "
+                    "is an eCash (BCHA) wallet, not a BTC wallet."
+                )
+                res = self.msg_box(
+                    parent=self,
+                    icon=QMessageBox.Warning,
+                    title=_("You are sending to a legacy address"),
+                    rich_text=True,
+                    text=msg1,
+                    informative_text=msg2,
+                    detail_text=msg3,
+                    checkbox_text=_("Never show this again"),
+                    checkbox_ischecked=False,
+                )
+                if res[1]:  # Never ask if checked
+                    self.config.set_key("warn_legacy_address", False)
+                break
+
     def do_preview(self):
         self.do_send(preview = True)
 
@@ -2091,6 +2138,8 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
 
         if not self._chk_no_segwit_suspects():
             return
+
+        self._warn_if_legacy_address()
 
         r = self.read_send_tab()
         if not r:

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -2094,22 +2094,21 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             line = line.strip()
             if Address.is_legacy(line):
                 msg1 = (
-                    _("You are about to send eCash (BCHA) to a legacy address.")
+                    _("You are about to send {} to a legacy address.").format(CURRENCY)
                     + "<br><br>"
                     + _(
-                        "Legacy addresses are deprecated for eCash "
-                        "(BCHA), and used by Bitcoin (BTC)."
-                    )
+                        "Legacy addresses are deprecated for {} "
+                        ", and used by Bitcoin (BTC)."
+                    ).format(CURRENCY)
                 )
                 msg2 = _(
-                    "Proceed if what you are intending to do is sending "
-                    "eCash (BCHA)."
-                )
+                    "Proceed if what you intend to do is to send {}."
+                ).format(CURRENCY)
                 msg3 = _(
-                    "If you are intending to send BTC, close the "
-                    "application and use a BTC wallet instead.  Electrum ABC "
-                    "is an eCash (BCHA) wallet, not a BTC wallet."
-                )
+                     "If you intend to send BTC, close the application "
+                     "and use a BTC wallet instead. {} is a "
+                     "{} wallet, not a BTC wallet."
+                ).format(PROJECT_NAME, CURRENCY)
                 res = self.msg_box(
                     parent=self,
                     icon=QMessageBox.Warning,


### PR DESCRIPTION
Legacy addresses are the source of confusion for many BCHA users.

See:

https://blog.cex.io/news/why-you-should-never-send-bch-to-btc-address-21346

This changeset creates a popup warning window when the user tries to
send BCHA to a legacy address.  The window has a "Never show this again"
checkbox.

This PR replaces #75

