### PR TITLE
Cirrus build osx

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,21 @@
+task:
+  clone_script: |
+    if [ -z "$CIRRUS_PR" ]; then
+      git clone --recursive --branch=$CIRRUS_BRANCH https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+      git reset --hard $CIRRUS_CHANGE_IN_REPO
+    else
+      git clone --recursive https://x-access-token:${CIRRUS_REPO_CLONE_TOKEN}@github.com/${CIRRUS_REPO_FULL_NAME}.git $CIRRUS_WORKING_DIR
+      git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
+      git reset --hard $CIRRUS_CHANGE_IN_REPO
+    fi
+  timeout_in: 120m
+  name: "Build macos DMG"
+  macos_instance:
+    image: catalina-base
+  brew_script:
+    - brew update
+    - brew install coreutils gettext pyenv
+  test_script:
+    - cd contrib/osx && ./make_osx
+  binaries_artifacts:
+    path: "dist/*.dmg"

--- a/contrib/osx/README.md
+++ b/contrib/osx/README.md
@@ -21,8 +21,8 @@ The above ensures that you pull in the zbar, secp256k1, and other submodules.
 With [brew](https://brew.sh) installed, run
 
 ```shell
-brew install coreutils
-brew install pyenv
+brew update
+brew install coreutils gettext pyenv
 ```
 
 Alternatively, with [macports](https://www.macports.org) installed, run


### PR DESCRIPTION
This PR adds a Cirrus CI configuration to build an unsigned macos DMG and upload it as a downloadable artifact. It runs on a Catalina VM which is the oldest one available for this CI. I tried Travis as well but the build will always timeout because their macos machines are too slow to accomodate such a build, and splitting the script is not desirable. The build documentation is also updated in accordance with the issues I faced during testing.