### PR TITLE
Clean up exec file

### DIFF
--- a/electrum-abc
+++ b/electrum-abc
@@ -141,8 +141,9 @@ def check_imports():
         raise AssertionError("Certificates not found")
 
 
-def prompt_password(prompt, confirm=True):
-    """ Get password routine """
+def prompt_password(prompt: str = "Password:",
+                    confirm: bool = False) -> str:
+    """Get password routine"""
     password = getpass.getpass(prompt, stream=None)
     if password and confirm:
         password2 = getpass.getpass("Confirm: ")
@@ -160,7 +161,7 @@ def prompt_create_wallet_password() -> str:
 
 
 def run_non_rpc(simple_config: SimpleConfig):
-    """ Run non RPC commands """
+    """Run non RPC commands"""
     cmd_name = simple_config.get("cmd")
 
     storage = WalletStorage(simple_config.get_wallet_path())

--- a/electrum-abc
+++ b/electrum-abc
@@ -27,91 +27,122 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+# pylint: disable=C0103
+# pylint: enable=C0103
+"""
+Electron Cash - lightweight Bitcoin Cash client
+"""
+import getpass
 import logging
 import os
 import sys
+import threading
+
+import electroncash.web as web
+from electroncash import (
+    Network,
+    SimpleConfig,
+    daemon,
+    keystore,
+    mnemo,
+    networks,
+    util,
+)
+from electroncash.commands import (
+    Commands,
+    config_variables,
+    get_parser,
+    known_commands,
+)
+from electroncash.i18n import _
+from electroncash.migrate_data import migrate_data_from_ec, update_config
+from electroncash.plugins import Plugins
+from electroncash.storage import WalletStorage
+from electroncash.util import (
+    InvalidPassword,
+    json_decode,
+    json_encode,
+    print_msg,
+    print_stderr,
+    set_verbosity,
+)
+from electroncash.wallet import (
+    ImportedAddressWallet,
+    ImportedPrivkeyWallet,
+    Wallet,
+)
+
+# Import ok on other platforms, won't be called.
+from electroncash.winconsole import create_or_attach_console
 
 # Workaround for PyQt5 5.12.3
 # see https://github.com/pyinstaller/pyinstaller/issues/4293
-if sys.platform == "win32" and hasattr(sys, 'frozen') and hasattr(sys, '_MEIPASS'):
-    os.environ['PATH'] = sys._MEIPASS + ";" + os.environ['PATH']
+if sys.platform == "win32" and hasattr(sys, "frozen") and hasattr(sys, "_MEIPASS"):
+    path = sys._MEIPASS + ";" + os.environ["PATH"]  # pylint: disable=no-member,W0212
+    os.environ["PATH"] = path
 
 # Note CashShuffle's .proto files have namespace conflicts with keepkey
 # This is a workaround to force the python implementation versus the C++
 # implementation which does more intelligent things with protobuf namespaces
-os.environ['PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION'] = 'python'
+os.environ["PROTOCOL_BUFFERS_PYTHON_IMPLEMENTATION"] = "python"
 
 if sys.version_info < (3, 6):
     sys.exit(f"*** Support for Python 3.5 has been discontinued.\n"
              f"*** Please run the application with Python 3.6 or above.")
 
 # from https://gist.github.com/tito/09c42fb4767721dc323d
-import threading
 try:
-    import jnius
-except:
-    jnius = None
-if jnius:
+    import jnius  # pylint: disable=E0401
+except ImportError:
+    jnius = None  # pylint: disable=C0103
+if jnius is not None:
     orig_thread_run = threading.Thread.run
-    def thread_check_run(*args, **kwargs):
+
+    def thread_check_run(*thread_args, **thread_kwargs):
+        """Detect when a thread exits to prevent Android crash"""
         try:
-            return orig_thread_run(*args, **kwargs)
+            return orig_thread_run(*thread_args, **thread_kwargs)
         finally:
             jnius.detach()
+
     threading.Thread.run = thread_check_run
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
-is_bundle = getattr(sys, 'frozen', False)
-is_local = not is_bundle and os.path.exists(os.path.join(script_dir, "electrum-abc.desktop"))
+IS_BUNDLE = getattr(sys, "frozen", False)
+IS_LOCAL = not IS_BUNDLE and os.path.exists(
+    os.path.join(script_dir, "electrum-abc.desktop")
+)
 
-if is_local:
-    sys.path.insert(0, os.path.join(script_dir, 'packages'))
+if IS_LOCAL:
+    sys.path.insert(0, os.path.join(script_dir, "packages"))
 
 
 def check_imports():
-    # pure-python dependencies need to be imported here for pyinstaller
+    """ pure-python dependencies need to be imported here for pyinstaller """
     try:
-        import dns
-        import pyaes
-        import ecdsa
-        import requests
-        import qrcode
-        import google.protobuf
-        import jsonrpclib
-    except ImportError as e:
-        sys.exit("Error: %s. Try 'sudo pip install <module-name>'"%str(e))
-    # the following imports are for pyinstaller
-    from google.protobuf import descriptor
-    from google.protobuf import message
-    from google.protobuf import reflection
-    from google.protobuf import descriptor_pb2
-    from jsonrpclib import SimpleJSONRPCServer
+        import dns  # pylint: disable=C0415,W0611
+        import ecdsa  # pylint: disable=C0415,W0611
+        import google.protobuf  # pylint: disable=C0415,W0611
+        import jsonrpclib  # pylint: disable=C0415,W0611
+        import pyaes  # pylint: disable=C0415,W0611
+        import qrcode  # pylint: disable=C0415,W0611
+        import requests  # pylint: disable=C0415
+    except ImportError as i_e:
+        sys.exit("Error: %s. Try 'sudo pip install <module-name>'" % str(i_e))
+    from google.protobuf import descriptor  # pylint: disable=C0415,W0611
+    from google.protobuf import descriptor_pb2  # pylint: disable=C0415,W0611
+    from google.protobuf import message  # pylint: disable=C0415,W0611
+    from google.protobuf import reflection  # pylint: disable=C0415,W0611
+    from jsonrpclib import SimpleJSONRPCServer  # pylint: disable=C0415,W0611
+
     # make sure that certificates are here
-    assert os.path.exists(requests.utils.DEFAULT_CA_BUNDLE_PATH)
+    certs = requests.utils.DEFAULT_CA_BUNDLE_PATH
+    if not os.path.exists(certs):
+        raise AssertionError("Certificates not found")
 
 
-from electroncash import util
-from electroncash import SimpleConfig, Network
-from electroncash import networks
-from electroncash.wallet import Wallet, ImportedPrivkeyWallet, ImportedAddressWallet
-from electroncash.storage import WalletStorage
-from electroncash.util import (print_msg, print_stderr, json_encode, json_decode,
-                               set_verbosity, InvalidPassword)
-from electroncash.i18n import _
-from electroncash.commands import get_parser, known_commands, Commands, config_variables
-from electroncash import daemon
-from electroncash import keystore
-from electroncash import mnemo
-from electroncash.winconsole import create_or_attach_console  # Import ok on other platforms, won't be called.
-import electroncash.web as web
-from electroncash.constants import SCRIPT_NAME, PROJECT_NAME, PORTABLE_DATA_DIR
-from electroncash.migrate_data import migrate_data_from_ec, update_config
-
-
-def prompt_password(prompt: str = "Password:",
-                    confirm: bool = False) -> str:
-    """Get password routine"""
-    import getpass
+def prompt_password(prompt, confirm=True):
+    """ Get password routine """
     password = getpass.getpass(prompt, stream=None)
     if password and confirm:
         password2 = getpass.getpass("Confirm: ")
@@ -129,8 +160,8 @@ def prompt_create_wallet_password() -> str:
 
 
 def run_non_rpc(simple_config: SimpleConfig):
-    """Run non RPC commands"""
-    cmd_name = simple_config.get('cmd')
+    """ Run non RPC commands """
+    cmd_name = simple_config.get("cmd")
 
     storage = WalletStorage(simple_config.get_wallet_path())
     if storage.file_exists():
@@ -171,17 +202,17 @@ def restore_wallet(simple_config: SimpleConfig,
             sys.exit("Error: Seed or key not recognized")
         if password:
             k.update_password(None, password)
-        storage.put('keystore', k.dump())
-        storage.put('wallet_type', 'standard')
-        storage.put('use_encryption', bool(password))
-        seed_type = getattr(k, 'seed_type', None)
+        storage.put("keystore", k.dump())
+        storage.put("wallet_type", "standard")
+        storage.put("use_encryption", bool(password))
+        seed_type = getattr(k, "seed_type", None)
         if seed_type:
             # save to top-level storage too so it doesn't get lost if user
             # switches EC versions
-            storage.put('seed_type', seed_type)
+            storage.put("seed_type", seed_type)
         storage.write()
         wallet = Wallet(storage)
-    if not simple_config.get('offline'):
+    if not simple_config.get("offline"):
         network = Network(simple_config)
         network.start()
         wallet.start_threads(network)
@@ -205,22 +236,22 @@ def create_wallet(simple_config: SimpleConfig,
                   storage: WalletStorage):
     """Create a new wallet"""
     password = prompt_create_wallet_password()
-    passphrase = simple_config.get('passphrase', '')
-    seed_type = simple_config.get('seed_type', 'bip39')
-    if seed_type == 'bip39':
-        seed = mnemo.make_bip39_words('english')
-    elif seed_type in ['electrum', 'standard']:
-        seed_type = 'electrum'
-        seed = mnemo.Mnemonic_Electrum('en').make_seed()
+    passphrase = simple_config.get("passphrase", "")
+    seed_type = simple_config.get("seed_type", "bip39")
+    if seed_type == "bip39":
+        seed = mnemo.make_bip39_words("english")
+    elif seed_type in ["electrum", "standard"]:
+        seed_type = "electrum"
+        seed = mnemo.Mnemonic_Electrum("en").make_seed()
     else:
         raise RuntimeError("Unknown seed_type " + str(seed_type))
     k = keystore.from_seed(seed, passphrase, seed_type=seed_type)
-    storage.put('seed_type', seed_type)
-    storage.put('keystore', k.dump())
-    storage.put('wallet_type', 'standard')
+    storage.put("seed_type", seed_type)
+    storage.put("keystore", k.dump())
+    storage.put("wallet_type", "standard")
     wallet = Wallet(storage)
-    wallet.update_password(None, password, True)
-    wallet.synchronize()
+    wallet.update_password(None, password, True)  # pylint: disable=no-member
+    wallet.synchronize()  # pylint: disable=no-member
     print_msg("Your wallet generation seed is:\n    \"%s\"" % seed)
     print_msg("Wallet seed format:", seed_type)
     if k.has_derivation() and seed_type != "electrum":
@@ -233,6 +264,7 @@ def create_wallet(simple_config: SimpleConfig,
 
 
 def init_daemon(config_options):
+    """ Initialize the daemon """
     config = SimpleConfig(config_options)
     storage = WalletStorage(config.get_wallet_path())
     if not storage.file_exists():
@@ -240,11 +272,13 @@ def init_daemon(config_options):
         print_msg(f"Type '{SCRIPT_NAME} create' to create a new wallet, or provide a path to a wallet with the -w option")
         sys.exit(0)
     if storage.is_encrypted():
-        if 'wallet_password' in config_options:
-            print_msg('Warning: unlocking wallet with commandline argument \"--walletpassword\"')
-            password = config_options['wallet_password']
-        elif config.get('password'):
-            password = config.get('password')
+        if "wallet_password" in config_options:
+            print_msg(
+                'Warning: unlocking wallet with commandline argument "--walletpassword"'
+            )
+            password = config_options["wallet_password"]
+        elif config.get("password"):
+            password = config.get("password")
         else:
             password = prompt_password()
             if not password:
@@ -252,25 +286,26 @@ def init_daemon(config_options):
                 sys.exit(1)
     else:
         password = None
-    config_options['password'] = password
+    config_options["password"] = password
 
 
 def init_cmdline(config_options, server):
+    """ Initialize command line """
     config = SimpleConfig(config_options)
-    cmdname = config.get('cmd')
+    cmdname = config.get("cmd")
     cmd = known_commands[cmdname]
 
-    if cmdname == 'signtransaction' and config.get('privkey'):
+    if cmdname == "signtransaction" and config.get("privkey"):
         cmd.requires_wallet = False
         cmd.requires_password = False
 
-    if cmdname in ['payto', 'paytomany'] and config.get('unsigned'):
+    if cmdname in ["payto", "paytomany"] and config.get("unsigned"):
         cmd.requires_password = False
 
-    if cmdname in ['payto', 'paytomany'] and config.get('broadcast'):
+    if cmdname in ["payto", "paytomany"] and config.get("broadcast"):
         cmd.requires_network = True
 
-    # instanciate wallet for command-line
+    # instantiate wallet for command-line
     storage = WalletStorage(config.get_wallet_path())
 
     if cmd.requires_wallet and not storage.file_exists():
@@ -279,16 +314,21 @@ def init_cmdline(config_options, server):
         sys.exit(0)
 
     # important warning
-    if cmd.name in ['getprivatekeys']:
+    if cmd.name in ["getprivatekeys"]:
         print_stderr("WARNING: ALL your private keys are secret.")
         print_stderr("Exposing a single private key can compromise your entire wallet!")
-        print_stderr("In particular, DO NOT use 'redeem private key' services proposed by third parties.")
+        print_stderr(
+            "In particular, DO NOT use 'redeem private key' services proposed "
+            "by third parties."
+        )
 
+    is_storage_pw_req = storage.get("use_encryption") or storage.is_encrypted()
     # commands needing password
-    if (cmd.requires_wallet and storage.is_encrypted() and server is None)\
-       or (cmd.requires_password and (storage.get('use_encryption') or storage.is_encrypted())):
-        if config.get('password'):
-            password = config.get('password')
+    if (cmd.requires_wallet and storage.is_encrypted() and server is None) or (
+        cmd.requires_password and is_storage_pw_req
+    ):
+        if config.get("password"):
+            password = config.get("password")
         else:
             password = prompt_password()
             if not password:
@@ -297,19 +337,20 @@ def init_cmdline(config_options, server):
     else:
         password = None
 
-    config_options['password'] = password
+    config_options["password"] = password
 
-    if cmd.name == 'password':
-        new_password = prompt_password('New password:', True)
-        config_options['new_password'] = new_password
+    if cmd.name == "password":
+        new_password = prompt_password("New password:", True)
+        config_options["new_password"] = new_password
 
     return cmd, password
 
 
 def run_offline_command(config, config_options):
-    cmdname = config.get('cmd')
+    """Run command that doesn't require network"""
+    cmdname = config.get("cmd")
     cmd = known_commands[cmdname]
-    password = config_options.get('password')
+    password = config_options.get("password")
     if cmd.requires_wallet:
         storage = WalletStorage(config.get_wallet_path())
         if storage.is_encrypted():
@@ -317,10 +358,12 @@ def run_offline_command(config, config_options):
         wallet = Wallet(storage)
     else:
         wallet = None
-    # check password
-    if cmd.requires_password and storage.get('use_encryption'):
+    is_wallet_pw_req = (
+        wallet is not None and cmd.requires_password and storage.get("use_encryption")
+    )
+    if is_wallet_pw_req:
         try:
-            seed = wallet.check_password(password)
+            wallet.check_password(password)
         except InvalidPassword:
             print_msg("Error: This password does not decode this wallet.")
             sys.exit(1)
@@ -329,12 +372,17 @@ def run_offline_command(config, config_options):
     # arguments passed to function
     args = [config.get(x) for x in cmd.params]
     # decode json arguments
-    if cmdname not in ('setconfig',):
+    if cmdname not in ("setconfig",):
         args = list(map(json_decode, args))
     # options
     kwargs = {}
-    for x in cmd.options:
-        kwargs[x] = (config_options.get(x) if x in ['password', 'new_password'] else config.get(x))
+    cmd_opts_in_cfg_opts = {"password", "new_password"}
+    for cmd_option in cmd.options:
+        kwargs[cmd_option] = (
+            config_options.get(cmd_option)
+            if cmd_option in cmd_opts_in_cfg_opts
+            else config.get(cmd_option)
+        )
     cmd_runner = Commands(config, wallet, None)
     func = getattr(cmd_runner, cmd.name)
     result = func(*args, **kwargs)
@@ -345,7 +393,7 @@ def run_offline_command(config, config_options):
 
 
 def init_plugins(config, gui_name):
-    from electroncash.plugins import Plugins
+    """Initialize plugins"""
     return Plugins(config, gui_name)
 
 
@@ -387,14 +435,17 @@ def run_start(config, config_options, subcommand):
         daemon_thread = daemon.Daemon(config, file_desc, False, plugins)
         daemon_thread.start()
         if config.get("websocket_server"):
-            from electroncash import websockets
+            # The websockets module relies on an optional module that isn't
+            # always available: SimpleWebSocketServer
+            from electroncash import websockets  # pylint: disable=C0415
             websockets.WebSocketServer(config, daemon_thread.network).start()
         if config.get("requests_dir"):
             requests_path = os.path.join(config.get("requests_dir"), "index.html")
             if not os.path.exists(requests_path):
                 print("Requests directory not configured.")
                 print(
-                    "You can configure it using https://github.com/spesmilo/electrum-merchant"
+                    "You can configure it using "
+                    "https://github.com/spesmilo/electrum-merchant"
                 )
                 sys.exit(1)
         daemon_thread.join()
@@ -451,12 +502,9 @@ def process_config_options(args):
     if config_options.get("server"):
         config_options["auto_connect"] = False
 
-    # fixme: this can probably be achieved with a runtime hook (pyinstaller)
+    # FIXME: this can probably be achieved with a runtime hook (pyinstaller)
     try:
-        tmp_folder = os.path.join(
-            sys._MEIPASS,
-            "is_portable"
-        )
+        tmp_folder = os.path.join(sys._MEIPASS, "is_portable")  # pylint: disable=W0212
         config_options["portable"] = is_bundle and os.path.exists(tmp_folder)
     except AttributeError:
         config_options["portable"] = False
@@ -510,8 +558,8 @@ def main():
     util.setup_thread_excepthook()
 
     # On windows, allocate a console if needed
-    if sys.platform.startswith('win'):
-        require_console = '-v' in sys.argv or '--verbose' in sys.argv
+    if sys.platform.startswith("win"):
+        require_console = "-v" in sys.argv or "--verbose" in sys.argv
         console_title = _(f"{PROJECT_NAME} - Verbose Output") if require_console else None
         # Attempt to attach to ancestor process console. If create=True we will
         # create a new console window if no ancestor process console exists.
@@ -525,24 +573,24 @@ def main():
         create_or_attach_console(create=require_console, title=console_title)
 
     # on osx, delete Process Serial Number arg generated for apps launched in Finder
-    sys.argv = list(filter(lambda x: not x.startswith('-psn'), sys.argv))
+    sys.argv = list(filter(lambda x: not x.startswith("-psn"), sys.argv))
 
     # old 'help' syntax
-    if len(sys.argv) > 1 and sys.argv[1] == 'help':
-        sys.argv.remove('help')
-        sys.argv.append('-h')
+    if len(sys.argv) > 1 and sys.argv[1] == "help":
+        sys.argv.remove("help")
+        sys.argv.append("-h")
 
     # read arguments from stdin pipe and prompt
     for i, arg in enumerate(sys.argv):
-        if arg == '-':
+        if arg == "-":
             if sys.stdin.isatty():
-                raise BaseException('Cannot get argument from stdin')
+                raise BaseException("Cannot get argument from stdin")
             sys.argv[i] = sys.stdin.read()
             break
-        if arg == '?':
+        if arg == "?":
             sys.argv[i] = input("Enter argument:")
-        elif arg == ':':
-            sys.argv[i] = prompt_password('Enter argument (will not echo):')
+        elif arg == ":":
+            sys.argv[i] = prompt_password("Enter argument (will not echo):")
 
     # parse command line
     parser = get_parser()
@@ -555,7 +603,7 @@ def main():
     cmdname = args.cmd if args.cmd is not None else "gui"
 
     # run non-RPC commands separately
-    if cmdname in ['create', 'restore']:
+    if cmdname in ["create", "restore"]:
         run_non_rpc(config)
         sys.exit(0)
 
@@ -570,5 +618,5 @@ def main():
     sys.exit(0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
This is a backport of the PR https://github.com/Electron-Cash/Electron-Cash/pull/2120, that at the moment is still open.  Please see discussion there.  This removes most of the linting errors and warnings thrown at you by IDEs.

I had to add `# pylint: disable=...` to a lot of lines, mostly inline imports that cannot be moved to the top of the file.  I dislike this, but I find it better than having errors/warnings from the linters.  When there are too many errors and warnings it's hard not ignore all of them, even the important ones.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bitcoin-abc/electrumabc/100)
<!-- Reviewable:end -->
