### PR TITLE
change threshold for long address in "transaction details"

### DIFF
--- a/electroncash_gui/qt/transaction_dialog.py
+++ b/electroncash_gui/qt/transaction_dialog.py
@@ -721,12 +721,12 @@ class TxDialog(QDialog, MessageBoxMixin, PrintError):
             # /CashAccounts support
             # Mark B. Lundeberg's patented output formatter logic™
             if v is not None:
-                if len(addrstr) > 42: # for long outputs, make a linebreak.
+                if len(addrstr) > 48: # for long outputs, make a linebreak.
                     cursor.insertBlock()
                     addrstr = '\u21b3'
                     cursor.insertText(addrstr, ext)
                 # insert enough spaces until column 43, to line up amounts
-                cursor.insertText(' '*(43 - len(addrstr)), ext)
+                cursor.insertText(' '*(49 - len(addrstr)), ext)
                 cursor.insertText(format_amount(v), ext)
             cursor.insertBlock()
             # /Mark B. Lundeberg's patented output formatting logic™


### PR DESCRIPTION
We recently started showing the prefix in all CashAddresses everywhere in the GUI.
As a result, the "tx details" dialog started splitting outputs on 2 lines.

A cash address with a "ecash:" prefix has a length of 48.
42 is the length of an address with prefix omitted.

This change puts outputs back on a single line with the "ecash:" cashaddress format.