### PR TITLE
allow encrypting watch-only wallets

### DIFF
--- a/electroncash/bitcoin.py
+++ b/electroncash/bitcoin.py
@@ -572,8 +572,8 @@ def verify_message(address: Union[str, "Address"], sig: bytes, message:bytes, *,
         return False
     return True
 
-def encrypt_message(message, pubkey):
-    return EC_KEY.encrypt_message(message, bfh(pubkey))
+def encrypt_message(message, pubkey, magic=b'BIE1'):
+    return EC_KEY.encrypt_message(message, bfh(pubkey), magic)
 
 
 def chunks(l, n):
@@ -721,7 +721,7 @@ class EC_KEY(object):
     # ECIES encryption/decryption methods; AES-128-CBC with PKCS7 is used as the cipher; hmac-sha256 is used as the mac
 
     @classmethod
-    def encrypt_message(self, message, pubkey):
+    def encrypt_message(self, message, pubkey, magic=b'BIE1'):
         assert_bytes(message)
 
         pk = ser_to_point(pubkey)
@@ -735,20 +735,20 @@ class EC_KEY(object):
         iv, key_e, key_m = key[0:16], key[16:32], key[32:]
         ciphertext = aes_encrypt_with_iv(key_e, iv, message)
         ephemeral_pubkey = bfh(ephemeral.get_public_key(compressed=True))
-        encrypted = b'BIE1' + ephemeral_pubkey + ciphertext
+        encrypted = magic + ephemeral_pubkey + ciphertext
         mac = hmac.new(key_m, encrypted, hashlib.sha256).digest()
 
         return base64.b64encode(encrypted + mac)
 
-    def decrypt_message(self, encrypted):
+    def decrypt_message(self, encrypted, magic=b'BIE1'):
         encrypted = base64.b64decode(encrypted)
         if len(encrypted) < 85:
             raise Exception('invalid ciphertext: length')
-        magic = encrypted[:4]
+        magic_found = encrypted[:4]
         ephemeral_pubkey = encrypted[4:37]
         ciphertext = encrypted[37:-32]
         mac = encrypted[-32:]
-        if magic != b'BIE1':
+        if magic_found != magic:
             raise Exception('invalid ciphertext: invalid magic bytes')
         try:
             ephemeral_pubkey = ser_to_point(ephemeral_pubkey)

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -104,7 +104,7 @@ def command(s):
             if c.requires_wallet and wallet is None:
                 raise BaseException(f"Wallet not loaded. Use '{SCRIPT_NAME}"
                                     f" daemon load_wallet'")
-            if c.requires_password and password is None and wallet.storage.get('use_encryption') \
+            if c.requires_password and password is None and wallet.has_password() \
                and not kwargs.get("unsigned"):
                 return {'error': 'Password required' }
             return func(*args, **kwargs)

--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -58,6 +58,10 @@ class KeyStore(PrintError):
     def can_import(self):
         return False
 
+    def may_have_password(self):
+        """Returns whether the keystore can be encrypted with a password."""
+        raise NotImplementedError()
+
     def get_tx_derivations(self, tx):
         keypairs = {}
         for txin in tx.inputs():
@@ -135,9 +139,6 @@ class Imported_KeyStore(Software_KeyStore):
 
     def is_deterministic(self):
         return False
-
-    def can_change_password(self):
-        return True
 
     def get_master_public_key(self):
         return None
@@ -246,9 +247,6 @@ class Deterministic_KeyStore(Software_KeyStore):
 
     def is_watching_only(self):
         return not self.has_seed()
-
-    def can_change_password(self):
-        return not self.is_watching_only()
 
     def add_seed(self, seed, *, seed_type="electrum"):
         if self.seed:
@@ -626,13 +624,19 @@ class Hardware_KeyStore(KeyStore, Xpub):
         assert not self.has_seed()
         return False
 
-    def can_change_password(self):
-        return False
-
     def needs_prevtx(self):
         """Returns true if this hardware wallet needs to know the input
         transactions to sign a transactions"""
         return True
+
+    def get_password_for_storage_encryption(self):
+        from .storage import get_derivation_used_for_hw_device_encryption
+
+        client = self.plugin.get_client(self)
+        derivation = get_derivation_used_for_hw_device_encryption()
+        xpub = client.get_xpub(derivation, "standard")
+        password = self.get_pubkey_from_xpub(xpub, ())
+        return password
 
 
 # extended pubkeys

--- a/electroncash/storage.py
+++ b/electroncash/storage.py
@@ -35,7 +35,7 @@ import base64
 import zlib
 
 from .address import Address
-from .util import PrintError, profiler, standardize_path
+from .util import InvalidPassword, PrintError, profiler, standardize_path
 from .plugins import run_hook, plugin_loaders
 from .keystore import bip44_derivation_btc
 from . import bitcoin
@@ -61,6 +61,13 @@ def multisig_type(wallet_type):
         match = [int(x) for x in match.group(1, 2)]
     return match
 
+def get_derivation_used_for_hw_device_encryption():
+    return ("m"
+            "/4541509'"      # ascii 'ELE'  as decimal ("BIP43 purpose")
+            "/1112098098'")  # ascii 'BIE2' as decimal
+
+# storage encryption version
+STO_EV_PLAINTEXT, STO_EV_USER_PW, STO_EV_XPUB_PW = range(0, 3)
 
 class WalletStorage(PrintError):
 
@@ -79,11 +86,13 @@ class WalletStorage(PrintError):
             try:
                 with open(self.path, "r", encoding='utf-8') as f:
                     self.raw = f.read()
+                self._encryption_version = self._init_encryption_version()
             except UnicodeDecodeError as e:
                 raise IOError("Error reading file: "+ str(e))
             if not self.is_encrypted():
                 self.load_data(self.raw)
         else:
+            self._encryption_version = STO_EV_PLAINTEXT
             # avoid new wallets getting 'upgraded'
             self.put('seed_version', FINAL_SEED_VERSION)
 
@@ -120,11 +129,47 @@ class WalletStorage(PrintError):
             if self.requires_upgrade():
                 self.upgrade()
 
+    def is_past_initial_decryption(self):
+        """Return if storage is in a usable state for normal operations.
+
+        The value is True exactly
+            if encryption is disabled completely (self.is_encrypted() == False),
+            or if encryption is enabled but the contents have already been decrypted.
+        """
+        return bool(self.data)
+
     def is_encrypted(self):
+        """Return if storage encryption is currently enabled."""
+        return self.get_encryption_version() != STO_EV_PLAINTEXT
+
+    def is_encrypted_with_user_pw(self):
+        return self.get_encryption_version() == STO_EV_USER_PW
+
+    def is_encrypted_with_hw_device(self):
+        return self.get_encryption_version() == STO_EV_XPUB_PW
+
+    def get_encryption_version(self):
+        """Return the version of encryption used for this storage.
+
+        0: plaintext / no encryption
+
+        ECIES, private key derived from a password,
+        1: password is provided by user
+        2: password is derived from an xpub; used with hw wallets
+        """
+        return self._encryption_version
+
+    def _init_encryption_version(self):
         try:
-            return base64.b64decode(self.raw)[0:4] == b'BIE1'
+            magic = base64.b64decode(self.raw)[0:4]
+            if magic == b'BIE1':
+                return STO_EV_USER_PW
+            elif magic == b'BIE2':
+                return STO_EV_XPUB_PW
+            else:
+                return STO_EV_PLAINTEXT
         except:
-            return False
+            return STO_EV_PLAINTEXT
 
     def file_exists(self):
         return self._file_exists
@@ -134,20 +179,50 @@ class WalletStorage(PrintError):
         ec_key = bitcoin.EC_KEY(secret)
         return ec_key
 
+    def _get_encryption_magic(self):
+        v = self._encryption_version
+        if v == STO_EV_USER_PW:
+            return b'BIE1'
+        elif v == STO_EV_XPUB_PW:
+            return b'BIE2'
+        else:
+            raise Exception('no encryption magic for version: %s' % v)
+
     def decrypt(self, password):
         ec_key = self.get_key(password)
-        s = zlib.decompress(ec_key.decrypt_message(self.raw)) if self.raw else None
+        if self.raw:
+            enc_magic = self._get_encryption_magic()
+            s = zlib.decompress(ec_key.decrypt_message(self.raw, enc_magic))
+        else:
+            s = None
         self.pubkey = ec_key.get_public_key()
         s = s.decode('utf8')
         self.load_data(s)
 
-    def set_password(self, password, encrypt):
-        self.put('use_encryption', bool(password))
-        if encrypt and password:
+    def check_password(self, password):
+        """Raises an InvalidPassword exception on invalid password"""
+        if not self.is_encrypted():
+            return
+        if self.pubkey and self.pubkey != self.get_key(password).get_public_key():
+            raise InvalidPassword()
+
+    def set_keystore_encryption(self, enable):
+        self.put('use_encryption', enable)
+
+    def set_password(self, password, enc_version=None):
+        """Set a password to be used for encrypting this storage."""
+        if enc_version is None:
+            enc_version = self._encryption_version
+        if password and enc_version != STO_EV_PLAINTEXT:
             ec_key = self.get_key(password)
             self.pubkey = ec_key.get_public_key()
+            self._encryption_version = enc_version
         else:
             self.pubkey = None
+            self._encryption_version = STO_EV_PLAINTEXT
+        # make sure next storage.write() saves changes
+        with self.lock:
+            self.modified = True
 
     def get(self, key, default=None):
         with self.lock:
@@ -193,7 +268,8 @@ class WalletStorage(PrintError):
         if self.pubkey:
             s = bytes(s, 'utf8')
             c = zlib.compress(s)
-            s = bitcoin.encrypt_message(c, self.pubkey)
+            enc_magic = self._get_encryption_magic()
+            s = bitcoin.encrypt_message(c, self.pubkey, enc_magic)
             s = s.decode('utf8')
 
         temp_path = self.path + TMP_SUFFIX

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -14,7 +14,7 @@ from PyQt5 import QtWidgets
 from electroncash import keystore, Wallet, WalletStorage
 from electroncash.network import Network
 from electroncash.util import UserCancelled, InvalidPassword, finalization_print_error, TimeoutException
-from electroncash.base_wizard import BaseWizard
+from electroncash.base_wizard import BaseWizard, HWD_SETUP_DECRYPT_WALLET
 from electroncash.i18n import _
 from electroncash.constants import PROJECT_NAME
 from electroncash import keystore
@@ -22,7 +22,7 @@ from electroncash.wallet import Standard_Wallet
 
 from .seed_dialog import SeedLayout, KeysLayout
 from .network_dialog import NetworkChoiceLayout
-from .password_dialog import PasswordLayout, PW_NEW
+from .password_dialog import PasswordLayout, PasswordLayoutForHW, PW_NEW
 from .bip38_importer import Bip38Importer
 from .util import (
     Buttons,
@@ -45,6 +45,10 @@ MSG_ENTER_SEED_OR_MPK = _("Please enter a seed phrase or a master key (xpub or x
 MSG_COSIGNER = _("Please enter the master public key of cosigner #{}:")
 MSG_ENTER_PASSWORD = _("Choose a password to encrypt your wallet keys.") + '\n'\
                      + _("Leave this field empty if you want to disable encryption.")
+MSG_HW_STORAGE_ENCRYPTION = _("Set wallet file encryption.") + '\n'\
+                          + _("Your wallet file does not contain secrets, mostly just metadata. ") \
+                          + _("It also contains your master public key that allows watching your addresses.") + '\n\n'\
+                          + _("Note: If you enable this setting, you will need your hardware device to open your wallet.")
 MSG_RESTORE_PASSPHRASE = \
     _("Please enter your seed derivation passphrase. "
       "Note: this is NOT your encryption password. "
@@ -210,12 +214,18 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
                     msg =_("This file does not exist.") + '\n' \
                           + _("Press 'Next' to create this wallet, or choose another file.")
                     pw = False
-                elif self.storage.file_exists() and self.storage.is_encrypted():
-                    msg = _("This file is encrypted.") + '\n' + _('Enter your password or choose another file.')
-                    pw = True
                 else:
-                    msg = _("Press 'Next' to open this wallet.")
-                    pw = False
+                    if self.storage.is_encrypted_with_user_pw():
+                        msg = _("This file is encrypted with a password.") + '\n' \
+                              + _('Enter your password or choose another file.')
+                        pw = True
+                    elif self.storage.is_encrypted_with_hw_device():
+                        msg = _("This file is encrypted using a hardware device.") + '\n' \
+                              + _("Press 'Next' to choose device to decrypt.")
+                        pw = False
+                    else:
+                        msg = _("Press 'Next' to open this wallet.")
+                        pw = False
             else:
                 msg = _('Cannot read file')
                 pw = False
@@ -242,17 +252,40 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
             if not self.storage.file_exists():
                 break
             if self.storage.file_exists() and self.storage.is_encrypted():
-                password = self.pw_e.text()
-                try:
-                    self.storage.decrypt(password)
-                    break
-                except InvalidPassword as e:
-                    QtWidgets.QMessageBox.information(None, _('Error'), str(e))
-                    continue
-                except BaseException as e:
-                    traceback.print_exc(file=sys.stdout)
-                    QtWidgets.QMessageBox.information(None, _('Error'), str(e))
-                    return
+                if self.storage.is_encrypted_with_user_pw():
+                    password = self.pw_e.text()
+                    try:
+                        self.storage.decrypt(password)
+                        break
+                    except InvalidPassword as e:
+                        QtWidgets.QMessageBox.information(None, _('Error'), str(e))
+                        continue
+                    except BaseException as e:
+                        traceback.print_exc(file=sys.stdout)
+                        QtWidgets.QMessageBox.information(None, _('Error'), str(e))
+                        return
+                elif self.storage.is_encrypted_with_hw_device():
+                    try:
+                        self.run('choose_hw_device', HWD_SETUP_DECRYPT_WALLET)
+                    except InvalidPassword as e:
+                        # FIXME if we get here because of mistyped passphrase
+                        # then that passphrase gets "cached"
+                        QtWidgets.QMessageBox.information(
+                            None, _('Error'),
+                            _('Failed to decrypt using this hardware device.') + '\n' +
+                            _('If you use a passphrase, make sure it is correct.'))
+                        self.stack = []
+                        return self.run_and_get_wallet()
+                    except BaseException as e:
+                        traceback.print_exc(file=sys.stdout)
+                        QtWidgets.QMessageBox.information(None, _('Error'), str(e))
+                        return
+                    if self.storage.is_past_initial_decryption():
+                        break
+                    else:
+                        return
+                else:
+                    raise Exception('Unexpected encryption version')
 
         path = self.storage.path
         if self.storage.requires_split():
@@ -413,18 +446,26 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
         self.exec_layout(slayout)
         return slayout.is_ext
 
-    def pw_layout(self, msg, kind):
-        playout = PasswordLayout(None, msg, kind, self.next_button)
+    def pw_layout(self, msg, kind, force_disable_encrypt_cb):
+        playout = PasswordLayout(None, msg, kind, self.next_button,
+                                 force_disable_encrypt_cb=force_disable_encrypt_cb)
         playout.encrypt_cb.setChecked(True)
         self.exec_layout(playout.layout())
         return playout.new_password(), playout.encrypt_cb.isChecked()
 
     @wizard_dialog
-    def request_password(self, run_next):
+    def request_password(self, run_next, force_disable_encrypt_cb=False):
         """Request the user enter a new password and confirm it.  Return
         the password or None for no password.  Note that this dialog screen
         cannot go back, and instead the user can only cancel."""
-        return self.pw_layout(MSG_ENTER_PASSWORD, PW_NEW)
+        return self.pw_layout(MSG_ENTER_PASSWORD, PW_NEW, force_disable_encrypt_cb)
+
+    @wizard_dialog
+    def request_storage_encryption(self, run_next):
+        playout = PasswordLayoutForHW(None, MSG_HW_STORAGE_ENCRYPTION, PW_NEW, self.next_button)
+        playout.encrypt_cb.setChecked(True)
+        self.exec_layout(playout.layout())
+        return playout.encrypt_cb.isChecked()
 
     @staticmethod
     def _add_extra_button_to_layout(extra_button, layout):

--- a/electroncash_gui/qt/password_dialog.py
+++ b/electroncash_gui/qt/password_dialog.py
@@ -28,7 +28,7 @@ import re
 import math
 
 from PyQt5.QtCore import Qt
-from PyQt5.QtGui import QIcon
+from PyQt5.QtGui import QIcon, QPixmap
 from PyQt5 import QtWidgets
 
 from electroncash.i18n import _
@@ -67,7 +67,16 @@ class PasswordLayout:
 
     titles = [_("Enter Password"), _("Change Password"), _("Enter Passphrase")]
 
-    def __init__(self, wallet, msg, kind, OK_button, *, permit_empty=True):
+    def __init__(
+        self,
+        wallet,
+        msg,
+        kind,
+        OK_button,
+        *,
+        permit_empty: bool = True,
+        force_disable_encrypt_cb: bool = False,
+    ):
         self.wallet = wallet
 
         self.permit_empty = bool(permit_empty)
@@ -147,7 +156,8 @@ class PasswordLayout:
             ok = bool(self.new_pw.text() == self.conf_pw.text()
                       and (self.new_pw.text() or self.permit_empty))
             OK_button.setEnabled(ok)
-            self.encrypt_cb.setEnabled(bool(ok and self.new_pw.text()))
+            self.encrypt_cb.setEnabled(ok and bool(self.new_pw.text())
+                                       and not force_disable_encrypt_cb)
         self.new_pw.textChanged.connect(enable_OK)
         self.conf_pw.textChanged.connect(enable_OK)
 
@@ -189,11 +199,84 @@ class PasswordLayout:
         return pw
 
 
-class ChangePasswordDialog(WindowModalDialog):
+class PasswordLayoutForHW(object):
+
+    def __init__(self, wallet, msg, kind, OK_button):
+        self.wallet = wallet
+
+        self.kind = kind
+        self.OK_button = OK_button
+
+        vbox = QtWidgets.QVBoxLayout()
+        label = QtWidgets.QLabel(msg + "\n")
+        label.setWordWrap(True)
+
+        grid = QtWidgets.QGridLayout()
+        grid.setSpacing(8)
+        grid.setColumnMinimumWidth(0, 150)
+        grid.setColumnMinimumWidth(1, 100)
+        grid.setColumnStretch(1,1)
+
+        logo_grid = QtWidgets.QGridLayout()
+        logo_grid.setSpacing(8)
+        logo_grid.setColumnMinimumWidth(0, 70)
+        logo_grid.setColumnStretch(1,1)
+
+        logo = QtWidgets.QLabel()
+        logo.setAlignment(Qt.AlignCenter)
+
+        logo_grid.addWidget(logo,  0, 0)
+        logo_grid.addWidget(label, 0, 1, 1, 2)
+        vbox.addLayout(logo_grid)
+
+        if wallet and wallet.has_storage_encryption():
+            lockfile = ":icons/lock.png"
+        else:
+            lockfile = ":icons/unlock.png"
+        logo.setPixmap(QPixmap(lockfile).scaledToWidth(36))
+
+        vbox.addLayout(grid)
+
+        self.encrypt_cb = QtWidgets.QCheckBox(_('Encrypt wallet file'))
+        grid.addWidget(self.encrypt_cb, 1, 0, 1, 2)
+
+        self.vbox = vbox
+
+    def title(self):
+        return _("Toggle Encryption")
+
+    def layout(self):
+        return self.vbox
+
+
+class ChangePasswordDialogBase(WindowModalDialog):
 
     def __init__(self, parent, wallet):
         WindowModalDialog.__init__(self, parent)
-        is_encrypted = wallet.storage.is_encrypted()
+        is_encrypted = wallet.has_storage_encryption()
+        OK_button = OkButton(self)
+
+        self.create_password_layout(wallet, is_encrypted, OK_button)
+
+        self.setWindowTitle(self.playout.title())
+        vbox = QtWidgets.QVBoxLayout(self)
+        vbox.addLayout(self.playout.layout())
+        vbox.addStretch(1)
+        vbox.addLayout(Buttons(CancelButton(self), OK_button))
+        self.playout.encrypt_cb.setChecked(is_encrypted)
+
+    def create_password_layout(self, wallet, is_encrypted, OK_button):
+        raise NotImplementedError()
+
+
+class ChangePasswordDialogForSW(ChangePasswordDialogBase):
+
+    def __init__(self, parent, wallet):
+        ChangePasswordDialogBase.__init__(self, parent, wallet)
+        if not wallet.has_password():
+            self.playout.encrypt_cb.setChecked(True)
+
+    def create_password_layout(self, wallet, is_encrypted, OK_button):
         if not wallet.has_password():
             msg = _('Your wallet is not protected.')
             msg += ' ' + _('Use this dialog to add a password to your wallet.')
@@ -203,19 +286,34 @@ class ChangePasswordDialog(WindowModalDialog):
             else:
                 msg = _('Your wallet is password protected and encrypted.')
             msg += ' ' + _('Use this dialog to change your password.')
-        OK_button = OkButton(self)
-        self.playout = PasswordLayout(wallet, msg, PW_CHANGE, OK_button)
-        self.setWindowTitle(self.playout.title())
-        vbox = QtWidgets.QVBoxLayout(self)
-        vbox.addLayout(self.playout.layout())
-        vbox.addStretch(1)
-        vbox.addLayout(Buttons(CancelButton(self), OK_button))
-        self.playout.encrypt_cb.setChecked(is_encrypted or not wallet.has_password())
+        self.playout = PasswordLayout(
+            wallet, msg, PW_CHANGE, OK_button,
+            force_disable_encrypt_cb=not wallet.can_have_keystore_encryption())
 
     def run(self):
         if not self.exec_():
             return False, None, None, None
         return True, self.playout.old_password(), self.playout.new_password(), self.playout.encrypt_cb.isChecked()
+
+
+class ChangePasswordDialogForHW(ChangePasswordDialogBase):
+
+    def __init__(self, parent, wallet):
+        ChangePasswordDialogBase.__init__(self, parent, wallet)
+
+    def create_password_layout(self, wallet, is_encrypted, OK_button):
+        if not is_encrypted:
+            msg = _('Your wallet file is NOT encrypted.')
+        else:
+            msg = _('Your wallet file is encrypted.')
+        msg += '\n' + _('Note: If you enable this setting, you will need your hardware device to open your wallet.')
+        msg += '\n' + _('Use this dialog to toggle encryption.')
+        self.playout = PasswordLayoutForHW(wallet, msg, PW_CHANGE, OK_button)
+
+    def run(self):
+        if not self.exec_():
+            return False, None
+        return True, self.playout.encrypt_cb.isChecked()
 
 
 class PasswordDialog(WindowModalDialog):

--- a/electroncash_plugins/cosigner_pool/qt.py
+++ b/electroncash_plugins/cosigner_pool/qt.py
@@ -338,7 +338,7 @@ class Plugin(BasePlugin):
                                   'which makes them not compatible with the current design of cosigner pool.'))
             return
         password = None
-        if wallet.has_password():
+        if wallet.has_keystore_encryption():
             password = window.password_dialog(_('An encrypted transaction was retrieved from cosigning pool.') + '\n' +
                                               _('Please enter your password to decrypt it.'))
             if not password:

--- a/electroncash_plugins/digitalbitbox/digitalbitbox.py
+++ b/electroncash_plugins/digitalbitbox/digitalbitbox.py
@@ -11,7 +11,7 @@ try:
     from electroncash.keystore import Hardware_KeyStore
     from ..hw_wallet import HW_PluginBase
     from electroncash.util import print_error, to_string, UserCancelled
-
+    from electroncash.base_wizard import HWD_SETUP_NEW_WALLET
     import time
     import hid
     import json
@@ -696,7 +696,7 @@ class DigitalBitboxPlugin(HW_PluginBase):
             return None
 
 
-    def setup_device(self, device_info, wizard):
+    def setup_device(self, device_info, wizard, purpose):
         devmgr = self.device_manager()
         device_id = device_info.device.id_
         client = devmgr.client_by_id(device_id)
@@ -704,7 +704,8 @@ class DigitalBitboxPlugin(HW_PluginBase):
             raise Exception(_('Failed to create a client for this device.') + '\n' +
                             _('Make sure it is in the correct state.'))
         client.handler = self.create_handler(wizard)
-        client.setupRunning = True
+        if purpose == HWD_SETUP_NEW_WALLET:
+            client.setupRunning = True
         client.get_xpub("m/44'/0'", 'standard')
 
 

--- a/electroncash_plugins/hw_wallet/plugin.py
+++ b/electroncash_plugins/hw_wallet/plugin.py
@@ -57,6 +57,13 @@ class HW_PluginBase(BasePlugin):
                 self.device_manager().unpair_xpub(keystore.xpub)
                 self._cleanup_keystore_extra(keystore)
 
+    def setup_device(self, device_info, wizard, purpose):
+        """Called when creating a new wallet or when using the device to decrypt
+        an existing wallet. Select the device to use.  If the device is
+        uninitialized, go through the initialization process.
+        """
+        raise NotImplementedError()
+
     def _cleanup_keystore_extra(self, keystore):
         # awkward cleanup code for the keystore 'thread' object (see qt.py)
         finalization_print_error(keystore)  # track object lifecycle

--- a/electroncash_plugins/hw_wallet/qt.py
+++ b/electroncash_plugins/hw_wallet/qt.py
@@ -82,9 +82,10 @@ class QtHandlerBase(QObject, PrintError):
         self.status_signal.emit(paired)
 
     def _update_status(self, paired):
-        button = self.button
-        icon = button.icon_paired if paired else button.icon_unpaired
-        button.setIcon(QIcon(icon))
+        if hasattr(self, 'button'):
+            button = self.button
+            icon = button.icon_paired if paired else button.icon_unpaired
+            button.setIcon(QIcon(icon))
 
     def query_choice(self, msg, labels):
         self.done.clear()

--- a/electroncash_plugins/keepkey/keepkey.py
+++ b/electroncash_plugins/keepkey/keepkey.py
@@ -288,7 +288,7 @@ class KeepKeyPlugin(HW_PluginBase):
         )
         return self.types.HDNodePathType(node=node, address_n=address_n)
 
-    def setup_device(self, device_info, wizard):
+    def setup_device(self, device_info, wizard, purpose):
         devmgr = self.device_manager()
         device_id = device_info.device.id_
         client = devmgr.client_by_id(device_id)

--- a/electroncash_plugins/ledger/ledger.py
+++ b/electroncash_plugins/ledger/ledger.py
@@ -609,7 +609,7 @@ class LedgerPlugin(HW_PluginBase):
             client = Ledger_Client(self, client, ishw1)
         return client
 
-    def setup_device(self, device_info, wizard):
+    def setup_device(self, device_info, wizard, purpose):
         devmgr = self.device_manager()
         device_id = device_info.device.id_
         client = devmgr.client_by_id(device_id)

--- a/electroncash_plugins/satochip/satochip.py
+++ b/electroncash_plugins/satochip/satochip.py
@@ -548,7 +548,7 @@ class SatochipPlugin(HW_PluginBase):
             self.print_error('create_client(): exception:'+str(e))
             return None
 
-    def setup_device(self, device_info, wizard):
+    def setup_device(self, device_info, wizard, purpose):
         self.print_error("setup_device()")#debugSatochip
         if not LIBS_AVAILABLE:
             raise RuntimeError("No libraries available")

--- a/electroncash_plugins/trezor/trezor.py
+++ b/electroncash_plugins/trezor/trezor.py
@@ -310,7 +310,7 @@ class TrezorPlugin(HW_PluginBase):
         )
         return HDNodePathType(node=node, address_n=address_n)
 
-    def setup_device(self, device_info, wizard):
+    def setup_device(self, device_info, wizard, purpose):
         '''Called when creating a new wallet.  Select the device to use.  If
         the device is uninitialized, go through the intialization
         process.'''

--- a/electrum-abc
+++ b/electrum-abc
@@ -272,6 +272,8 @@ def init_daemon(config_options):
         print_msg(f"Type '{SCRIPT_NAME} create' to create a new wallet, or provide a path to a wallet with the -w option")
         sys.exit(0)
     if storage.is_encrypted():
+        if storage.is_encrypted_with_hw_device():
+            raise NotImplementedError("CLI functionality of encrypted hw wallets")
         if "wallet_password" in config_options:
             print_msg(
                 'Warning: unlocking wallet with commandline argument "--walletpassword"'
@@ -327,6 +329,8 @@ def init_cmdline(config_options, server):
     if (cmd.requires_wallet and storage.is_encrypted() and server is None) or (
         cmd.requires_password and is_storage_pw_req
     ):
+        if storage.is_encrypted_with_hw_device():
+            raise NotImplementedError("CLI functionality of encrypted hw wallets")
         if config.get("password"):
             password = config.get("password")
         else:
@@ -354,12 +358,14 @@ def run_offline_command(config, config_options):
     if cmd.requires_wallet:
         storage = WalletStorage(config.get_wallet_path())
         if storage.is_encrypted():
+            if storage.is_encrypted_with_hw_device():
+                raise NotImplementedError("CLI functionality of encrypted hw wallets")
             storage.decrypt(password)
         wallet = Wallet(storage)
     else:
         wallet = None
     is_wallet_pw_req = (
-        wallet is not None and cmd.requires_password and storage.get("use_encryption")
+        wallet is not None and cmd.requires_password and wallet.has_password()
     )
     if is_wallet_pw_req:
         try:


### PR DESCRIPTION
This is a backport of https://github.com/spesmilo/electrum/pull/3346/commits

The main difference between this codebase and the electrum codebase that required extra-care is that we have two different wallet classes for imported addresses and imported privkeys, when electrum handles both with a single class (but different keystores).

Closes #147
Related to Electron-Cash/Electron-Cash#750