### PR TITLE
use ecash: address for the bitcoinabc.org explorer

### DIFF
--- a/electroncash/web.py
+++ b/electroncash/web.py
@@ -52,7 +52,7 @@ mainnet_block_explorers = {
                    {'tx': 'tx', 'addr': 'address',
                     'block': 'block'}),
     'BitcoinABC.org': ('https://explorer.bitcoinabc.org',
-                       Address.FMT_CASHADDR_BCH,
+                       Address.FMT_CASHADDR,
                        {'tx': 'tx',
                         'addr': 'address',
                         'block': 'block-height'}),


### PR DESCRIPTION
Right now the bitcoinabc.org explorer no longer support bitcoincash: cash addresses.
The other two explorers still only support bitcoincash: addresses.

Test plan
On the addresses tab, right click and select "Open in explorer"