### PR TITLE
Fix loading multiple signed transactions

### DIFF
--- a/electroncash/consolidate.py
+++ b/electroncash/consolidate.py
@@ -58,6 +58,8 @@ class AddressConsolidator:
         include_slp: bool = False,
         min_value_sats: Optional[int] = None,
         max_value_sats: Optional[int] = None,
+        min_height: Optional[int] = None,
+        max_height: Optional[int] = None,
         output_address: Optional[Address] = None,
         max_tx_size: Optional[int] = MAX_STANDARD_TX_SIZE,
     ):
@@ -76,6 +78,8 @@ class AddressConsolidator:
                 and (include_frozen or not utxo["is_frozen_coin"])
                 and (min_value_sats is None or utxo["value"] >= min_value_sats)
                 and (max_value_sats is None or utxo["value"] <= max_value_sats)
+                and (min_height is None or utxo["height"] >= min_height)
+                and (max_height is None or utxo["height"] <= max_height)
             )
         ]
         self.wallet = wallet_instance

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -175,7 +175,6 @@ class AmountSpinBox(QtWidgets.QDoubleSpinBox):
     def __init__(self):
         super().__init__()
         self.setToolTip(f"Amount in {XEC}")
-        self.setEnabled(False)
         # 0.01 XEC is 1 satoshi
         self.setDecimals(2)
         self.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
@@ -210,32 +209,38 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
         self.include_slp_cb.toggled.connect(self.warn_burn_tokens)
         layout.addWidget(self.include_slp_cb)
 
-        min_value_sublayout = QtWidgets.QHBoxLayout()
-        layout.addLayout(min_value_sublayout)
-        self.filter_by_min_value_cb = QtWidgets.QCheckBox(
-            "Define a minimum value for coins to select"
-        )
-        self.filter_by_min_value_cb.setChecked(False)
-        min_value_sublayout.addWidget(self.filter_by_min_value_cb)
-
         self.minimum_amount_sb = AmountSpinBox()
         self.minimum_amount_sb.setValue(5.46)
-        self.filter_by_min_value_cb.toggled.connect(self.minimum_amount_sb.setEnabled)
-        min_value_sublayout.addWidget(self.minimum_amount_sb)
-
-        max_value_sublayout = QtWidgets.QHBoxLayout()
-        layout.addLayout(max_value_sublayout)
-        self.filter_by_max_value_cb = QtWidgets.QCheckBox(
-            "Define a maximum value for coins to select"
+        self.filter_by_min_value_cb = self.add_filter_by_value_line(
+            "Define a minimum value for coins to select",
+            self.minimum_amount_sb,
         )
-        self.filter_by_max_value_cb.setChecked(False)
-        max_value_sublayout.addWidget(self.filter_by_max_value_cb)
 
         self.maximum_amount_sb = AmountSpinBox()
         self.maximum_amount_sb.setValue(21_000_000_000_000)
         self.maximum_amount_sb.valueChanged.connect(self.on_maximum_amount_changed)
-        self.filter_by_max_value_cb.toggled.connect(self.maximum_amount_sb.setEnabled)
-        max_value_sublayout.addWidget(self.maximum_amount_sb)
+        self.filter_by_max_value_cb = self.add_filter_by_value_line(
+            "Define a maximum value for coins to select",
+            self.maximum_amount_sb,
+        )
+
+    def add_filter_by_value_line(
+        self, label_text: str, value_widget: QtWidgets.QWidget
+    ) -> QtWidgets.QCheckBox:
+        """Add a line with a checkbox and a widget to specify a value.
+        The value widget is enabled when the checkbox is checked.
+        Return the created QCheckBox instance."""
+        sublayout = QtWidgets.QHBoxLayout()
+        self.layout().addLayout(sublayout)
+        checkbox = QtWidgets.QCheckBox(label_text)
+        sublayout.addWidget(checkbox)
+        checkbox.setChecked(False)
+
+        value_widget.setEnabled(False)
+        checkbox.toggled.connect(value_widget.setEnabled)
+        sublayout.addWidget(value_widget)
+
+        return checkbox
 
     def warn_burn_tokens(self, include_slp_is_checked: bool):
         if include_slp_is_checked:

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -226,26 +226,28 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
 
         self.minimum_amount_sb = AmountSpinBox()
         self.minimum_amount_sb.setValue(5.46)
+        self.minimum_amount_sb.valueChanged.connect(self.on_min_or_max_amount_changed)
         self.filter_by_min_value_cb = self.add_filter_by_value_line(
             "Minimum amount (XEC)", self.minimum_amount_sb
         )
 
         self.maximum_amount_sb = AmountSpinBox()
         self.maximum_amount_sb.setValue(21_000_000_000_000)
-        self.maximum_amount_sb.valueChanged.connect(self.on_maximum_amount_changed)
+        self.maximum_amount_sb.valueChanged.connect(self.on_min_or_max_amount_changed)
         self.filter_by_max_value_cb = self.add_filter_by_value_line(
             "Maximum amount (XEC)", self.maximum_amount_sb
         )
 
         self.minimum_height_sb = BlockHeightSpinBox()
         self.minimum_height_sb.setValue(0)
+        self.minimum_height_sb.valueChanged.connect(self.on_min_or_max_height_changed)
         self.filter_by_min_height_cb = self.add_filter_by_value_line(
             "Minimum block height", self.minimum_height_sb
         )
 
         self.maximum_height_sb = BlockHeightSpinBox()
         self.maximum_height_sb.setValue(1_000_000)
-        self.maximum_height_sb.valueChanged.connect(self.on_maximum_height_changed)
+        self.maximum_height_sb.valueChanged.connect(self.on_min_or_max_height_changed)
         self.filter_by_max_height_cb = self.add_filter_by_value_line(
             "Maximum block height", self.maximum_height_sb
         )
@@ -296,11 +298,23 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
             else int(100 * self.maximum_amount_sb.value())
         )
 
-    def on_maximum_amount_changed(self, max_amount: float):
-        self.minimum_amount_sb.setMaximum(max_amount)
+    def on_min_or_max_amount_changed(self, *args):
+        """Warn if the min-max range is empty"""
+        if self.minimum_amount_sb.value() > self.maximum_amount_sb.value():
+            self.minimum_amount_sb.setStyleSheet("color: red;")
+            self.maximum_amount_sb.setStyleSheet("color: red;")
+        else:
+            self.minimum_amount_sb.setStyleSheet("")
+            self.maximum_amount_sb.setStyleSheet("")
 
-    def on_maximum_height_changed(self, max_height: int):
-        self.minimum_height_sb.setValue(max_height)
+    def on_min_or_max_height_changed(self, *args):
+        """Warn if the min-max range is empty"""
+        if self.minimum_height_sb.value() > self.maximum_height_sb.value():
+            self.minimum_height_sb.setStyleSheet("color: red;")
+            self.maximum_height_sb.setStyleSheet("color: red;")
+        else:
+            self.minimum_height_sb.setStyleSheet("")
+            self.maximum_height_sb.setStyleSheet("")
 
 
 class OutputsPage(QtWidgets.QWizardPage):

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -13,7 +13,6 @@ from electroncash.constants import PROJECT_NAME, XEC
 from electroncash.transaction import Transaction
 from electroncash.wallet import Abstract_Wallet
 from electroncash_gui.qt.multi_transactions_dialog import MultiTransactionsWidget
-from electroncash_gui.qt.util import MessageBoxMixin
 
 
 class TransactionsStatus(Enum):
@@ -101,7 +100,7 @@ class ConsolidateWorker(QtCore.QObject):
         self.finished.emit()
 
 
-class ConsolidateCoinsWizard(QtWidgets.QWizard, MessageBoxMixin):
+class ConsolidateCoinsWizard(QtWidgets.QWizard):
     def __init__(
         self,
         address: Address,

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -206,8 +206,11 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
 
         self.minimum_value_sb = QtWidgets.QDoubleSpinBox()
         self.minimum_value_sb.setEnabled(False)
-        self.minimum_value_sb.setSingleStep(0.01)
-        self.minimum_value_sb.setValue(0)
+        self.minimum_value_sb.setStepType(
+            QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
+        )
+        self.minimum_value_sb.setMaximum(21_000_000_000_000)
+        self.minimum_value_sb.setValue(5.46)
         self.minimum_value_sb.setToolTip(f"{XEC}")
         self.filter_by_min_value_cb.toggled.connect(self.minimum_value_sb.setEnabled)
         min_value_sublayout.addWidget(self.minimum_value_sb)
@@ -222,7 +225,9 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
 
         self.maximum_value_sb = QtWidgets.QDoubleSpinBox()
         self.maximum_value_sb.setEnabled(False)
-        self.maximum_value_sb.setSingleStep(0.01)
+        self.maximum_value_sb.setStepType(
+            QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
+        )
         self.maximum_value_sb.setMaximum(21_000_000_000_000)
         self.maximum_value_sb.setValue(21_000_000_000_000)
         self.maximum_value_sb.setToolTip(f"{XEC}")

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -206,6 +206,8 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
 
         self.minimum_value_sb = QtWidgets.QDoubleSpinBox()
         self.minimum_value_sb.setEnabled(False)
+        # 0.01 XEC is 1 satoshi
+        self.minimum_value_sb.setDecimals(2)
         self.minimum_value_sb.setStepType(
             QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
         )
@@ -225,6 +227,7 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
 
         self.maximum_value_sb = QtWidgets.QDoubleSpinBox()
         self.maximum_value_sb.setEnabled(False)
+        self.maximum_value_sb.setDecimals(2)
         self.maximum_value_sb.setStepType(
             QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
         )

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -171,6 +171,20 @@ class ConsolidateCoinsWizard(QtWidgets.QWizard):
         self.tx_page.set_unsigned_transactions(self.transactions)
 
 
+class AmountSpinBox(QtWidgets.QDoubleSpinBox):
+    def __init__(self):
+        super().__init__()
+        self.setToolTip(f"Amount in {XEC}")
+        self.setEnabled(False)
+        # 0.01 XEC is 1 satoshi
+        self.setDecimals(2)
+        self.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
+        self.setMaximum(21_000_000_000_000)
+        self.setGroupSeparatorShown(True)
+        # Enough width to display "21 000 000 000,00":
+        self.setMinimumWidth(170)
+
+
 class CoinSelectionPage(QtWidgets.QWizardPage):
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -204,16 +218,8 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
         self.filter_by_min_value_cb.setChecked(False)
         min_value_sublayout.addWidget(self.filter_by_min_value_cb)
 
-        self.minimum_amount_sb = QtWidgets.QDoubleSpinBox()
-        self.minimum_amount_sb.setEnabled(False)
-        # 0.01 XEC is 1 satoshi
-        self.minimum_amount_sb.setDecimals(2)
-        self.minimum_amount_sb.setStepType(
-            QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
-        )
-        self.minimum_amount_sb.setMaximum(21_000_000_000_000)
+        self.minimum_amount_sb = AmountSpinBox()
         self.minimum_amount_sb.setValue(5.46)
-        self.minimum_amount_sb.setToolTip(f"{XEC}")
         self.filter_by_min_value_cb.toggled.connect(self.minimum_amount_sb.setEnabled)
         min_value_sublayout.addWidget(self.minimum_amount_sb)
 
@@ -225,15 +231,8 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
         self.filter_by_max_value_cb.setChecked(False)
         max_value_sublayout.addWidget(self.filter_by_max_value_cb)
 
-        self.maximum_amount_sb = QtWidgets.QDoubleSpinBox()
-        self.maximum_amount_sb.setEnabled(False)
-        self.maximum_amount_sb.setDecimals(2)
-        self.maximum_amount_sb.setStepType(
-            QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
-        )
-        self.maximum_amount_sb.setMaximum(21_000_000_000_000)
+        self.maximum_amount_sb = AmountSpinBox()
         self.maximum_amount_sb.setValue(21_000_000_000_000)
-        self.maximum_amount_sb.setToolTip(f"{XEC}")
         self.maximum_amount_sb.valueChanged.connect(self.on_maximum_amount_changed)
         self.filter_by_max_value_cb.toggled.connect(self.maximum_amount_sb.setEnabled)
         max_value_sublayout.addWidget(self.maximum_amount_sb)

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -204,18 +204,18 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
         self.filter_by_min_value_cb.setChecked(False)
         min_value_sublayout.addWidget(self.filter_by_min_value_cb)
 
-        self.minimum_value_sb = QtWidgets.QDoubleSpinBox()
-        self.minimum_value_sb.setEnabled(False)
+        self.minimum_amount_sb = QtWidgets.QDoubleSpinBox()
+        self.minimum_amount_sb.setEnabled(False)
         # 0.01 XEC is 1 satoshi
-        self.minimum_value_sb.setDecimals(2)
-        self.minimum_value_sb.setStepType(
+        self.minimum_amount_sb.setDecimals(2)
+        self.minimum_amount_sb.setStepType(
             QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
         )
-        self.minimum_value_sb.setMaximum(21_000_000_000_000)
-        self.minimum_value_sb.setValue(5.46)
-        self.minimum_value_sb.setToolTip(f"{XEC}")
-        self.filter_by_min_value_cb.toggled.connect(self.minimum_value_sb.setEnabled)
-        min_value_sublayout.addWidget(self.minimum_value_sb)
+        self.minimum_amount_sb.setMaximum(21_000_000_000_000)
+        self.minimum_amount_sb.setValue(5.46)
+        self.minimum_amount_sb.setToolTip(f"{XEC}")
+        self.filter_by_min_value_cb.toggled.connect(self.minimum_amount_sb.setEnabled)
+        min_value_sublayout.addWidget(self.minimum_amount_sb)
 
         max_value_sublayout = QtWidgets.QHBoxLayout()
         layout.addLayout(max_value_sublayout)
@@ -225,17 +225,18 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
         self.filter_by_max_value_cb.setChecked(False)
         max_value_sublayout.addWidget(self.filter_by_max_value_cb)
 
-        self.maximum_value_sb = QtWidgets.QDoubleSpinBox()
-        self.maximum_value_sb.setEnabled(False)
-        self.maximum_value_sb.setDecimals(2)
-        self.maximum_value_sb.setStepType(
+        self.maximum_amount_sb = QtWidgets.QDoubleSpinBox()
+        self.maximum_amount_sb.setEnabled(False)
+        self.maximum_amount_sb.setDecimals(2)
+        self.maximum_amount_sb.setStepType(
             QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType
         )
-        self.maximum_value_sb.setMaximum(21_000_000_000_000)
-        self.maximum_value_sb.setValue(21_000_000_000_000)
-        self.maximum_value_sb.setToolTip(f"{XEC}")
-        self.filter_by_max_value_cb.toggled.connect(self.maximum_value_sb.setEnabled)
-        max_value_sublayout.addWidget(self.maximum_value_sb)
+        self.maximum_amount_sb.setMaximum(21_000_000_000_000)
+        self.maximum_amount_sb.setValue(21_000_000_000_000)
+        self.maximum_amount_sb.setToolTip(f"{XEC}")
+        self.maximum_amount_sb.valueChanged.connect(self.on_maximum_amount_changed)
+        self.filter_by_max_value_cb.toggled.connect(self.maximum_amount_sb.setEnabled)
+        max_value_sublayout.addWidget(self.maximum_amount_sb)
 
     def warn_burn_tokens(self, include_slp_is_checked: bool):
         if include_slp_is_checked:
@@ -254,7 +255,7 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
         return (
             None
             if not self.filter_by_min_value_cb.isChecked()
-            else int(100 * self.minimum_value_sb.value())
+            else int(100 * self.minimum_amount_sb.value())
         )
 
     def get_maximum_value(self) -> Optional[int]:
@@ -262,8 +263,11 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
         return (
             None
             if not self.filter_by_max_value_cb.isChecked()
-            else int(100 * self.maximum_value_sb.value())
+            else int(100 * self.maximum_amount_sb.value())
         )
+
+    def on_maximum_amount_changed(self, max_amount: float):
+        self.minimum_amount_sb.setMaximum(max_amount)
 
 
 class OutputsPage(QtWidgets.QWizardPage):

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -43,6 +43,8 @@ class ConsolidateWorker(QtCore.QObject):
         include_slp: bool,
         minimum_value: Optional[int],
         maximum_value: Optional[int],
+        minimum_height: Optional[int],
+        maximum_height: Optional[int],
         output_address: Address,
         max_tx_size: int,
     ):
@@ -57,6 +59,8 @@ class ConsolidateWorker(QtCore.QObject):
             include_slp,
             minimum_value,
             maximum_value,
+            minimum_height,
+            maximum_height,
             output_address,
             max_tx_size,
         )
@@ -148,6 +152,8 @@ class ConsolidateCoinsWizard(QtWidgets.QWizard):
                 self.coins_page.include_slp_cb.isChecked(),
                 self.coins_page.get_minimum_value(),
                 self.coins_page.get_maximum_value(),
+                self.coins_page.minimum_height_sb.value(),
+                self.coins_page.maximum_height_sb.value(),
                 self.output_page.get_output_address(),
                 self.output_page.tx_size_sb.value(),
             )
@@ -184,6 +190,15 @@ class AmountSpinBox(QtWidgets.QDoubleSpinBox):
         self.setMinimumWidth(170)
 
 
+class BlockHeightSpinBox(QtWidgets.QSpinBox):
+    def __init__(self):
+        super().__init__()
+        self.setToolTip("Block height")
+        # This maximum should give us a useful range of ~20,000 years
+        self.setMaximum(1_000_000_000)
+        self.setGroupSeparatorShown(True)
+
+
 class CoinSelectionPage(QtWidgets.QWizardPage):
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -212,16 +227,27 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
         self.minimum_amount_sb = AmountSpinBox()
         self.minimum_amount_sb.setValue(5.46)
         self.filter_by_min_value_cb = self.add_filter_by_value_line(
-            "Define a minimum value for coins to select",
-            self.minimum_amount_sb,
+            "Minimum amount (XEC)", self.minimum_amount_sb
         )
 
         self.maximum_amount_sb = AmountSpinBox()
         self.maximum_amount_sb.setValue(21_000_000_000_000)
         self.maximum_amount_sb.valueChanged.connect(self.on_maximum_amount_changed)
         self.filter_by_max_value_cb = self.add_filter_by_value_line(
-            "Define a maximum value for coins to select",
-            self.maximum_amount_sb,
+            "Maximum amount (XEC)", self.maximum_amount_sb
+        )
+
+        self.minimum_height_sb = BlockHeightSpinBox()
+        self.minimum_height_sb.setValue(0)
+        self.filter_by_min_height_cb = self.add_filter_by_value_line(
+            "Minimum block height", self.minimum_height_sb
+        )
+
+        self.maximum_height_sb = BlockHeightSpinBox()
+        self.maximum_height_sb.setValue(1_000_000)
+        self.maximum_height_sb.valueChanged.connect(self.on_maximum_height_changed)
+        self.filter_by_max_height_cb = self.add_filter_by_value_line(
+            "Maximum block height", self.maximum_height_sb
         )
 
     def add_filter_by_value_line(
@@ -272,6 +298,9 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
 
     def on_maximum_amount_changed(self, max_amount: float):
         self.minimum_amount_sb.setMaximum(max_amount)
+
+    def on_maximum_height_changed(self, max_height: int):
+        self.minimum_height_sb.setValue(max_height)
 
 
 class OutputsPage(QtWidgets.QWizardPage):

--- a/electroncash_gui/qt/multi_transactions_dialog.py
+++ b/electroncash_gui/qt/multi_transactions_dialog.py
@@ -8,9 +8,10 @@ from electroncash import transaction
 from electroncash.bitcoin import sha256
 from electroncash.constants import XEC
 from electroncash.wallet import Abstract_Wallet
+from electroncash_gui.qt.util import MessageBoxMixin
 
 
-class MultiTransactionsWidget(QtWidgets.QWidget):
+class MultiTransactionsWidget(QtWidgets.QWidget, MessageBoxMixin):
     """Display multiple transactions, with statistics and tools (sign, broadcast...)"""
 
     def __init__(self, wallet, main_window, parent=None):

--- a/electroncash_gui/qt/multi_transactions_dialog.py
+++ b/electroncash_gui/qt/multi_transactions_dialog.py
@@ -92,7 +92,7 @@ class MultiTransactionsWidget(QtWidgets.QWidget):
         self.save_button.setText("Save")
         self.save_button.setEnabled(True)
         self.sign_button.setEnabled(can_sign)
-        self.broadcast_button.setEnabled(False)
+        self.broadcast_button.setEnabled(self.are_transactions_complete())
 
         self.num_tx_label.setText(f"Number of transactions: <b>{len(transactions)}</b>")
 
@@ -195,13 +195,16 @@ class MultiTransactionsWidget(QtWidgets.QWidget):
             "Done signing",
             f"Signed {len(self.transactions)} transactions. Remember to save them!",
         )
+        self.broadcast_button.setEnabled(self.are_transactions_complete())
+        self.save_button.setText("Save (signed)")
 
+    def are_transactions_complete(self) -> bool:
+        if not self.transactions:
+            return False
         # FIXME: for now it is assumed that all loaded transactions have the same
         #        status (signed or unsigned). Checking for completeness is currently
         #        too slow to be done on many large transactions.
-        are_tx_complete = self.transactions[0].is_complete()
-        self.broadcast_button.setEnabled(are_tx_complete)
-        self.save_button.setText("Save (signed)")
+        return self.transactions[0].is_complete()
 
     def on_broadcast_clicked(self):
         self.main_window.push_top_level_window(self)


### PR DESCRIPTION
This PR fixes various bugs in the coin consolidation and loading multiple transactions tools. 

The tool was tested with unsigned transactions, not with signed transactions. The lack of input amount in raw signed transactions caused some issues. Also, the "Broadcast" button was not activated when the loaded transactions were already signed.

The minimum amount widget was useless because of the default `QDoubleSpinBox` range  not allowing to specify an amount larger than 100,00. Specify a more sensible range.

In addition to fixing these issues, this PR also implements a coin selection option based on block height.
