### PR TITLE
lower the default fee rate

### DIFF
--- a/electroncash_gui/qt/fee_slider.py
+++ b/electroncash_gui/qt/fee_slider.py
@@ -41,7 +41,7 @@ class FeeSlider(QSlider):
             self.update_no_custom_fee_rate()
 
     def update_no_custom_fee_rate(self):
-        self.fee_step = self.config.max_fee_rate() / 10
+        self.fee_step = self.config.max_slider_fee / self.config.slider_steps
         fee_rate = self.config.fee_per_kb()
         pos = max(min(fee_rate / self.fee_step, 10) - 1, 0)
         self.setEnabled(True)
@@ -53,7 +53,7 @@ class FeeSlider(QSlider):
     # configuraing this as is done is here still required, can't just set range 0,0 to deactivate.
     # chose to make this a seperate function from update for easier code maintainence
     def update_has_custom_fee_rate(self):
-        self.fee_step = self.config.max_fee_rate() / 10
+        self.fee_step = self.config.max_slider_fee / self.config.slider_steps
         fee_rate = self.config.fee_per_kb()
         pos = max(0,min(fee_rate / self.fee_step, 1))
         self.setRange(0, 1)

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -2188,12 +2188,6 @@ class ElectrumWindow(QMainWindow, MessageBoxMixin, PrintError):
             x_fee_address, x_fee_amount = x_fee
             msg.append( _("Additional fees") + ": " + self.format_amount_and_units(x_fee_amount) )
 
-        confirm_rate = 2 * self.config.max_fee_rate()
-
-        # IN THE FUTURE IF WE WANT TO APPEND SOMETHING IN THE MSG ABOUT THE FEE, CODE IS COMMENTED OUT:
-        #if fee > confirm_rate * tx.estimated_size() / 1000:
-        #    msg.append(_('Warning') + ': ' + _("The fee for this transaction seems unusually high."))
-
         if (fee < (tx.estimated_size())):
             msg.append(_('Warning') + ': ' + _("You're using a fee of less than 1.0 sats/B. It may take a very long time to confirm."))
             tx.ephemeral['warned_low_fee_already'] = True


### PR DESCRIPTION
The new slider values now range from 5000 to 50000 sat/kB, instead of 10000--100000.

The fee is automatically updated in the config file for users upgrading from older versions of Electrum ABC if they are using the default setting for their old version.

For users with a custom slider setting that is higher than the new slider maximum, the fee will be set to the new maximum.