### PR TITLE
.gitmodules should use the canonical Tor git repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/madler/zlib.git
 [submodule "contrib/tor"]
 	path = contrib/tor
-	url = https://github.com/EchterAgo/tor.git
+	url = https://gitweb.torproject.org/tor.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -18,4 +18,4 @@
 	url = https://github.com/madler/zlib.git
 [submodule "contrib/tor"]
 	path = contrib/tor
-	url = https://gitweb.torproject.org/tor.git
+	url = https://git.torproject.org/tor.git


### PR DESCRIPTION
Change the Tor repo to the canonical [`https://gitweb.torproject.org/tor.git/`](https://gitweb.torproject.org/tor.git/).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bitcoin-abc/electrumabc/97)
<!-- Reviewable:end -->
