### PR TITLE
fix AppImage deterministic build

### DIFF
--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -89,6 +89,8 @@ python='appdir_python'
 
 info "Installing pip"
 "$python" -m ensurepip
+# we need a pip newer than 21.0, because of https://github.com/takluyver/flit/issues/451#issuecomment-941075197
+"$python" -m pip install pip==21.3.1
 
 
 info "Preparing electrum-locale"


### PR DESCRIPTION
When building python dependencies with `pip install --no-binary :all:...`, we run into a bug caused by a cyclic dependency with `tomli==1.2.1` and `flit_core==3.2.0` while building dependencies of setuptools_scm.
It works with `pip >= 0.21` according to https://github.com/takluyver/flit/issues/451#issuecomment-941075197

This helps fix the deterministic build, which should produce an AppImage binary that fixes #158 