### PR TITLE
Address  consolidation tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,7 @@
 files: |
     (?x)^(
         electroncash/tests/.*py|
+        electroncash/consolidate.py|
         electroncash/constants.py|
         electroncash/keystore.py|
         electroncash_gui/qt/address_list.py|

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ files: |
         electroncash/constants.py|
         electroncash/keystore.py|
         electroncash_gui/qt/address_list.py|
+        electroncash_gui/qt/consolidate_coins_dialog.py|
         electroncash_gui/qt/exception_window.py
     )$
 repos:

--- a/electroncash/consolidate.py
+++ b/electroncash/consolidate.py
@@ -57,7 +57,6 @@ class AddressConsolidator:
         min_value_sats: Optional[int] = None,
         max_value_sats: Optional[int] = None,
     ):
-
         self._coins = [
             utxo
             for utxo in wallet.get_addr_utxo(address).values()
@@ -76,7 +75,7 @@ class AddressConsolidator:
         self.wallet = wallet
 
     def get_unsigned_transactions(
-        self, output_address, max_tx_size: int = MAX_STANDARD_TX_SIZE
+        self, output_address: Address, max_tx_size: int = MAX_STANDARD_TX_SIZE
     ) -> List[Transaction]:
         """
         Build as many raw transactions as needed to consolidate the coins.

--- a/electroncash/consolidate.py
+++ b/electroncash/consolidate.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+# Electrum ABC - lightweight eCash client
+# Copyright (C) 2021 The Electrum ABC developers
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+"""
+This module provides coin consolidation tools.
+"""
+from typing import Optional
+
+from .address import Address
+from .wallet import Abstract_Wallet
+
+
+class AddressConsolidator:
+    """Consolidate coins for a single address in a wallet."""
+
+    def __init__(
+        self,
+        address: Address,
+        wallet: Abstract_Wallet,
+        include_coinbase: bool = True,
+        include_non_coinbase: bool = True,
+        include_frozen: bool = False,
+        include_slp: bool = False,
+        min_value_sats: Optional[int] = None,
+        max_value_sats: Optional[int] = None,
+    ):
+
+        self._coins = [
+            utxo
+            for utxo in wallet.get_addr_utxo(address).values()
+            if (
+                (include_coinbase or not utxo["coinbase"])
+                and (include_non_coinbase or utxo["coinbase"])
+                and (include_slp or utxo["slp_token"] is None)
+                and (include_frozen or not utxo["is_frozen_coin"])
+                and (min_value_sats is None or utxo["value"] >= min_value_sats)
+                and (max_value_sats is None or utxo["value"] <= max_value_sats)
+            )
+        ]

--- a/electroncash/consolidate.py
+++ b/electroncash/consolidate.py
@@ -93,14 +93,6 @@ class AddressConsolidator:
                 "signatures": [None],
                 "num_sig": 1,
             }
-        elif isinstance(self.wallet, wallet.Simple_Deterministic_Wallet):
-            derivation = self.wallet.get_address_index(address)
-            x_pubkey = self.wallet.keystore.get_xpubkey(*derivation)
-            sig_info = {
-                "x_pubkeys": [x_pubkey],
-                "signatures": [None],
-                "num_sig": 1,
-            }
         elif isinstance(self.wallet, wallet.Multisig_Wallet):
             derivation = self.wallet.get_address_index(address)
             sig_info = {
@@ -110,6 +102,16 @@ class AddressConsolidator:
                 "signatures": [None] * self.wallet.n,
                 "num_sig": self.wallet.m,
                 "pubkeys": None,
+            }
+        else:
+            # Default case for wallet.Simple_Deterministic_Wallet and Mock wallet used
+            # in test
+            derivation = self.wallet.get_address_index(address)
+            x_pubkey = self.wallet.keystore.get_xpubkey(*derivation)
+            sig_info = {
+                "x_pubkeys": [x_pubkey],
+                "signatures": [None],
+                "num_sig": 1,
             }
 
         # Add more metadata to coins

--- a/electroncash/consolidate.py
+++ b/electroncash/consolidate.py
@@ -133,22 +133,23 @@ class AddressConsolidator:
         assert max_tx_size < MAX_TX_SIZE
         placeholder_amount = 200
         transactions = []
-        while self._coins:
+        i = 0
+        while i < len(self._coins):
             tx_size = 0
             amount = 0
             tx = Transaction(None)
             tx.set_inputs([])
-            while tx_size < max_tx_size and self._coins:
+            while tx_size < max_tx_size and i < len(self._coins):
                 dummy_tx = Transaction(None)
-                dummy_tx.set_inputs(tx.inputs() + [self._coins[0]])
+                dummy_tx.set_inputs(tx.inputs() + [self._coins[i]])
                 dummy_tx.set_outputs(
                     [(TYPE_ADDRESS, output_address, placeholder_amount)]
                 )
                 tx_size = len(dummy_tx.serialize(estimate_size=True)) // 2
 
                 if tx_size < max_tx_size:
-                    amount = amount + self._coins[0]["value"]
-                    tx.add_inputs([self._coins.pop(0)])
+                    amount = amount + self._coins[i]["value"]
+                    tx.add_inputs([self._coins[i]])
                     tx.set_outputs(
                         [
                             (
@@ -158,6 +159,7 @@ class AddressConsolidator:
                             )
                         ]
                     )
+                    i += 1
 
             transactions.append(tx)
         return transactions

--- a/electroncash/consolidate.py
+++ b/electroncash/consolidate.py
@@ -25,7 +25,7 @@
 This module provides coin consolidation tools.
 """
 import copy
-from typing import List, Optional, Tuple
+from typing import Iterator, List, Optional, Tuple
 
 from . import wallet
 from .address import Address
@@ -136,12 +136,13 @@ class AddressConsolidator:
             number of inputs per transaction.
         :return:
         """
-        transactions = []
+        return list(self.iter_transactions())
+
+    def iter_transactions(self) -> Iterator[Transaction]:
         coin_index = 0
         while coin_index < len(self._coins):
             coin_index, tx = self.build_another_transaction(coin_index)
-            transactions.append(tx)
-        return transactions
+            yield tx
 
     def build_another_transaction(self, coin_index: int) -> Tuple[int, Transaction]:
         """Build another transaction using coins starting at index coin_index.

--- a/electroncash/consolidate.py
+++ b/electroncash/consolidate.py
@@ -75,16 +75,16 @@ class AddressConsolidator:
 
         self.wallet = wallet
 
-    def get_transactions(
+    def get_unsigned_transactions(
         self, output_address, max_tx_size: int = MAX_STANDARD_TX_SIZE
     ) -> List[Transaction]:
         """
         Build as many raw transactions as needed to consolidate the coins.
 
-        :param max_tx_size: Maximum tx size in bytes. This is what limits the
-            number of inputs per transaction.
         :param output_address: Make all transactions send the total amount to this
             address.
+        :param max_tx_size: Maximum tx size in bytes. This is what limits the
+            number of inputs per transaction.
         :return:
         """
         assert max_tx_size < MAX_TX_SIZE

--- a/electroncash/consolidate.py
+++ b/electroncash/consolidate.py
@@ -24,12 +24,13 @@
 """
 This module provides coin consolidation tools.
 """
+import copy
 from typing import List, Optional
 
+from . import wallet
 from .address import Address
 from .bitcoin import TYPE_ADDRESS
 from .transaction import Transaction
-from .wallet import Abstract_Wallet
 
 MAX_STANDARD_TX_SIZE: int = 100_000
 """Maximum size for transactions that nodes are willing to relay/mine.
@@ -49,7 +50,7 @@ class AddressConsolidator:
     def __init__(
         self,
         address: Address,
-        wallet: Abstract_Wallet,
+        wallet_instance: wallet.Abstract_Wallet,
         include_coinbase: bool = True,
         include_non_coinbase: bool = True,
         include_frozen: bool = False,
@@ -59,7 +60,7 @@ class AddressConsolidator:
     ):
         self._coins = [
             utxo
-            for utxo in wallet.get_addr_utxo(address).values()
+            for utxo in wallet_instance.get_addr_utxo(address).values()
             if (
                 (include_coinbase or not utxo["coinbase"])
                 and (include_non_coinbase or utxo["coinbase"])
@@ -69,10 +70,51 @@ class AddressConsolidator:
                 and (max_value_sats is None or utxo["value"] <= max_value_sats)
             )
         ]
-        for c in self._coins:
-            wallet.add_input_info(c)
+        self.wallet = wallet_instance
 
-        self.wallet = wallet
+        # Cache data common to all coins
+        self.address = address
+        self.txin_type = wallet_instance.get_txin_type(address)
+        self.received = {}
+        for tx_hash, height in wallet_instance.get_address_history(address):
+            l = self.wallet.txo.get(tx_hash, {}).get(address, [])
+            for n, v, is_cb in l:
+                self.received[tx_hash + f":{n}"] = (height, v, is_cb)
+
+        if isinstance(self.wallet, wallet.ImportedAddressWallet):
+            sig_info = {
+                "x_pubkeys": ["fd" + address.to_script_hex()],
+                "signatures": [None],
+            }
+        elif isinstance(self.wallet, wallet.ImportedPrivkeyWallet):
+            pubkey = self.wallet.keystore.address_to_pubkey(address)
+            sig_info = {
+                "x_pubkeys": [pubkey.to_ui_string()],
+                "signatures": [None],
+                "num_sig": 1,
+            }
+        elif isinstance(self.wallet, wallet.Simple_Deterministic_Wallet):
+            derivation = self.wallet.get_address_index(address)
+            x_pubkey = self.wallet.keystore.get_xpubkey(*derivation)
+            sig_info = {
+                "x_pubkeys": [x_pubkey],
+                "signatures": [None],
+                "num_sig": 1,
+            }
+        elif isinstance(self.wallet, wallet.Multisig_Wallet):
+            derivation = self.wallet.get_address_index(address)
+            sig_info = {
+                "x_pubkeys": [
+                    k.get_xpubkey(*derivation) for k in self.wallet.get_keystores()
+                ],
+                "signatures": [None] * self.wallet.n,
+                "num_sig": self.wallet.m,
+                "pubkeys": None,
+            }
+
+        # Add more metadata to coins
+        for i, c in enumerate(self._coins):
+            self.add_input_info(c, sig_info)
 
     def get_unsigned_transactions(
         self, output_address: Address, max_tx_size: int = MAX_STANDARD_TX_SIZE
@@ -117,3 +159,15 @@ class AddressConsolidator:
 
             transactions.append(tx)
         return transactions
+
+    def add_input_info(self, txin, siginfo: dict):
+        """Reimplemented from wallet.add_input_info to optimize for multiple calls
+        with same address and same history.
+        Caching the transaction history is the most significant optimization,
+        as the original function loads the history from disk (text file) for
+        every call."""
+        txin["type"] = self.txin_type
+        item = self.received.get(txin["prevout_hash"] + f":{txin['prevout_n']}")
+        tx_height, value, is_cb = item
+        txin["value"] = value
+        txin.update(copy.deepcopy(siginfo))

--- a/electroncash/constants.py
+++ b/electroncash/constants.py
@@ -64,3 +64,9 @@ WHITELISTED_TESTNET_PREFIXES: List[str] = [
     CASHADDR_TESTNET_PREFIX,
     CASHADDR_TESTNET_PREFIX_BCH,
 ]
+
+DUST_THRESHOLD: int = 546
+"""
+Change < dust threshold is added to the tx fee.
+The unit is satoshis.
+"""

--- a/electroncash/constants.py
+++ b/electroncash/constants.py
@@ -38,6 +38,9 @@ class Unit:
     def name_for_selection_menu(self):
         return self.ticker if not self.old_name else f"{self.ticker} ({self.old_name})"
 
+    def __str__(self):
+        return self.ticker
+
 
 SAT = Unit("sats", 0)
 XEC = Unit("XEC", 2, "bits")

--- a/electroncash/network.py
+++ b/electroncash/network.py
@@ -38,6 +38,7 @@ import json
 from typing import Dict
 
 import socks
+from .constants import DUST_THRESHOLD
 from . import util
 from . import bitcoin
 from . import networks
@@ -1837,12 +1838,7 @@ class Network(util.DaemonThread):
             server_msg = str(server_msg)
         server_msg = server_msg.replace("\n", r"\n") # replace \n with slash-n because dict does this.
         if r'dust' in server_msg:
-            dust_thold = 546
-            try:
-                from .wallet import dust_threshold
-                dust_thold = dust_threshold(Network.get_instance())
-            except: pass
-            return _("Transaction could not be broadcast due to dust outputs (dust threshold is {} satoshis).").format(dust_thold)
+            return _(f"Transaction could not be broadcast due to dust outputs (dust threshold is {DUST_THRESHOLD} satoshis).")
         elif r'Missing inputs' in server_msg or r'Inputs unavailable' in server_msg or r"bad-txns-inputs-spent" in server_msg or r"bad-txns-inputs-missingorspent" in server_msg:
             return _("Transaction could not be broadcast due to missing, already-spent, or otherwise invalid inputs.")
         elif r"transaction already in block chain" in server_msg:

--- a/electroncash/tests/__main__.py
+++ b/electroncash/tests/__main__.py
@@ -7,6 +7,7 @@ from .test_blockchain import TestBlockchain
 from .test_cashacct import TestCashAccounts
 from .test_cashaddrenc import TestCashAddrAddress
 from .test_commands import TestCommands
+from .test_consolidate import suite as test_consolidate_suite
 from .test_dnssec import TestDnsSec
 from .test_import_electroncash_data import TestImportECData
 from .test_interface import TestInterface
@@ -32,6 +33,7 @@ def suite():
     test_suite.addTest(loadTests(TestCashAccounts))
     test_suite.addTest(loadTests(TestCashAddrAddress))
     test_suite.addTest(loadTests(TestCommands))
+    test_suite.addTest(test_consolidate_suite())
     test_suite.addTest(loadTests(TestDnsSec))
     test_suite.addTest(loadTests(TestImportECData))
     test_suite.addTest(loadTests(TestInterface))

--- a/electroncash/tests/test_consolidate.py
+++ b/electroncash/tests/test_consolidate.py
@@ -103,7 +103,7 @@ class TestConsolidateCoinSelection(unittest.TestCase):
             self.assertLessEqual(coin["value"], 1005)
         self.assertEqual(len(consolidator._coins), 3)
 
-    def test_get_raw_transactions(self):
+    def test_get_unsigned_transactions(self):
         for size in range(200, 1500, 100):
             # select all coins
             consolidator = consolidate.AddressConsolidator(
@@ -116,7 +116,7 @@ class TestConsolidateCoinSelection(unittest.TestCase):
                 min_value_sats=None,
                 max_value_sats=None,
             )
-            txs = consolidator.get_transactions(
+            txs = consolidator.get_unsigned_transactions(
                 output_address=TEST_ADDRESS,
                 max_tx_size=size,
             )

--- a/electroncash/tests/test_consolidate.py
+++ b/electroncash/tests/test_consolidate.py
@@ -1,0 +1,102 @@
+import unittest
+from unittest.mock import Mock
+
+from .. import consolidate
+
+
+class TestConsolidateCoinSelection(unittest.TestCase):
+    def test_coin_selection(self) -> None:
+        coins = {}
+        v = 0
+        for is_coinbase in (True, False):
+            for is_frozen_coin in (True, False):
+                for slp in (None, "not None"):
+                    coins[f"dummy_txid:{v}"] = {
+                        "value": v,
+                        "coinbase": is_coinbase,
+                        "is_frozen_coin": is_frozen_coin,
+                        "slp_token": slp,
+                    }
+                    v += 1  # noqa: SIM113
+
+        mock_wallet = Mock()
+        mock_wallet.get_addr_utxo.return_value = coins
+
+        for incl_coinbase in (True, False):
+            for incl_noncoinbase in (True, False):
+                for incl_frozen in (True, False):
+                    for incl_slp in (True, False):
+                        consolidator = consolidate.AddressConsolidator(
+                            "address",
+                            mock_wallet,
+                            incl_coinbase,
+                            incl_noncoinbase,
+                            incl_frozen,
+                            incl_slp,
+                        )
+                        for coin in consolidator._coins:
+                            if not incl_coinbase:
+                                self.assertFalse(coin["coinbase"])
+                            if not incl_noncoinbase:
+                                self.assertTrue(coin["coinbase"])
+                            if not incl_frozen:
+                                self.assertFalse(coin["is_frozen_coin"])
+                            if not incl_slp:
+                                self.assertIsNone(coin["slp_token"])
+
+        # test minimum and maximum value
+        self.assertListEqual([c["value"] for c in coins.values()], list(range(8)))
+
+        consolidator = consolidate.AddressConsolidator(
+            "address",
+            mock_wallet,
+            True,
+            True,
+            True,
+            True,
+            min_value_sats=3,
+            max_value_sats=None,
+        )
+        for coin in consolidator._coins:
+            self.assertGreaterEqual(coin["value"], 3)
+        self.assertEqual(len(consolidator._coins), 5)
+
+        consolidator = consolidate.AddressConsolidator(
+            "address",
+            mock_wallet,
+            True,
+            True,
+            True,
+            True,
+            min_value_sats=None,
+            max_value_sats=5,
+        )
+        for coin in consolidator._coins:
+            self.assertLessEqual(coin["value"], 5)
+        self.assertEqual(len(consolidator._coins), 6)
+
+        consolidator = consolidate.AddressConsolidator(
+            "address",
+            mock_wallet,
+            True,
+            True,
+            True,
+            True,
+            min_value_sats=3,
+            max_value_sats=5,
+        )
+        for coin in consolidator._coins:
+            self.assertGreaterEqual(coin["value"], 3)
+            self.assertLessEqual(coin["value"], 5)
+        self.assertEqual(len(consolidator._coins), 3)
+
+
+def suite():
+    test_suite = unittest.TestSuite()
+    loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
+    test_suite.addTest(loadTests(TestConsolidateCoinSelection))
+    return test_suite
+
+
+if __name__ == "__main__":
+    unittest.main(defaultTest="suite")

--- a/electroncash/tests/test_consolidate.py
+++ b/electroncash/tests/test_consolidate.py
@@ -9,6 +9,9 @@ TEST_ADDRESS: Address = Address.from_string(
     "ecash:qr3l6uufcuwm9prgpa6cfxnez87fzstxesp7ugp0ez"
 )
 
+FEERATE: int = 1
+"""Satoshis per byte"""
+
 
 class TestConsolidateCoinSelection(unittest.TestCase):
     def setUp(self) -> None:
@@ -121,6 +124,22 @@ class TestConsolidateCoinSelection(unittest.TestCase):
             # tx size is roughly 148 * n_in + 34 * n_out + 10
             expected_n_inputs_for_size = (size - 44) // 148
             self.assertEqual(len(txs), math.ceil(8 / expected_n_inputs_for_size))
+
+            # Check the fee and amount
+            total_inputs = 0
+            total_outputs = 0
+            total_fee = 0
+            total_size = 0
+            for tx in txs:
+                tx_size = len(tx.serialize(estimate_size=True)) // 2
+                self.assertEqual(tx.get_fee(), tx_size * FEERATE)
+                total_fee += tx.get_fee()
+                total_inputs += tx.input_value()
+                total_outputs += tx.output_value()
+                total_size += tx_size
+            self.assertEqual(total_inputs, sum(range(1000, 1008)))
+            self.assertEqual(total_outputs, total_inputs - total_fee)
+            self.assertEqual(total_fee, total_size * FEERATE)
 
 
 def suite():

--- a/electroncash/tests/test_consolidate.py
+++ b/electroncash/tests/test_consolidate.py
@@ -142,12 +142,11 @@ class TestConsolidateCoinSelection(unittest.TestCase):
                 True,
                 min_value_sats=None,
                 max_value_sats=None,
-            )
-            self.assertEqual(n_coins, len(consolidator._coins))
-            txs = consolidator.get_unsigned_transactions(
                 output_address=TEST_ADDRESS,
                 max_tx_size=max_tx_size,
             )
+            self.assertEqual(n_coins, len(consolidator._coins))
+            txs = consolidator.get_unsigned_transactions()
             for tx in txs:
                 self.assertLess(len(tx.serialize(estimate_size=True)) // 2, max_tx_size)
 

--- a/electroncash/tests/test_consolidate.py
+++ b/electroncash/tests/test_consolidate.py
@@ -1,34 +1,46 @@
+import math
 import unittest
 from unittest.mock import Mock
 
 from .. import consolidate
+from ..address import Address
+
+TEST_ADDRESS: Address = Address.from_string(
+    "ecash:qr3l6uufcuwm9prgpa6cfxnez87fzstxesp7ugp0ez"
+)
 
 
 class TestConsolidateCoinSelection(unittest.TestCase):
-    def test_coin_selection(self) -> None:
+    def setUp(self) -> None:
         coins = {}
-        v = 0
+        i = 0
         for is_coinbase in (True, False):
             for is_frozen_coin in (True, False):
                 for slp in (None, "not None"):
-                    coins[f"dummy_txid:{v}"] = {
-                        "value": v,
+                    coins[f"dummy_txid:{i}"] = {
+                        "address": TEST_ADDRESS,
+                        "prevout_n": i,
+                        "prevout_hash": "a" * 64,
+                        "height": 1,
+                        "value": 1000 + i,
                         "coinbase": is_coinbase,
                         "is_frozen_coin": is_frozen_coin,
                         "slp_token": slp,
+                        "type": "p2pkh",
                     }
-                    v += 1  # noqa: SIM113
+                    i += 1  # noqa: SIM113
 
-        mock_wallet = Mock()
-        mock_wallet.get_addr_utxo.return_value = coins
+        self.mock_wallet = Mock()
+        self.mock_wallet.get_addr_utxo.return_value = coins
 
+    def test_coin_selection(self) -> None:
         for incl_coinbase in (True, False):
             for incl_noncoinbase in (True, False):
                 for incl_frozen in (True, False):
                     for incl_slp in (True, False):
                         consolidator = consolidate.AddressConsolidator(
                             "address",
-                            mock_wallet,
+                            self.mock_wallet,
                             incl_coinbase,
                             incl_noncoinbase,
                             incl_frozen,
@@ -45,50 +57,70 @@ class TestConsolidateCoinSelection(unittest.TestCase):
                                 self.assertIsNone(coin["slp_token"])
 
         # test minimum and maximum value
-        self.assertListEqual([c["value"] for c in coins.values()], list(range(8)))
-
         consolidator = consolidate.AddressConsolidator(
             "address",
-            mock_wallet,
+            self.mock_wallet,
             True,
             True,
             True,
             True,
-            min_value_sats=3,
+            min_value_sats=1003,
             max_value_sats=None,
         )
         for coin in consolidator._coins:
-            self.assertGreaterEqual(coin["value"], 3)
+            self.assertGreaterEqual(coin["value"], 1003)
         self.assertEqual(len(consolidator._coins), 5)
 
         consolidator = consolidate.AddressConsolidator(
             "address",
-            mock_wallet,
+            self.mock_wallet,
             True,
             True,
             True,
             True,
             min_value_sats=None,
-            max_value_sats=5,
+            max_value_sats=1005,
         )
         for coin in consolidator._coins:
-            self.assertLessEqual(coin["value"], 5)
+            self.assertLessEqual(coin["value"], 1005)
         self.assertEqual(len(consolidator._coins), 6)
 
         consolidator = consolidate.AddressConsolidator(
             "address",
-            mock_wallet,
+            self.mock_wallet,
             True,
             True,
             True,
             True,
-            min_value_sats=3,
-            max_value_sats=5,
+            min_value_sats=1003,
+            max_value_sats=1005,
         )
         for coin in consolidator._coins:
-            self.assertGreaterEqual(coin["value"], 3)
-            self.assertLessEqual(coin["value"], 5)
+            self.assertGreaterEqual(coin["value"], 1003)
+            self.assertLessEqual(coin["value"], 1005)
         self.assertEqual(len(consolidator._coins), 3)
+
+    def test_get_raw_transactions(self):
+        for size in range(200, 1500, 100):
+            # select all coins
+            consolidator = consolidate.AddressConsolidator(
+                "address",
+                self.mock_wallet,
+                True,
+                True,
+                True,
+                True,
+                min_value_sats=None,
+                max_value_sats=None,
+            )
+            txs = consolidator.get_transactions(
+                output_address=TEST_ADDRESS,
+                max_tx_size=size,
+            )
+
+            # tx size is roughly 148 * n_in + 34 * n_out + 10
+            expected_n_inputs_for_size = (size - 44) // 148
+            self.assertEqual(len(txs), math.ceil(8 / expected_n_inputs_for_size))
 
 
 def suite():

--- a/electroncash/transaction.py
+++ b/electroncash/transaction.py
@@ -816,10 +816,20 @@ class Transaction:
         self._inputs.extend(inputs)
         self.raw = None
 
+    def set_inputs(self, inputs):
+        self._inputs = inputs
+        self.raw = None
+
     def add_outputs(self, outputs):
         assert all(isinstance(output[1], (PublicKey, Address, ScriptOutput))
                    for output in outputs)
         self._outputs.extend(outputs)
+        self.raw = None
+
+    def set_outputs(self, outputs):
+        assert all(isinstance(output[1], (PublicKey, Address, ScriptOutput))
+                   for output in outputs)
+        self._outputs = outputs
         self.raw = None
 
     def input_value(self):

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -78,16 +78,8 @@ from .i18n import _
 
 DEFAULT_CONFIRMED_ONLY = False
 
-def relayfee(network):
-    RELAY_FEE = 5000
-    MAX_RELAY_FEE = 50000
-    f = network.relay_fee if network and network.relay_fee else RELAY_FEE
-    return min(f, MAX_RELAY_FEE)
 
 def dust_threshold(network):
-    # Change < dust threshold is added to the tx fee
-    #return 182 * 3 * relayfee(network) / 1000 # original Electrum logic
-    #return 1 # <-- was this value until late Sept. 2018
     return 546 # hard-coded Bitcoin Cash dust threshold. Was changed to this as of Sept. 2018
 
 
@@ -1745,9 +1737,6 @@ class Abstract_Wallet(PrintError, SPVDelegate):
             status = 3 + min(conf, 6)
             status_str = format_time(timestamp) if timestamp else _("unknown")
         return status, status_str
-
-    def relayfee(self):
-        return relayfee(self.network)
 
     def dust_threshold(self):
         return dust_threshold(self.network)

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -42,6 +42,7 @@ from collections import defaultdict, namedtuple
 from enum import Enum, auto
 from typing import Set, Tuple, Union
 
+from .constants import DUST_THRESHOLD
 from .i18n import ngettext
 from .util import (NotEnoughFunds, ExcessiveFee, PrintError,
                    UserCancelled, InvalidPassword, profiler,
@@ -52,7 +53,6 @@ from .address import Address, Script, ScriptOutput, PublicKey
 from .version import PACKAGE_VERSION
 from .keystore import load_keystore, Hardware_KeyStore, Imported_KeyStore, BIP32_KeyStore, xpubkey_to_address
 from . import mnemo
-from . import networks
 from . import keystore
 from .storage import multisig_type, WalletStorage
 
@@ -77,10 +77,6 @@ from .i18n import _
 
 
 DEFAULT_CONFIRMED_ONLY = False
-
-
-def dust_threshold(network):
-    return 546 # hard-coded Bitcoin Cash dust threshold. Was changed to this as of Sept. 2018
 
 
 def sweep_preparations(privkeys, network, imax=100):
@@ -145,8 +141,8 @@ def sweep(privkeys, network, config, recipient, fee=None, imax=100, sign_schnorr
         fee = config.estimate_fee(tx.estimated_size())
     if total - fee < 0:
         raise NotEnoughFunds(_('Not enough funds on address.') + '\nTotal: %d satoshis\nFee: %d'%(total, fee))
-    if total - fee < dust_threshold(network):
-        raise NotEnoughFunds(_('Not enough funds on address.') + '\nTotal: %d satoshis\nFee: %d\nDust Threshold: %d'%(total, fee, dust_threshold(network)))
+    if total - fee < DUST_THRESHOLD:
+        raise NotEnoughFunds(_('Not enough funds on address.') + f'\nTotal: {total} satoshis\nFee: {fee}\nDust Threshold: {DUST_THRESHOLD}')
 
     outputs = [(bitcoin.TYPE_ADDRESS, recipient, total - fee)]
     locktime = network.get_local_height()
@@ -1738,9 +1734,6 @@ class Abstract_Wallet(PrintError, SPVDelegate):
             status_str = format_time(timestamp) if timestamp else _("unknown")
         return status, status_str
 
-    def dust_threshold(self):
-        return dust_threshold(self.network)
-
     def reserve_change_addresses(self, count, temporary=False):
         """ Reserve and return `count` change addresses. In order
         of preference, this will return from:
@@ -1924,7 +1917,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
 
             coin_chooser = coinchooser.CoinChooserPrivacy()
             tx = coin_chooser.make_tx(inputs, outputs, change_addrs,
-                                      fee_estimator, self.dust_threshold(), sign_schnorr=sign_schnorr)
+                                      fee_estimator, DUST_THRESHOLD, sign_schnorr=sign_schnorr)
         else:
             sendable = sum(map(lambda x:x['value'], inputs))
             _type, data, value = outputs[i_max]

--- a/electroncash_gui/qt/address_list.py
+++ b/electroncash_gui/qt/address_list.py
@@ -405,7 +405,7 @@ class AddressList(MyTreeWidget):
             addr_URL = web.BE_URL(self.config, web.ExplorerUrlParts.ADDR, addr)
             if addr_URL:
                 menu.addAction(_("View on block explorer"), lambda: webopen(addr_URL))
-            a = menu.addAction(
+            menu.addAction(
                 "Consolidate coins for address",
                 lambda: self._open_consolidate_coins_dialog(addr),
             )

--- a/electroncash_gui/qt/address_list.py
+++ b/electroncash_gui/qt/address_list.py
@@ -618,5 +618,5 @@ class AddressList(MyTreeWidget):
         self.update()
 
     def _open_consolidate_coins_dialog(self, addr):
-        d = ConsolidateCoinsWizard(addr, self.parent.wallet, parent=self)
+        d = ConsolidateCoinsWizard(addr, self.parent.wallet, self.parent, parent=self)
         d.exec_()

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -18,7 +18,7 @@ from electroncash_gui.qt.util import MessageBoxMixin
 
 
 class TransactionsStatus(Enum):
-    INTERRUPTED = "transaction building interrupted"
+    INTERRUPTED = "cancelled"
     NOT_STARTED = "not started"
     SELECTING = "selecting coins..."
     BUILDING = "building transactions..."
@@ -30,7 +30,10 @@ class ConsolidateWorker(QtCore.QObject):
     finished = QtCore.pyqtSignal()
     status_changed = QtCore.pyqtSignal(TransactionsStatus)
     transactions_ready = QtCore.pyqtSignal(list)
+    """Emits the list of :class:`Transaction` after the last transaction is
+     generated."""
     progress = QtCore.pyqtSignal(int)
+    """Emits the number of generated transactions after each new transaction."""
 
     def __init__(
         self,
@@ -75,11 +78,11 @@ class ConsolidateWorker(QtCore.QObject):
         transactions = []
         for i, tx in enumerate(self.consolidator.iter_transactions()):
             if self.was_interruption_requested():
-                self.status_changed.emit(TransactionsStatus.FINISHED)
+                self.status_changed.emit(TransactionsStatus.INTERRUPTED)
                 self.finished.emit()
                 return
             transactions.append(tx)
-            self.progress.emit(i)
+            self.progress.emit(i + 1)
 
         if transactions:
             self.status_changed.emit(TransactionsStatus.FINISHED)

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -1,18 +1,25 @@
-from typing import Optional
+import json
+from pathlib import Path
+from typing import Optional, Sequence
 
 from PyQt5 import QtWidgets
 
 from electroncash.address import Address, AddressError
-from electroncash.consolidate import MAX_STANDARD_TX_SIZE, MAX_TX_SIZE
-from electroncash.constants import PROJECT_NAME
-from electroncash.wallet import Wallet
+from electroncash.consolidate import (
+    MAX_STANDARD_TX_SIZE,
+    MAX_TX_SIZE,
+    AddressConsolidator,
+)
+from electroncash.constants import PROJECT_NAME, XEC
+from electroncash.transaction import Transaction
+from electroncash.wallet import Abstract_Wallet
 
 
 class ConsolidateCoinsWizard(QtWidgets.QWizard):
     def __init__(
         self,
         address: Address,
-        wallet: Wallet,
+        wallet: Abstract_Wallet,
         parent: Optional[QtWidgets.QWidget] = None,
     ):
         super().__init__(parent)
@@ -20,13 +27,62 @@ class ConsolidateCoinsWizard(QtWidgets.QWizard):
             f"Consolidate coins for address {address.to_full_ui_string()}"
         )
 
-        self.address = address
+        self.address: Address = address
+        self.wallet: Abstract_Wallet = wallet
+        self.transactions: Sequence[Transaction] = []
 
-        self.coin_selection_page = CoinSelectionPage()
-        self.addPage(self.coin_selection_page)
+        self.coins_page = CoinSelectionPage()
+        self.addPage(self.coins_page)
 
-        self.pay_to_page = OutputsPage()
-        self.addPage(self.pay_to_page)
+        self.output_page = OutputsPage(address)
+        self.addPage(self.output_page)
+
+        self.tx_page = TransactionsPage()
+        self.addPage(self.tx_page)
+        self.tx_page.save_button.clicked.connect(self.on_save_clicked)
+        self.tx_page.sign_button.clicked.connect(self.on_sign_clicked)
+        self.tx_page.broadcast_button.clicked.connect(self.on_broadcast_clicked)
+
+        self.currentIdChanged.connect(self.on_page_changed)
+
+    def on_page_changed(self, page_id: int):
+        if self.currentPage() is self.tx_page:
+            consolidator = AddressConsolidator(
+                self.address,
+                self.wallet,
+                self.coins_page.include_coinbase_cb.isChecked(),
+                self.coins_page.include_non_coinbase_cb.isChecked(),
+                self.coins_page.include_frozen_cb.isChecked(),
+                self.coins_page.include_slp_cb.isChecked(),
+                self.coins_page.get_minimum_value(),
+                self.coins_page.get_maximum_value(),
+            )
+            self.transactions = consolidator.get_unsigned_transactions(
+                self.output_page.get_output_address(),
+                self.output_page.tx_size_sb.value(),
+            )
+
+    def on_save_clicked(self):
+        dir = QtWidgets.QFileDialog.getExistingDirectory(
+            self, "Select output directory for transaction files", str(Path.home())
+        )
+        if not dir:
+            return
+        for i, tx in enumerate(self.transactions):
+            name = (
+                f"signed_{i:03d}.txn" if tx.is_complete() else f"unsigned_{i:03d}.txn"
+            )
+            path = Path(dir) / name
+
+            tx_dict = tx.as_dict()
+            with open(path, "w+", encoding="utf-8") as f:
+                f.write(json.dumps(tx_dict, indent=4) + "\n")
+
+    def on_sign_clicked(self):
+        pass
+
+    def on_broadcast_clicked(self):
+        pass
 
 
 class CoinSelectionPage(QtWidgets.QWizardPage):
@@ -66,7 +122,7 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
         self.minimum_value_sb.setEnabled(False)
         self.minimum_value_sb.setSingleStep(0.01)
         self.minimum_value_sb.setValue(0)
-        self.minimum_value_sb.setToolTip("XEC")
+        self.minimum_value_sb.setToolTip(f"{XEC}")
         self.filter_by_min_value_cb.toggled.connect(self.minimum_value_sb.setEnabled)
         min_value_sublayout.addWidget(self.minimum_value_sb)
 
@@ -83,7 +139,7 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
         self.maximum_value_sb.setSingleStep(0.01)
         self.maximum_value_sb.setMaximum(21_000_000_000_000)
         self.maximum_value_sb.setValue(21_000_000_000_000)
-        self.maximum_value_sb.setToolTip("XEC")
+        self.maximum_value_sb.setToolTip(f"{XEC}")
         self.filter_by_max_value_cb.toggled.connect(self.maximum_value_sb.setEnabled)
         max_value_sublayout.addWidget(self.maximum_value_sb)
 
@@ -99,14 +155,31 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
             if button == QtWidgets.QMessageBox.Cancel:
                 self.include_slp_cb.setChecked(False)
 
+    def get_minimum_value(self) -> Optional[int]:
+        """Return minimum value in satoshis, or None"""
+        return (
+            None
+            if not self.filter_by_min_value_cb.isChecked()
+            else int(100 * self.minimum_value_sb.value())
+        )
+
+    def get_maximum_value(self) -> Optional[int]:
+        """Return maximum value in satoshis, or None"""
+        return (
+            None
+            if not self.filter_by_max_value_cb.isChecked()
+            else int(100 * self.maximum_value_sb.value())
+        )
+
 
 class OutputsPage(QtWidgets.QWizardPage):
-    def __init__(self, parent=None):
+    def __init__(self, input_address: Address, parent=None):
         super().__init__(parent)
 
-        self._output_address: Optional[Address] = None
+        self.inputs_address: Address = input_address
+        self.output_address: Optional[Address] = None
 
-        self.setTitle("Pay to")
+        self.setTitle("Outputs")
 
         layout = QtWidgets.QVBoxLayout()
         self.setLayout(layout)
@@ -129,9 +202,9 @@ class OutputsPage(QtWidgets.QWizardPage):
         layout.addLayout(tx_size_layout)
         tx_size_layout.addWidget(QtWidgets.QLabel("Maximum transaction size"))
         self.tx_size_sb = QtWidgets.QSpinBox()
-        self.tx_size_sb.setValue(MAX_STANDARD_TX_SIZE)
         self.tx_size_sb.setMinimum(192)
         self.tx_size_sb.setMaximum(MAX_TX_SIZE)
+        self.tx_size_sb.setValue(MAX_STANDARD_TX_SIZE)
         tx_size_layout.addWidget(self.tx_size_sb)
 
         self.single_address_rb.toggled.connect(self.output_address_edit.setEnabled)
@@ -139,15 +212,72 @@ class OutputsPage(QtWidgets.QWizardPage):
         self.output_address_edit.textChanged.connect(self.validate_address)
 
     def validate_address(self, address_text: str):
-        previous_address = self._output_address
+        previous_address = self.output_address
         try:
-            self._output_address = Address.from_string(address_text)
+            self.output_address = Address.from_string(address_text)
         except AddressError:
-            self._output_address = None
-        if self._output_address != previous_address:
+            self.output_address = None
+        if self.output_address != previous_address:
             self.completeChanged.emit()
 
     def isComplete(self):
+        return not self.single_address_rb.isChecked() or self.output_address is not None
+
+    def get_output_address(self) -> Address:
         return (
-            not self.single_address_rb.isChecked() or self._output_address is not None
+            self.inputs_address
+            if self.same_address_rb.isChecked()
+            else self.output_address
         )
+
+
+class TransactionsPage(QtWidgets.QWizardPage):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setTitle("Transactions")
+
+        layout = QtWidgets.QVBoxLayout()
+        self.setLayout(layout)
+
+        self.num_tx_label = QtWidgets.QLabel("Number of transactions:")
+        layout.addWidget(self.num_tx_label)
+
+        self.num_in_label = QtWidgets.QLabel("Average number of inputs per tx:")
+        layout.addWidget(self.num_in_label)
+
+        self.value_label = QtWidgets.QLabel("Input value: 0; Output value: 0; Fees: 0")
+        layout.addWidget(self.num_tx_label)
+
+        buttons_layout = QtWidgets.QHBoxLayout()
+        layout.addLayout(buttons_layout)
+
+        self.save_button = QtWidgets.QPushButton("Save")
+        buttons_layout.addWidget(self.save_button)
+
+        self.sign_button = QtWidgets.QPushButton("Sign")
+        buttons_layout.addWidget(self.sign_button)
+
+        self.broadcast_button = QtWidgets.QPushButton("Broadcast")
+        self.broadcast_button.setEnabled(False)
+        buttons_layout.addWidget(self.broadcast_button)
+
+    def set_transactions(self, transactions: Sequence[Transaction]):
+        self.reset_buttons()
+
+        num_tx = len(self.transactions)
+        self.num_tx_label.setText(f"Number of transactions: {num_tx}")
+
+        avg_num_in = sum([len(tx.inputs()) for tx in transactions]) / num_tx
+        self.num_in_label.setText(f"Average number of inputs per tx: {avg_num_in}")
+
+        in_value = sum([tx.input_value() for tx in transactions]) / 100
+        out_value = sum([tx.output_value() for tx in transactions]) / 100
+        fees = sum([tx.get_fee() for tx in transactions]) / 100
+        self.value_label.setText(
+            f"Input value: {in_value} {XEC}; Output value: {out_value} {XEC}; Fees: {fees} {XEC}"
+        )
+
+    def reset_buttons(self):
+        # FIXME: check the wallet's ability to sign and disable Sign if needed
+        self.sign_button.setEnabled(True)
+        self.broadcast_button.setEnabled(False)

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -13,9 +13,10 @@ from electroncash.consolidate import (
 from electroncash.constants import PROJECT_NAME, XEC
 from electroncash.transaction import Transaction
 from electroncash.wallet import Abstract_Wallet
+from electroncash_gui.qt.util import MessageBoxMixin
 
 
-class ConsolidateCoinsWizard(QtWidgets.QWizard):
+class ConsolidateCoinsWizard(QtWidgets.QWizard, MessageBoxMixin):
     def __init__(
         self,
         address: Address,

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -186,14 +186,16 @@ class ConsolidateCoinsWizard(QtWidgets.QWizard, MessageBoxMixin):
         )
 
     def on_sign_clicked(self):
-        def sign_done(success):
-            pass
-
-        def cleanup():
-            pass
+        password = None
+        if self.wallet.has_password():
+            password = self.main_window.password_dialog(
+                "Enter your password to proceed"
+            )
+            if not password:
+                return
 
         for tx in self.transactions:
-            self.main_window.sign_tx(tx, sign_done, on_pw_cancel=cleanup)
+            self.wallet.sign_transaction(tx, password, use_cache=True)
 
         QtWidgets.QMessageBox.information(
             self,

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -324,6 +324,7 @@ class OutputsPage(QtWidgets.QWizardPage):
         layout = QtWidgets.QVBoxLayout()
         self.setLayout(layout)
 
+        layout.addWidget(QtWidgets.QLabel("<h2>Destination address</h2>"))
         self.same_address_rb = QtWidgets.QRadioButton("Same address as inputs")
         self.same_address_rb.setChecked(True)
         layout.addWidget(self.same_address_rb)
@@ -338,6 +339,9 @@ class OutputsPage(QtWidgets.QWizardPage):
         self.output_address_edit.setEnabled(False)
         single_address_sublayout.addWidget(self.output_address_edit)
 
+        layout.addSpacing(20)
+
+        layout.addWidget(QtWidgets.QLabel("<h2>Transaction parameters</h2>"))
         tx_size_layout = QtWidgets.QHBoxLayout()
         layout.addLayout(tx_size_layout)
         tx_size_layout.addWidget(QtWidgets.QLabel("Maximum transaction size (bytes)"))

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -55,9 +55,9 @@ class ConsolidateWorker(QtCore.QObject):
             include_slp,
             minimum_value,
             maximum_value,
+            output_address,
+            max_tx_size,
         )
-        self.output_address = output_address
-        self.max_tx_size = max_tx_size
 
     def build_transactions(self):
         self.status_changed.emit(TransactionsStatus.BUILDING)

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -1,0 +1,129 @@
+from typing import Optional
+
+from PyQt5 import QtWidgets
+
+from electroncash.address import Address, AddressError
+
+# from electroncash.consolidate import AddressConsolidator
+from electroncash.wallet import Wallet
+
+
+class ConsolidateCoinsWizard(QtWidgets.QWizard):
+    def __init__(
+        self,
+        address: Address,
+        wallet: Wallet,
+        parent: Optional[QtWidgets.QWidget] = None,
+    ):
+        super().__init__(parent)
+        self.setWindowTitle(
+            f"Consolidate coins for address {address.to_full_ui_string()}"
+        )
+
+        self.address = address
+
+        self.coin_selection_page = CoinSelectionPage()
+        self.addPage(self.coin_selection_page)
+
+        self.pay_to_page = PayToPage()
+        self.addPage(self.pay_to_page)
+
+
+class CoinSelectionPage(QtWidgets.QWizardPage):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setTitle("Filter coins")
+
+        layout = QtWidgets.QVBoxLayout()
+        self.setLayout(layout)
+
+        self.include_coinbase_cb = QtWidgets.QCheckBox("Include coinbase coins")
+        self.include_coinbase_cb.setChecked(True)
+        layout.addWidget(self.include_coinbase_cb)
+
+        self.include_non_coinbase_cb = QtWidgets.QCheckBox("Include non-coinbase coins")
+        self.include_non_coinbase_cb.setChecked(True)
+        layout.addWidget(self.include_non_coinbase_cb)
+
+        self.include_frozen_cb = QtWidgets.QCheckBox("Include frozen coins")
+        self.include_frozen_cb.setChecked(False)
+        layout.addWidget(self.include_frozen_cb)
+
+        self.include_slp_cb = QtWidgets.QCheckBox("Include SLP UTXOs")
+        self.include_slp_cb.setChecked(False)
+        layout.addWidget(self.include_slp_cb)
+
+        min_value_sublayout = QtWidgets.QHBoxLayout()
+        layout.addLayout(min_value_sublayout)
+        self.filter_by_min_value_cb = QtWidgets.QCheckBox(
+            "Define a minimum value for coins to select"
+        )
+        self.filter_by_min_value_cb.setChecked(False)
+        min_value_sublayout.addWidget(self.filter_by_min_value_cb)
+
+        self.minimum_value_sb = QtWidgets.QDoubleSpinBox()
+        self.minimum_value_sb.setEnabled(False)
+        self.minimum_value_sb.setSingleStep(0.01)
+        self.minimum_value_sb.setValue(0)
+        self.filter_by_min_value_cb.toggled.connect(self.minimum_value_sb.setEnabled)
+        min_value_sublayout.addWidget(self.minimum_value_sb)
+
+        max_value_sublayout = QtWidgets.QHBoxLayout()
+        layout.addLayout(max_value_sublayout)
+        self.filter_by_max_value_cb = QtWidgets.QCheckBox(
+            "Define a maximum value for coins to select"
+        )
+        self.filter_by_max_value_cb.setChecked(False)
+        max_value_sublayout.addWidget(self.filter_by_max_value_cb)
+
+        self.maximum_value_sb = QtWidgets.QDoubleSpinBox()
+        self.maximum_value_sb.setEnabled(False)
+        self.maximum_value_sb.setSingleStep(0.01)
+        self.maximum_value_sb.setMaximum(21_000_000_000_000)
+        self.maximum_value_sb.setValue(21_000_000_000_000)
+        self.filter_by_max_value_cb.toggled.connect(self.maximum_value_sb.setEnabled)
+        max_value_sublayout.addWidget(self.maximum_value_sb)
+
+
+class PayToPage(QtWidgets.QWizardPage):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self._output_address: Optional[Address] = None
+
+        self.setTitle("Pay to")
+
+        layout = QtWidgets.QVBoxLayout()
+        self.setLayout(layout)
+
+        self.same_address_rb = QtWidgets.QRadioButton("Same address as inputs")
+        self.same_address_rb.setChecked(True)
+        layout.addWidget(self.same_address_rb)
+
+        single_address_sublayout = QtWidgets.QHBoxLayout()
+        layout.addLayout(single_address_sublayout)
+        self.single_address_rb = QtWidgets.QRadioButton("Single address")
+        single_address_sublayout.addWidget(self.single_address_rb)
+
+        self.output_address_edit = QtWidgets.QLineEdit()
+        self.output_address_edit.setPlaceholderText("enter a valid destination address")
+        self.output_address_edit.setEnabled(False)
+        single_address_sublayout.addWidget(self.output_address_edit)
+
+        self.single_address_rb.toggled.connect(self.output_address_edit.setEnabled)
+        self.single_address_rb.toggled.connect(self.completeChanged.emit)
+        self.output_address_edit.textChanged.connect(self.validate_address)
+
+    def validate_address(self, address_text: str):
+        previous_address = self._output_address
+        try:
+            self._output_address = Address.from_string(address_text)
+        except AddressError:
+            self._output_address = None
+        if self._output_address != previous_address:
+            self.completeChanged.emit()
+
+    def isComplete(self):
+        return (
+            not self.single_address_rb.isChecked() or self._output_address is not None
+        )

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -2232,10 +2232,6 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         amount = tx.output_value() if self.max_button.isChecked() else sum(map(lambda x:x[2], outputs))
         fee = tx.get_fee()
 
-        #if fee < self.wallet.relayfee() * tx.estimated_size() / 1000 and tx.requires_fee(self.wallet):
-            #self.show_error(_("This transaction requires a higher fee, or it will not be propagated by the network"))
-            #return
-
         if preview:
             # NB: this ultimately takes a deepcopy of the tx in question
             # (TxDialog always takes a deep copy).

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -2251,11 +2251,6 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             _("Mining fee") + ": " + self.format_amount_and_units(fee),
         ]
 
-        x_fee = run_hook('get_tx_extra_fee', self.wallet, tx)
-        if x_fee:
-            x_fee_address, x_fee_amount = x_fee
-            msg.append( _("Additional fees") + ": " + self.format_amount_and_units(x_fee_amount) )
-
         if (fee < (tx.estimated_size())):
             msg.append(_('Warning') + ': ' + _("You're using a fee of less than 1.0 sats/B. It may take a very long time to confirm."))
             tx.ephemeral['warned_low_fee_already'] = True


### PR DESCRIPTION
This PR adds a tools to consolidate addresses with many coins into a smaller number of coins, by combining the inputs in large transactions with many inputs but only a single output.

This can help make a wallet more manageable, when the number of UTXOs for a single address exceeds the number of UTXOs that can be fitted into a single transaction. Without this, the `CoinChooser` always tries to spend all UTXOs from the same address at once, and as a result creates transaction that cannot be relayed.

To use it, go to the address tab, right-click on an address in the first column of the table, select the "Consolidate coins for address" action in the dropdown menu.

