### PR TITLE
Remove unused argument out_n

### DIFF
--- a/electroncash/cashacct.py
+++ b/electroncash/cashacct.py
@@ -1753,18 +1753,21 @@ class CashAcct(util.PrintError, verifier.SPVDelegate):
             self.minimal_ch_cache.d = {}
             self.processed_blocks.d = {}
 
-    def add_transaction_hook(self, txid: str, tx: object, out_n: int, script: ScriptOutput):
-        ''' Called by wallet inside add_transaction (with wallet.lock held) to
+    def add_transaction_hook(
+        self, txid: str, tx: object, script: ScriptOutput
+    ):
+        """Called by wallet inside add_transaction (with wallet.lock held) to
         notify us about transactions that were added containing a cashacct
-        scriptoutput. Note these tx's aren't yet in the verified set. '''
+        scriptoutput. Note these tx's aren't yet in the verified set."""
         assert isinstance(script, ScriptOutput)
         with self.lock:
             self.wallet_reg_tx[txid] = self.RegTx(txid=txid, script=script)
-            self._find_script(txid, giveto='w')  # makes sure there is only 1 copy in wallet_reg_tx
+            # makes sure there is only 1 copy in wallet_reg_tx
+            self._find_script(txid, giveto="w")
 
     def remove_transaction_hook(self, txid: str):
-        ''' Called by wallet inside remove_transaction (with wallet.lock held)
-        to tell us about a transaction that was removed. '''
+        """Called by wallet inside remove_transaction (with wallet.lock held)
+        to tell us about a transaction that was removed."""
         with self.lock:
             self._rm_vtx(txid)
             self.wallet_reg_tx.pop(txid, None)

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -1356,8 +1356,8 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                         # can only do it after making sure it's the *only*
                         # OP_RETURN in the tx.
                         deferred_cashacct_add = (
-                            lambda _tx_hash=tx_hash, _tx=tx, _n=n, _addr=addr:
-                                self.cashacct.add_transaction_hook(_tx_hash, _tx, _n, _addr)
+                            lambda _tx_hash=tx_hash, _tx=tx, _addr=addr:
+                                self.cashacct.add_transaction_hook(_tx_hash, _tx, _addr)
                         )
                 elif self.is_mine(addr):
                     # add coin to self.txo since it's mine.


### PR DESCRIPTION
Backport of https://github.com/Electron-Cash/Electron-Cash/pull/2214.

This belongs to a series of fixes for [dead code](https://github.com/Electron-Cash/Electron-Cash/issues/2213) found with `vulture . --min-confidence=100`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bitcoin-abc/electrumabc/101)
<!-- Reviewable:end -->
