### PR TITLE
Use coin_type 1 for derivation paths of coins on testnet

### DIFF
--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -767,7 +767,8 @@ def bip44_derivation_btc(account_id: int) -> str:
 
 def bip44_derivation_bch(account_id: int) -> str:
     """Return the BCH derivation path."""
-    return _bip44_derivation(145, account_id)
+    coin = 1 if networks.net.TESTNET else 145
+    return _bip44_derivation(coin, account_id)
 
 
 def bip44_derivation_bch_tokens(account_id: int) -> str:
@@ -777,7 +778,8 @@ def bip44_derivation_bch_tokens(account_id: int) -> str:
 
 def bip44_derivation_xec(account_id: int) -> str:
     """Return the XEC BIP44 derivation path for an account id."""
-    return _bip44_derivation(899, account_id)
+    coin = 1 if networks.net.TESTNET else 899
+    return _bip44_derivation(coin, account_id)
 
 
 def bip44_derivation_xec_tokens(account_id: int) -> str:

--- a/electroncash/tests/__main__.py
+++ b/electroncash/tests/__main__.py
@@ -2,6 +2,7 @@ import unittest
 
 from .test_address import TestAddressFromString
 from .test_asert import Test_ASERTDaa
+from .test_bip44_derivation_path import TestBip44Derivations
 from .test_bitcoin import suite as test_bitcoin_suite
 from .test_blockchain import TestBlockchain
 from .test_cashacct import TestCashAccounts
@@ -28,6 +29,7 @@ def suite():
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     test_suite.addTest(loadTests(TestAddressFromString))
     test_suite.addTest(loadTests(Test_ASERTDaa))
+    test_suite.addTest(loadTests(TestBip44Derivations))
     test_suite.addTest(test_bitcoin_suite())
     test_suite.addTest(loadTests(TestBlockchain))
     test_suite.addTest(loadTests(TestCashAccounts))

--- a/electroncash/tests/test_bip44_derivation_path.py
+++ b/electroncash/tests/test_bip44_derivation_path.py
@@ -1,0 +1,39 @@
+import unittest
+
+from .. import keystore, networks
+
+
+class TestBip44Derivations(unittest.TestCase):
+    def setUp(self):
+        self.initial_net = networks.net
+
+    def tearDown(self):
+        # make sure we restore the network settings, in case it affects other tests
+        if self.initial_net == networks.MainNet:
+            networks.set_mainnet()
+        else:
+            networks.set_testnet()
+
+    def test_mainnet(self):
+        networks.set_mainnet()
+        self.assertEqual(keystore.bip44_derivation_xec(1337), "m/44'/899'/1337'")
+        self.assertEqual(keystore.bip44_derivation_bch(1337), "m/44'/145'/1337'")
+        self.assertEqual(keystore.bip44_derivation_btc(1337), "m/44'/0'/1337'")
+        self.assertEqual(
+            keystore.bip44_derivation_xec_tokens(1337), "m/44'/1899'/1337'"
+        )
+        self.assertEqual(keystore.bip44_derivation_bch_tokens(1337), "m/44'/245'/1337'")
+
+    def test_testnet(self):
+        networks.set_testnet()
+        self.assertEqual(keystore.bip44_derivation_xec(1337), "m/44'/1'/1337'")
+        self.assertEqual(keystore.bip44_derivation_bch(1337), "m/44'/1'/1337'")
+        self.assertEqual(keystore.bip44_derivation_btc(1337), "m/44'/1'/1337'")
+        self.assertEqual(
+            keystore.bip44_derivation_xec_tokens(1337), "m/44'/1899'/1337'"
+        )
+        self.assertEqual(keystore.bip44_derivation_bch_tokens(1337), "m/44'/245'/1337'")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#62 did not include a derivation path for testnet

[SLIP44](https://github.com/satoshilabs/slips/blob/master/slip-0044.md) suggests using coin_type 1 for all testnet coins. It makes sense to adopt this position for these reasons:
1. Trezor already implements it this way on hardware wallets, so testnet support will come more easily for eCash.
2. There is no compelling reason to protect against coin splitting errors on testnet because the coins are worthless.

---

This patch also fixes a UX issue. Reproduction steps:
1. `./electrum-abc --testnet`
2. Create a new wallet. Follow prompts until derivation path page.
3. Derivation paths suggested are all for mainnet. This is confusing!

The above reproduction steps are made worse by connecting a Trezor wallet. `m/44'/145'/0'` is supplied as the default which appears to work when receiving coins. However these coins cannot be spent because Trezor gives an error that the derivation path is unknown (wrong derivation path for testnet coins).

This patch results in this new UX:
![Screenshot from 2021-11-08 15-28-12](https://user-images.githubusercontent.com/88557681/140836316-979227e0-3397-4782-969c-6599492cf9f5.png)

Could be cleaned up but the suggested path now works by default whether a hardware wallet is present or not.