### PR TITLE
Add a tool to sign or broadcast a list of transactions from files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,7 +6,8 @@ files: |
         electroncash/keystore.py|
         electroncash_gui/qt/address_list.py|
         electroncash_gui/qt/consolidate_coins_dialog.py|
-        electroncash_gui/qt/exception_window.py
+        electroncash_gui/qt/exception_window.py|
+        electroncash_gui/qt/multi_transactions_dialog.py
     )$
 repos:
 -   repo: https://github.com/pycqa/isort

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -169,8 +169,7 @@ class ConsolidateCoinsWizard(QtWidgets.QWizard, MessageBoxMixin):
 
     def on_build_transactions_finished(self, transactions: Sequence[Transaction]):
         self.transactions = transactions
-        can_sign = self.wallet.can_sign(self.transactions[0])
-        self.tx_page.set_unsigned_transactions(self.transactions, can_sign)
+        self.tx_page.set_unsigned_transactions(self.transactions)
 
 
 class CoinSelectionPage(QtWidgets.QWizardPage):
@@ -359,14 +358,12 @@ class TransactionsPage(QtWidgets.QWizardPage):
     def update_progress(self, num_tx: int):
         self.multi_tx_display.set_displayed_number_of_transactions(num_tx)
 
-    def set_unsigned_transactions(
-        self, transactions: Sequence[Transaction], can_sign: bool
-    ):
+    def set_unsigned_transactions(self, transactions: Sequence[Transaction]):
         self.unsetCursor()
         if not transactions:
             self.update_status(TransactionsStatus.NO_RESULT)
             return
-        self.multi_tx_display.set_transactions(transactions, can_sign)
+        self.multi_tx_display.set_transactions(transactions)
 
     def isComplete(self) -> bool:
         return self.status == TransactionsStatus.FINISHED

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -1,6 +1,4 @@
-import json
 from enum import Enum
-from pathlib import Path
 from typing import Optional, Sequence
 
 from PyQt5 import QtCore, QtWidgets
@@ -14,6 +12,7 @@ from electroncash.consolidate import (
 from electroncash.constants import PROJECT_NAME, XEC
 from electroncash.transaction import Transaction
 from electroncash.wallet import Abstract_Wallet
+from electroncash_gui.qt.multi_transactions_dialog import MultiTransactionsWidget
 from electroncash_gui.qt.util import MessageBoxMixin
 
 
@@ -120,7 +119,6 @@ class ConsolidateCoinsWizard(QtWidgets.QWizard, MessageBoxMixin):
         self.address: Address = address
         self.wallet: Abstract_Wallet = wallet
         self.transactions: Sequence[Transaction] = []
-        self.main_window = main_window
 
         self.coins_page = CoinSelectionPage()
         self.addPage(self.coins_page)
@@ -128,11 +126,8 @@ class ConsolidateCoinsWizard(QtWidgets.QWizard, MessageBoxMixin):
         self.output_page = OutputsPage(address)
         self.addPage(self.output_page)
 
-        self.tx_page = TransactionsPage()
+        self.tx_page = TransactionsPage(wallet, main_window)
         self.addPage(self.tx_page)
-        self.tx_page.save_button.clicked.connect(self.on_save_clicked)
-        self.tx_page.sign_button.clicked.connect(self.on_sign_clicked)
-        self.tx_page.broadcast_button.clicked.connect(self.on_broadcast_clicked)
 
         self.currentIdChanged.connect(self.on_page_changed)
 
@@ -176,66 +171,6 @@ class ConsolidateCoinsWizard(QtWidgets.QWizard, MessageBoxMixin):
         self.transactions = transactions
         can_sign = self.wallet.can_sign(self.transactions[0])
         self.tx_page.set_unsigned_transactions(self.transactions, can_sign)
-
-    def on_save_clicked(self):
-        dir = QtWidgets.QFileDialog.getExistingDirectory(
-            self, "Select output directory for transaction files", str(Path.home())
-        )
-        if not dir:
-            return
-        for i, tx in enumerate(self.transactions):
-            name = (
-                f"signed_{i:03d}.txn" if tx.is_complete() else f"unsigned_{i:03d}.txn"
-            )
-            path = Path(dir) / name
-
-            tx_dict = tx.as_dict()
-            with open(path, "w+", encoding="utf-8") as f:
-                f.write(json.dumps(tx_dict, indent=4) + "\n")
-        QtWidgets.QMessageBox.information(
-            self, "Done saving", f"Saved {len(self.transactions)} files to {dir}"
-        )
-
-    def on_sign_clicked(self):
-        password = None
-        if self.wallet.has_password():
-            password = self.main_window.password_dialog(
-                "Enter your password to proceed"
-            )
-            if not password:
-                return
-
-        for tx in self.transactions:
-            self.wallet.sign_transaction(tx, password, use_cache=True)
-
-        QtWidgets.QMessageBox.information(
-            self,
-            "Done signing",
-            f"Signed {len(self.transactions)} transactions. Remember to save them!",
-        )
-
-        # Signing is done in a different thread, so delay the check for completeness
-        # until the signatures have been added to the transaction.
-        QtCore.QTimer.singleShot(
-            2000,
-            lambda: self.tx_page.broadcast_button.setEnabled(
-                self.transactions[-1].is_complete()
-            ),
-        )
-        self.tx_page.save_button.setText("Save (signed)")
-
-    def on_broadcast_clicked(self):
-        self.main_window.push_top_level_window(self)
-        try:
-            for tx in self.transactions:
-                self.main_window.broadcast_transaction(tx, None)
-        finally:
-            self.main_window.pop_top_level_window(self)
-        QtWidgets.QMessageBox.information(
-            self,
-            "Done broadcasting",
-            f"Broadcasted {len(self.transactions)} transactions.",
-        )
 
 
 class CoinSelectionPage(QtWidgets.QWizardPage):
@@ -389,7 +324,7 @@ class OutputsPage(QtWidgets.QWizardPage):
 
 
 class TransactionsPage(QtWidgets.QWizardPage):
-    def __init__(self, parent=None):
+    def __init__(self, wallet, main_window, parent=None):
         super().__init__(parent)
         self.status: TransactionsStatus = TransactionsStatus.NOT_STARTED
         self.setTitle("Transactions")
@@ -400,46 +335,13 @@ class TransactionsPage(QtWidgets.QWizardPage):
         self.status_label = QtWidgets.QLabel()
         layout.addWidget(self.status_label)
 
-        self.num_tx_label = QtWidgets.QLabel()
-        layout.addWidget(self.num_tx_label)
-        self.num_in_label = QtWidgets.QLabel()
-        layout.addWidget(self.num_in_label)
-        self.in_value_label = QtWidgets.QLabel()
-        layout.addWidget(self.in_value_label)
-        self.out_value_label = QtWidgets.QLabel()
-        layout.addWidget(self.out_value_label)
-        self.fees_label = QtWidgets.QLabel()
-        layout.addWidget(self.fees_label)
-        self.reset_labels()
-
-        layout.addStretch(1)
-
-        buttons_layout = QtWidgets.QHBoxLayout()
-        layout.addLayout(buttons_layout)
-
-        self.save_button = QtWidgets.QPushButton("Save (unsigned)")
-        buttons_layout.addWidget(self.save_button)
-
-        self.sign_button = QtWidgets.QPushButton("Sign")
-        buttons_layout.addWidget(self.sign_button)
-
-        self.broadcast_button = QtWidgets.QPushButton("Broadcast")
-        self.broadcast_button.setEnabled(False)
-        buttons_layout.addWidget(self.broadcast_button)
-
-    def reset_labels(self):
-        self.num_tx_label.setText("Number of transactions:")
-        self.num_in_label.setText("Number of inputs per tx:")
-        self.in_value_label.setText("Input value:")
-        self.out_value_label.setText("Output value:")
-        self.fees_label.setText("Fees:")
+        self.multi_tx_display = MultiTransactionsWidget(wallet, main_window)
+        layout.addWidget(self.multi_tx_display)
 
     def display_work_in_progress(self):
         """Disable buttons, inform the user about the ongoing computation"""
-        self.reset_labels()
-        self.save_button.setEnabled(False)
-        self.sign_button.setEnabled(False)
-        self.broadcast_button.setEnabled(False)
+        self.multi_tx_display.reset_labels()
+        self.multi_tx_display.disable_buttons()
         self.setCursor(QtCore.Qt.WaitCursor)
 
     def update_status(self, status: TransactionsStatus):
@@ -455,32 +357,16 @@ class TransactionsPage(QtWidgets.QWizardPage):
             self.completeChanged.emit()
 
     def update_progress(self, num_tx: int):
-        self.num_tx_label.setText(f"Number of transactions: <b>{num_tx}</b>")
+        self.multi_tx_display.set_displayed_number_of_transactions(num_tx)
 
     def set_unsigned_transactions(
         self, transactions: Sequence[Transaction], can_sign: bool
     ):
-        """Enable buttons, compute and display some information about transactions."""
         self.unsetCursor()
         if not transactions:
             self.update_status(TransactionsStatus.NO_RESULT)
             return
-        # Reset buttons when fresh unsigned transactions are set
-        self.save_button.setText("Save (unsigned)")
-        self.save_button.setEnabled(True)
-        self.sign_button.setEnabled(can_sign)
-        self.broadcast_button.setEnabled(False)
-
-        # Assume the first transactions has the maximum number of inputs
-        num_in = 0 if len(transactions) == 0 else len(transactions[0].inputs())
-        self.num_in_label.setText(f"Maximum number of inputs per tx: <b>{num_in}</b>")
-
-        in_value = sum([tx.input_value() for tx in transactions]) / 100
-        out_value = sum([tx.output_value() for tx in transactions]) / 100
-        fees = sum([tx.get_fee() for tx in transactions]) / 100
-        self.in_value_label.setText(f"Input value: <b>{in_value} {XEC}</b>")
-        self.out_value_label.setText(f"Output value: <b>{out_value} {XEC}</b>")
-        self.fees_label.setText(f"Fees: <b>{fees} {XEC}</b>")
+        self.multi_tx_display.set_transactions(transactions, can_sign)
 
     def isComplete(self) -> bool:
         return self.status == TransactionsStatus.FINISHED

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -84,6 +84,7 @@ from .qrcodewidget import QRCodeWidget, QRDialog
 from .qrtextedit import ShowQRTextEdit, ScanQRTextEdit
 from .transaction_dialog import show_transaction
 from .fee_slider import FeeSlider
+from .multi_transactions_dialog import MultiTransactionsDialog
 from .popup_widget import ShowPopupLabel, KillPopupLabel
 from . import cashacctqt
 from .util import (
@@ -3579,7 +3580,13 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
                     f"{PROJECT_NAME} was unable to deserialize the"
                     f" transaction in file {filename}:\n" + str(e)
                 )
-        # todo: load the transactions in a dialog for batch signing and broadcast
+        if not transactions:
+            return
+
+        multi_tx_dialog = MultiTransactionsDialog(self.wallet, self, self)
+        multi_tx_dialog.widget.set_transactions(
+            transactions, self.wallet.can_sign(transactions[0]))
+        multi_tx_dialog.exec_()
 
     def do_process_from_txid(self, *, txid=None, parent=None, tx_desc=None):
         parent = parent or self

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -593,12 +593,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         filename, __ = QtWidgets.QFileDialog.getOpenFileName(self, "Select your wallet file", wallet_folder)
         if not filename:
             return
-        if filename.lower().endswith('.txn'):
-            # they did File -> Open on a .txn, just do that.
-            self.do_process_from_file(fileName=filename)
-            return
         self.gui_object.new_window(filename)
-
 
     def backup_wallet(self):
         self.wallet.storage.write()  # make sure file is committed to disk
@@ -669,7 +664,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
 
         file_menu = menubar.addMenu(_("&File"))
         self.recently_visited_menu = file_menu.addMenu(_("Open &Recent"))
-        file_menu.addAction(_("&Open") + "...", self.open_wallet).setShortcut(QKeySequence.Open)
+        file_menu.addAction(_("&Open wallet") + "...", self.open_wallet).setShortcut(QKeySequence.Open)
         file_menu.addAction(_("&New/Restore") + "...", self.new_wallet).setShortcut(QKeySequence.New)
         file_menu.addAction(_("&Save Copy As") + "...", self.backup_wallet).setShortcut(QKeySequence.SaveAs)
         file_menu.addAction(_("&Delete") + "...", self.remove_wallet)
@@ -3519,8 +3514,9 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             self._qr_dialog = None
             self.show_error(str(e))
 
-    def read_tx_from_file(self, *, fileName = None):
-        fileName = fileName or self.getOpenFileName(_("Select your transaction file"), "*.txn")
+
+    def read_tx_from_file(self) -> Optional[Transaction]:
+        fileName = self.getOpenFileName(_("Select your transaction file"), "*.txn")
         if not fileName:
             return
         try:
@@ -3552,10 +3548,10 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
                   f"transaction:") +
                 "\n" + str(e))
 
-    def do_process_from_file(self, *, fileName = None):
+    def do_process_from_file(self):
         from electroncash.transaction import SerializationError
         try:
-            tx = self.read_tx_from_file(fileName=fileName)
+            tx = self.read_tx_from_file()
             if tx:
                 self.show_transaction(tx)
         except SerializationError as e:

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -55,7 +55,6 @@ from typing import List, Optional
 
 import electroncash.constants
 import electroncash.web as web
-from electroncash import Transaction
 from electroncash import keystore, get_config
 from electroncash import networks
 from electroncash import paymentrequest
@@ -66,7 +65,12 @@ from electroncash.constants import PROJECT_NAME, REPOSITORY_URL, CURRENCY
 from electroncash.contacts import Contact
 from electroncash.i18n import _, ngettext, pgettext
 from electroncash.plugins import run_hook
-from electroncash.transaction import OPReturn, SerializationError, tx_from_str
+from electroncash.transaction import (
+    OPReturn,
+    SerializationError,
+    Transaction,
+    tx_from_str,
+)
 from electroncash.util import (format_time, format_satoshis, PrintError,
                                format_satoshis_plain, NotEnoughFunds,
                                ExcessiveFee, UserCancelled, InvalidPassword,
@@ -3581,7 +3585,6 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         parent = parent or self
         if self.gui_object.warn_if_no_network(parent):
             return
-        from electroncash import transaction
         ok = txid is not None
         if not ok:
             txid, ok = QtWidgets.QInputDialog.getText(parent, _('Lookup transaction'), _('Transaction ID') + ':')
@@ -3590,7 +3593,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             if not ok:
                 parent.show_message(_("Error retrieving transaction") + ":\n" + r)
                 return
-            tx = transaction.Transaction(r, sign_schnorr=self.wallet.is_schnorr_enabled())  # note that presumably the tx is already signed if it comes from blockchain so this sign_schnorr parameter is superfluous, but here to satisfy my OCD -Calin
+            tx = Transaction(r, sign_schnorr=self.wallet.is_schnorr_enabled())  # note that presumably the tx is already signed if it comes from blockchain so this sign_schnorr parameter is superfluous, but here to satisfy my OCD -Calin
             self.show_transaction(tx, tx_desc=tx_desc)
 
     def export_bip38_dialog(self):

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -1132,7 +1132,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         d = address_dialog.AddressDialog(self,  addr, windowParent=parent)
         d.exec_()
 
-    def show_transaction(self, tx, tx_desc = None):
+    def show_transaction(self, tx: Transaction, tx_desc = None):
         '''tx_desc is set only for txs created in the Send tab'''
         d = show_transaction(tx, self, tx_desc)
         self._tx_dialogs.add(d)

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -3584,8 +3584,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             return
 
         multi_tx_dialog = MultiTransactionsDialog(self.wallet, self, self)
-        multi_tx_dialog.widget.set_transactions(
-            transactions, self.wallet.can_sign(transactions[0]))
+        multi_tx_dialog.widget.set_transactions(transactions)
         multi_tx_dialog.exec_()
 
     def do_process_from_txid(self, *, txid=None, parent=None, tx_desc=None):

--- a/electroncash_gui/qt/multi_transactions_dialog.py
+++ b/electroncash_gui/qt/multi_transactions_dialog.py
@@ -147,3 +147,24 @@ class MultiTransactionsWidget(QtWidgets.QWidget):
             "Done broadcasting",
             f"Broadcasted {len(self.transactions)} transactions.",
         )
+
+
+class MultiTransactionsDialog(QtWidgets.QDialog):
+    """This dialog is just a minimalistic wrapper for the widget. It does not implement
+    any logic."""
+
+    def __init__(self, wallet, main_window, parent=None):
+        super().__init__(parent)
+        layout = QtWidgets.QVBoxLayout()
+        self.setLayout(layout)
+
+        self.widget = MultiTransactionsWidget(wallet, main_window, self)
+        layout.addWidget(self.widget)
+
+        buttons_layout = QtWidgets.QHBoxLayout()
+        layout.addLayout(buttons_layout)
+
+        close_button = QtWidgets.QPushButton("Close")
+        buttons_layout.addWidget(close_button)
+
+        close_button.clicked.connect(self.accept)

--- a/electroncash_gui/qt/multi_transactions_dialog.py
+++ b/electroncash_gui/qt/multi_transactions_dialog.py
@@ -1,0 +1,152 @@
+import json
+from pathlib import Path
+from typing import Sequence
+
+from PyQt5 import QtCore, QtWidgets
+
+from electroncash import Transaction
+from electroncash.constants import XEC
+from electroncash.wallet import Abstract_Wallet
+
+
+class MultiTransactionsWidget(QtWidgets.QWidget):
+    """Display multiple transactions, with statistics and tools (sign, broadcast...)"""
+
+    def __init__(self, wallet, main_window, parent=None):
+        super().__init__(parent)
+        self.wallet: Abstract_Wallet = wallet
+        self.transactions: Sequence[Transaction] = []
+        self.main_window = main_window
+
+        layout = QtWidgets.QVBoxLayout()
+        self.setLayout(layout)
+
+        self.num_tx_label = QtWidgets.QLabel()
+        layout.addWidget(self.num_tx_label)
+        self.num_in_label = QtWidgets.QLabel()
+        layout.addWidget(self.num_in_label)
+        self.in_value_label = QtWidgets.QLabel()
+        layout.addWidget(self.in_value_label)
+        self.out_value_label = QtWidgets.QLabel()
+        layout.addWidget(self.out_value_label)
+        self.fees_label = QtWidgets.QLabel()
+        layout.addWidget(self.fees_label)
+        self.reset_labels()
+
+        layout.addStretch(1)
+
+        buttons_layout = QtWidgets.QHBoxLayout()
+        layout.addLayout(buttons_layout)
+
+        self.save_button = QtWidgets.QPushButton("Save")
+        buttons_layout.addWidget(self.save_button)
+        self.sign_button = QtWidgets.QPushButton("Sign")
+        buttons_layout.addWidget(self.sign_button)
+        self.broadcast_button = QtWidgets.QPushButton("Broadcast")
+        buttons_layout.addWidget(self.broadcast_button)
+        self.disable_buttons()
+
+        self.save_button.clicked.connect(self.on_save_clicked)
+        self.sign_button.clicked.connect(self.on_sign_clicked)
+        self.broadcast_button.clicked.connect(self.on_broadcast_clicked)
+
+    def reset_labels(self):
+        self.num_tx_label.setText("Number of transactions:")
+        self.num_in_label.setText("Number of inputs per tx:")
+        self.in_value_label.setText("Input value:")
+        self.out_value_label.setText("Output value:")
+        self.fees_label.setText("Fees:")
+
+    def disable_buttons(self):
+        self.save_button.setEnabled(False)
+        self.sign_button.setEnabled(False)
+        self.broadcast_button.setEnabled(False)
+
+    def set_displayed_number_of_transactions(self, num_tx: int):
+        """This method can be called to set the number of transactions without
+        actually setting the transactions. It cen be used to demonstrate that progress
+        is being made while transactions are still being built."""
+        self.num_tx_label.setText(f"Number of transactions: <b>{num_tx}</b>")
+
+    def set_transactions(self, transactions: Sequence[Transaction], can_sign: bool):
+        """Enable buttons, compute and display some information about transactions."""
+        self.transactions = transactions
+
+        # Reset buttons when fresh unsigned transactions are set
+        self.save_button.setText("Save")
+        self.save_button.setEnabled(True)
+        self.sign_button.setEnabled(can_sign)
+        self.broadcast_button.setEnabled(False)
+
+        self.num_tx_label.setText(f"Number of transactions: <b>{len(transactions)}</b>")
+
+        # Assume the first transactions has the maximum number of inputs
+        num_in = 0 if len(transactions) == 0 else len(transactions[0].inputs())
+        self.num_in_label.setText(f"Number of inputs per tx: <b>{num_in}</b>")
+
+        in_value = sum([tx.input_value() for tx in transactions]) / 100
+        out_value = sum([tx.output_value() for tx in transactions]) / 100
+        fees = sum([tx.get_fee() for tx in transactions]) / 100
+        self.in_value_label.setText(f"Input value: <b>{in_value} {XEC}</b>")
+        self.out_value_label.setText(f"Output value: <b>{out_value} {XEC}</b>")
+        self.fees_label.setText(f"Fees: <b>{fees} {XEC}</b>")
+
+    def on_save_clicked(self):
+        dir = QtWidgets.QFileDialog.getExistingDirectory(
+            self, "Select output directory for transaction files", str(Path.home())
+        )
+        if not dir:
+            return
+        for i, tx in enumerate(self.transactions):
+            name = (
+                f"signed_{i:03d}.txn" if tx.is_complete() else f"unsigned_{i:03d}.txn"
+            )
+            path = Path(dir) / name
+
+            tx_dict = tx.as_dict()
+            with open(path, "w+", encoding="utf-8") as f:
+                f.write(json.dumps(tx_dict, indent=4) + "\n")
+        QtWidgets.QMessageBox.information(
+            self, "Done saving", f"Saved {len(self.transactions)} files to {dir}"
+        )
+
+    def on_sign_clicked(self):
+        password = None
+        if self.wallet.has_password():
+            password = self.main_window.password_dialog(
+                "Enter your password to proceed"
+            )
+            if not password:
+                return
+
+        for tx in self.transactions:
+            self.wallet.sign_transaction(tx, password, use_cache=True)
+
+        QtWidgets.QMessageBox.information(
+            self,
+            "Done signing",
+            f"Signed {len(self.transactions)} transactions. Remember to save them!",
+        )
+
+        # Signing is done in a different thread, so delay the check for completeness
+        # until the signatures have been added to the transaction.
+        QtCore.QTimer.singleShot(
+            2000,
+            lambda: self.broadcast_button.setEnabled(
+                self.transactions[-1].is_complete()
+            ),
+        )
+        self.save_button.setText("Save (signed)")
+
+    def on_broadcast_clicked(self):
+        self.main_window.push_top_level_window(self)
+        try:
+            for tx in self.transactions:
+                self.main_window.broadcast_transaction(tx, None)
+        finally:
+            self.main_window.pop_top_level_window(self)
+        QtWidgets.QMessageBox.information(
+            self,
+            "Done broadcasting",
+            f"Broadcasted {len(self.transactions)} transactions.",
+        )

--- a/electroncash_gui/qt/multi_transactions_dialog.py
+++ b/electroncash_gui/qt/multi_transactions_dialog.py
@@ -120,11 +120,15 @@ class MultiTransactionsWidget(QtWidgets.QWidget):
                 i, 3, QtWidgets.QTableWidgetItem(f"{fee / sats_per_unit:.2f}")
             )
 
-            addresses = ", ".join([addr.to_cashaddr() for (_, addr, _) in tx.outputs()])
-            color_item = QtWidgets.QTableWidgetItem(addresses)
-            color_item.setToolTip(addresses)
-            hash = sha256(addresses.encode("utf8"))
-            color_item.setBackground(QtGui.QColor(hash[0], hash[1], hash[2]))
+            # Print the output addresses on colored background, with a color depending
+            # on the hash of the output addresses. This helps with controlling that
+            # all the outputs are the same, when needed.
+            addresses_set = {addr.to_cashaddr() for (_, addr, _) in tx.outputs()}
+            addresses_txt = ", ".join(sorted(addresses_set))
+            color_item = QtWidgets.QTableWidgetItem(addresses_txt)
+            color_item.setToolTip(addresses_txt)
+            h = sha256(addresses_txt.encode("utf8"))
+            color_item.setBackground(QtGui.QColor(h[0], h[1], h[2]))
             self.transactions_table.setItem(i, 4, color_item)
 
         self.in_value_label.setText(

--- a/electroncash_gui/qt/multi_transactions_dialog.py
+++ b/electroncash_gui/qt/multi_transactions_dialog.py
@@ -68,10 +68,11 @@ class MultiTransactionsWidget(QtWidgets.QWidget):
         is being made while transactions are still being built."""
         self.num_tx_label.setText(f"Number of transactions: <b>{num_tx}</b>")
 
-    def set_transactions(self, transactions: Sequence[Transaction], can_sign: bool):
+    def set_transactions(self, transactions: Sequence[Transaction]):
         """Enable buttons, compute and display some information about transactions."""
         self.transactions = transactions
 
+        can_sign = self.wallet.can_sign(transactions[0]) if transactions else False
         # Reset buttons when fresh unsigned transactions are set
         self.save_button.setText("Save")
         self.save_button.setEnabled(True)

--- a/electroncash_gui/qt/multi_transactions_dialog.py
+++ b/electroncash_gui/qt/multi_transactions_dialog.py
@@ -2,7 +2,7 @@ import json
 from pathlib import Path
 from typing import Sequence
 
-from PyQt5 import QtCore, QtWidgets
+from PyQt5 import QtWidgets
 
 from electroncash import Transaction
 from electroncash.constants import XEC
@@ -128,14 +128,11 @@ class MultiTransactionsWidget(QtWidgets.QWidget):
             f"Signed {len(self.transactions)} transactions. Remember to save them!",
         )
 
-        # Signing is done in a different thread, so delay the check for completeness
-        # until the signatures have been added to the transaction.
-        QtCore.QTimer.singleShot(
-            2000,
-            lambda: self.broadcast_button.setEnabled(
-                self.transactions[-1].is_complete()
-            ),
-        )
+        # FIXME: for now it is assumed that all loaded transactions have the same
+        #        status (signed or unsigned). Checking for completeness is currently
+        #        too slow to be done on many large transactions.
+        are_tx_complete = self.transactions[0].is_complete()
+        self.broadcast_button.setEnabled(are_tx_complete)
         self.save_button.setText("Save (signed)")
 
     def on_broadcast_clicked(self):


### PR DESCRIPTION
The address consolidation tool developed in #142 provides buttons to sign or broadcast all generated  transactions. This would only benefit the person generating the  consolidation transactions in the first place.

In the case of multisig wallets, if the transactions need to be signed by other participants, they would need to load each transaction from file individually. 

This PR adds a tool to load multiple files (one tx per file) in an interface that is the same as the last step of the consolidation process, with a display of simple statistics about the transactions such as the total input and output amounts, and the total fees, and with the buttons to sign or broadcast the transactions.

TODO:
 - [x] more statistics to help signers verify the transactions (list of output addresses...)
 - [x] inspect individual transactions
 - [ ] if possible, improve the code loading transactions from file and deserializing them, because it is currently very slow on large wallets

