### PR TITLE
Implement a fallack for formatting amounts

### DIFF
--- a/electroncash/tests/test_util.py
+++ b/electroncash/tests/test_util.py
@@ -40,9 +40,9 @@ class _TestFormatSatoshis(unittest.TestCase):
         locale.setlocale(locale.LC_NUMERIC, initial_locale)
 
     def test_format_satoshis(self):
-        result = format_satoshis(1234)
-        expected = "0" + self.dp + "00001234"
-        self.assertEqual(expected, result)
+        self.assertEqual(format_satoshis(1234), "12" + self.dp + "34")
+        self.assertEqual(format_satoshis(12), "0" + self.dp + "12")
+        self.assertEqual(format_satoshis(7), "0" + self.dp + "07")
 
     def test_format_satoshis_zero(self):
         result = format_satoshis(0)
@@ -50,9 +50,8 @@ class _TestFormatSatoshis(unittest.TestCase):
         self.assertEqual(expected, result)
 
     def test_format_satoshis_negative(self):
-        result = format_satoshis(-1234)
-        expected = "-0" + self.dp + "00001234"
-        self.assertEqual(expected, result)
+        self.assertEqual(format_satoshis(-1234), "-12" + self.dp + "34")
+        self.assertEqual(format_satoshis(-1), "-0" + self.dp + "01")
 
     def test_format_fee(self):
         result = format_satoshis(1700/1000, 0, 0)
@@ -70,30 +69,30 @@ class _TestFormatSatoshis(unittest.TestCase):
 
     def test_format_satoshis_whitespaces(self):
         result = format_satoshis(12340, whitespaces=True)
-        expected = "     0" + self.dp + "0001234 "
+        expected = "         123" + self.dp + "4 "
         self.assertEqual(expected, result)
 
         result = format_satoshis(1234, whitespaces=True)
-        expected = "     0" + self.dp + "00001234"
+        expected = "          12" + self.dp + "34"
         self.assertEqual(expected, result)
 
     def test_format_satoshis_whitespaces_negative(self):
         result = format_satoshis(-12340, whitespaces=True)
-        expected = "    -0" + self.dp + "0001234 "
+        expected = "        -123" + self.dp + "4 "
         self.assertEqual(expected, result)
 
         result = format_satoshis(-1234, whitespaces=True)
-        expected = "    -0" + self.dp + "00001234"
+        expected = "         -12" + self.dp + "34"
         self.assertEqual(expected, result)
 
     def test_format_satoshis_diff_positive(self):
         result = format_satoshis(1234, is_diff=True)
-        expected = "+0" + self.dp + "00001234"
+        expected = "+12" + self.dp + "34"
         self.assertEqual(expected, result)
 
     def test_format_satoshis_diff_negative(self):
         result = format_satoshis(-1234, is_diff=True)
-        expected = "-0" + self.dp + "00001234"
+        expected = "-12" + self.dp + "34"
         self.assertEqual(expected, result)
 
 

--- a/electroncash/version.py
+++ b/electroncash/version.py
@@ -2,7 +2,7 @@
 import re
 
 # version of the client package
-VERSION_TUPLE = (5, 0, 0)
+VERSION_TUPLE = (5, 0, 1)
 PACKAGE_VERSION = ".".join(map(str, VERSION_TUPLE))
 # protocol version requested
 PROTOCOL_VERSION = '1.4'

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -82,27 +82,6 @@ from .exception_window import ExceptionHook
 from .update_checker import UpdateChecker
 
 
-FALLBACK_LOCALE =  ("en_US", "UTF-8")
-
-
-def set_locale():
-    """Try to set a reasonable LC_NUMERIC locale, to show well formatted
-    amounts, with thousands grouping for large values.
-    """
-    language_code, encoding = locale.getdefaultlocale()
-    try:
-        locale.setlocale(locale.LC_NUMERIC, (language_code, encoding))
-    except locale.Error:
-        try:
-            if language_code is not None:
-                # Windows has exotic encodings that cause failures.
-                locale.setlocale(locale.LC_NUMERIC, (language_code, "UTF-8"))
-            else:
-                locale.setlocale(locale.LC_NUMERIC, FALLBACK_LOCALE)
-        except locale.Error:
-            pass
-
-
 class ElectrumGui(QObject, PrintError):
     new_window_signal = pyqtSignal(str, object)
     update_available_signal = pyqtSignal(bool)
@@ -141,10 +120,6 @@ class ElectrumGui(QObject, PrintError):
             # Fixme: instantiating the QApplication inside the __init__ of
             #        a QObject is probably the reason for segfault on exit.
             self.app = QApplication(sys.argv)
-            if locale.getlocale(locale.LC_NUMERIC) == (None, None):
-                # On some OS, instantiating the QApplication sets the locale.
-                # But on Windows, doing it manually seems to be required.
-                set_locale()
         finally:
             call_after_app()
 


### PR DESCRIPTION
On some  systems (mostly MacOS, but also some Windows), the locale-aware amounts formatting with thousands grouping does not work as expected. Implement a fallback for such cases. 

The fallback method uses a "." as decimal point and a "," for thousands separation (python default)