### PR TITLE
lower the default fee to 2 sats/byte

### DIFF
--- a/electroncash/migrate_data.py
+++ b/electroncash/migrate_data.py
@@ -28,8 +28,8 @@ INVALID_FUSION_HOSTS = [
     "161.97.82.60"]
 
 # The default fee set to 80000 in 4.3.0 was lowered to 10000 in 4.3.2,
-# and then again to 5000 in 4.3.3
-OLD_DEFAULT_FEES = [80000, 10000]
+# and then again to 5000 in 4.3.3, and then again to 2000 in 5.0.2
+OLD_DEFAULT_FEES = [80000, 10000, 5000]
 
 
 # function copied from https://github.com/Electron-Cash/Electron-Cash/blob/master/electroncash/util.py

--- a/electroncash/simple_config.py
+++ b/electroncash/simple_config.py
@@ -35,7 +35,7 @@ class SimpleConfig(PrintError):
         2. User configuration (in the user's config directory)
     They are taken in order (1. overrides config options set in 2.)
     """
-    max_slider_fee: int = 50000
+    max_slider_fee: int = 10000
     """Maximum fee rate in sat/kB that can be selected using the slider widget
     in the send tab. Make sure this is a multiple of slider_steps, so that
     all slider positions are integers."""
@@ -274,8 +274,8 @@ class SimpleConfig(PrintError):
         """
         Return default fee rate in sat/kB for new wallets.
         """
-        # use the lowest rate that can be set with the slider
-        return cls.max_slider_fee // cls.slider_steps
+        # use the 2nd lowest rate that can be set with the slider
+        return cls.max_slider_fee // cls.slider_steps * 2
 
     def fee_per_kb(self) -> int:
         """Return transaction fee in sats per kB"""


### PR DESCRIPTION
Lower the default fee to 2 satoshis per byte (from 5) and change the
fee slider range to 1 - 10 (from 5 - 50).

Make sure to automatically update this setting for users when they
upgrade to the next version, if they haven't touched the previous default fee.