### PR TITLE
instantiate QApplication before any other QObject

### DIFF
--- a/electroncash/daemon.py
+++ b/electroncash/daemon.py
@@ -364,6 +364,5 @@ class Daemon(DaemonThread):
             #
             os.environ['QT_OPENGL'] = str(config.get('qt_opengl'))
         gui = __import__('electroncash_gui.' + gui_name, fromlist=['electroncash_gui'])
-        gui.instantiate_qapplication(config)
         self.gui = gui.ElectrumGui(config, self, plugins)
         self.gui.main()

--- a/electroncash/daemon.py
+++ b/electroncash/daemon.py
@@ -347,7 +347,6 @@ class Daemon(DaemonThread):
         remove_lockfile(get_lockfile(self.config))
         super().stop()
 
-
     def init_gui(self):
         config = self.config
         plugins = self.plugins
@@ -365,5 +364,6 @@ class Daemon(DaemonThread):
             #
             os.environ['QT_OPENGL'] = str(config.get('qt_opengl'))
         gui = __import__('electroncash_gui.' + gui_name, fromlist=['electroncash_gui'])
+        gui.instantiate_qapplication(config)
         self.gui = gui.ElectrumGui(config, self, plugins)
         self.gui.main()

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -135,7 +135,7 @@ def _pre_and_post_app_setup(config) -> Callable[[], None]:
     return ret
 
 app = None
-def instantiate_qapplication(config):
+def init_qapplication(config):
     global app
     i18n.set_language(config.get('language'))
     call_after_app = _pre_and_post_app_setup(config)

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -53,9 +53,33 @@ from .plugin import FusionPlugin, TOR_PORTS, COIN_FRACTION_FUDGE_FACTOR, select_
 
 from pathlib import Path
 heredir = Path(__file__).parent
-icon_fusion_logo = QIcon(str(heredir / 'Cash Fusion Logo - No Text.svg'))
-icon_fusion_logo_gray = QIcon(str(heredir / 'Cash Fusion Logo - No Text Gray.svg'))
-image_red_exclamation = QImage(str(heredir / 'red_exclamation.png'))
+
+# Lazy init the icons to avoid creating QObject when importing the module,
+# in case the QApplication doesn't exist yet.
+icon_fusion_logo = None
+icon_fusion_logo_gray = None
+image_red_exclamation = None
+
+
+def get_icon_fusion_logo():
+    global icon_fusion_logo
+    if icon_fusion_logo is None:
+        icon_fusion_logo = QIcon(str(heredir / 'Cash Fusion Logo - No Text.svg'))
+    return icon_fusion_logo
+
+
+def get_icon_fusion_logo_gray():
+    global icon_fusion_logo_gray
+    if icon_fusion_logo_gray is None:
+        icon_fusion_logo_gray = QIcon(str(heredir / 'Cash Fusion Logo - No Text Gray.svg'))
+    return icon_fusion_logo_gray
+
+
+def get_image_red_exclamation():
+    global image_red_exclamation
+    if image_red_exclamation is None:
+        image_red_exclamation = QImage(str(heredir / 'red_exclamation.png'))
+    return image_red_exclamation
 
 
 class Plugin(FusionPlugin, QObject):
@@ -258,7 +282,7 @@ class Plugin(FusionPlugin, QObject):
         settings_tab = SettingsWidget(self)
         self.server_status_changed_signal.connect(settings_tab.update_server_error)
         tabs = network_dialog.nlayout.tabs
-        tabs.addTab(settings_tab, icon_fusion_logo, _('CashFusion'))
+        tabs.addTab(settings_tab, get_icon_fusion_logo(), _('CashFusion'))
         self.widgets.add(settings_tab)
         self.weak_settings_tab = weakref.ref(settings_tab)
 
@@ -370,7 +394,7 @@ class Plugin(FusionPlugin, QObject):
             if window and self.active and self.gui and self.gui.windows and self.tor_port_good is None:
                 network = self.gui.daemon.network
                 if network and network.tor_controller.is_available() and not network.tor_controller.is_enabled():
-                    icon_pm = icon_fusion_logo.pixmap(32)
+                    icon_pm = get_icon_fusion_logo().pixmap(32)
                     answer = window.question(
                         _('CashFusion requires Tor to operate anonymously. Would'
                           ' you like to enable the Tor client now?'),
@@ -458,7 +482,7 @@ class PasswordDialog(WindowModalDialog):
     def __init__(self, wallet, message, callback_ok = None, callback_cancel = None):
         parent = Plugin.get_suitable_dialog_window_parent(wallet)
         super().__init__(parent=parent, title=_("Enter Password"))
-        self.setWindowIcon(icon_fusion_logo)
+        self.setWindowIcon(get_icon_fusion_logo())
         self.wallet = wallet
         self.callback_ok = callback_ok
         self.callback_cancel = callback_cancel
@@ -470,7 +494,7 @@ class PasswordDialog(WindowModalDialog):
         self.msglabel.setMinimumWidth(250)
         self.msglabel.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Expanding)
         hbox = QHBoxLayout()
-        iconlabel = QLabel(); iconlabel.setPixmap(icon_fusion_logo.pixmap(32))
+        iconlabel = QLabel(); iconlabel.setPixmap(get_icon_fusion_logo().pixmap(32))
         hbox.addWidget(iconlabel)
         hbox.addWidget(self.msglabel, 1, Qt.AlignLeft|Qt.AlignVCenter)
         cmargins = hbox.contentsMargins(); cmargins.setBottom(10); hbox.setContentsMargins(cmargins)  # pad the bottom a bit
@@ -544,7 +568,7 @@ class PasswordDialog(WindowModalDialog):
 
 class DisabledFusionButton(StatusBarButton):
     def __init__(self, wallet, message):
-        super().__init__(icon_fusion_logo_gray, 'Fusion', self.show_message)
+        super().__init__(get_icon_fusion_logo_gray(), 'Fusion', self.show_message)
         self.wallet = wallet
         self.message = message
         self.setToolTip(_("CashFusion (disabled)"))
@@ -562,8 +586,8 @@ class FusionButton(StatusBarButton):
 
         self.server_error : tuple = None
 
-        self.icon_autofusing_on = icon_fusion_logo
-        self.icon_autofusing_off = icon_fusion_logo_gray
+        self.icon_autofusing_on = get_icon_fusion_logo()
+        self.icon_autofusing_off = get_icon_fusion_logo_gray()
         self.icon_fusing_problem = self.style().standardIcon(QStyle.SP_MessageBoxWarning)
 
 #        title = QWidgetAction(self)
@@ -613,7 +637,7 @@ class FusionButton(StatusBarButton):
                 r = self.rect()
                 r -= QMargins(4,6,4,6)
                 r.moveCenter(r.center() + QPoint(4,4))
-                p.drawImage(r, image_red_exclamation)
+                p.drawImage(r, get_image_red_exclamation())
             finally:
                 # paranoia. The above never raises but.. if it does.. PyQt will
                 # crash hard if we don't end the QPainter properly before
@@ -924,7 +948,7 @@ class SettingsWidget(QWidget):
 class WalletSettingsDialog(WindowModalDialog):
     def __init__(self, parent, plugin, wallet):
         super().__init__(parent=parent, title=_("CashFusion - Wallet Settings"))
-        self.setWindowIcon(icon_fusion_logo)
+        self.setWindowIcon(get_icon_fusion_logo())
         self.plugin = plugin
         self.wallet = wallet
         self.conf = Conf(self.wallet)
@@ -1365,7 +1389,7 @@ class FusionsWindow(ServerFusionsBaseMixin, QDialog):
         ServerFusionsBaseMixin.__init__(self, plugin, refresh_interval=1000)
 
         self.setWindowTitle(_("CashFusion - Fusions"))
-        self.setWindowIcon(icon_fusion_logo)
+        self.setWindowIcon(get_icon_fusion_logo())
 
         main_layout = QVBoxLayout(self)
 

--- a/electrum-abc
+++ b/electrum-abc
@@ -405,6 +405,11 @@ def init_plugins(config, gui_name):
 
 def run_gui(config, config_options):
     """Run Electrum ABC with GUI"""
+    # The QApplication must be started before any QObject is created.
+    # The first call that creates QObjects in this function is init_plugins.
+    from electroncash_gui.qt import init_qapplication
+    init_qapplication(config)
+
     file_desc, server = daemon.get_fd_or_server(config)
     if file_desc is not None:
         plugins = init_plugins(config, config.get("gui", "qt"))


### PR DESCRIPTION
A ``QObject`` should always be instantiated after the ``QApplication``.

This should solve the warnings that we see when starting the application:
```
$ ./electrum-abc
QCoreApplication::arguments: Please instantiate the QApplication object first
QCoreApplication::arguments: Please instantiate the QApplication object first
QCoreApplication::arguments: Please instantiate the QApplication object first
QCoreApplication::arguments: Please instantiate the QApplication object first
```

And I suspect that it also solves the occasional segfaults that we see when closing the application.

This is a work in progress:
 - [x] don't instantiate QApplication inside a QObject's init
 - [x] do it before any QObject / QWidget is initialized (before ``init_plugins``)
