### PR TITLE
Add a link to top level readme for instructions to verify release binaries

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,3 +154,7 @@ Windows
 
 See `contrib/build-wine/ <contrib/build-wine>`_.
 
+Verifying Release Binaries
+==========================
+
+See `pubkeys/README.md <https://github.com/Bitcoin-ABC/ElectrumABC/blob/master/pubkeys/README.md>`_


### PR DESCRIPTION
The instructions are buried in the pubkeys directory.