### PR TITLE
Tor: Update to version 0.4.5.5-rc with some patches

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/madler/zlib.git
 [submodule "contrib/tor"]
 	path = contrib/tor
-	url = https://github.com/torproject/tor.git
+	url = https://github.com/EchterAgo/tor.git


### PR DESCRIPTION
This has two important fixes:

* Major bugfixes (onion service v3):

  Stop requiring a live consensus for v3 clients and services, and allow
  a "reasonably live" consensus instead. This allows v3 onion services
  to work even if the authorities fail to generate a consensus for more
  than 2 hours in a row.

* Major feature (exit):

  Re-entry into the network is now denied at the Exit level to all
  relays' ORPorts and authorities' ORPorts and DirPorts. This change
  should help mitgate a set of denial-of-service attacks.

Tree built from:

https://github.com/EchterAgo/tor/commits/electroncash_0_4_5

This includes a static linking fix as well as Autoconf 2.70
compatibility.


This is a backport of https://github.com/Electron-Cash/Electron-Cash/pull/2147