### PR TITLE
Backports for storage.py

### DIFF
--- a/electroncash/base_wizard.py
+++ b/electroncash/base_wizard.py
@@ -602,5 +602,5 @@ class BaseWizard(util.PrintError):
             self.wallet.synchronize()
             self.wallet.storage.write()
             self.terminate()
-        msg = _(f"{PROJECT_NAME} is generating your addresses, please wait.")
+        msg = _(f"{PROJECT_NAME} is generating your addresses, please wait...")
         self.waiting_dialog(task, msg)

--- a/electroncash/base_wizard.py
+++ b/electroncash/base_wizard.py
@@ -28,6 +28,7 @@
 import os
 import sys
 import traceback
+from functools import partial
 from typing import Callable
 
 from . import bitcoin
@@ -40,7 +41,7 @@ from .storage import (
     get_derivation_used_for_hw_device_encryption
 )
 from .wallet import (ImportedAddressWallet, ImportedPrivkeyWallet,
-                     Standard_Wallet, Multisig_Wallet, wallet_types)
+                     Standard_Wallet, Multisig_Wallet, Wallet, wallet_types)
 from .i18n import _
 from .constants import PROJECT_NAME, REPOSITORY_URL, CURRENCY
 
@@ -100,6 +101,12 @@ class BaseWizard(util.PrintError):
         ]
         choices = [pair for pair in wallet_kinds if pair[0] in wallet_types]
         self.choice_dialog(title=title, message=message, choices=choices, run_next=self.on_wallet_type)
+
+    def upgrade_storage(self):
+        def on_finished():
+            self.wallet = Wallet(self.storage)
+            self.terminate()
+        self.waiting_dialog(partial(self.storage.upgrade), _('Upgrading wallet format...'), on_finished=on_finished)
 
     def on_wallet_type(self, choice):
         self.wallet_type = choice

--- a/electroncash/bitcoin.py
+++ b/electroncash/bitcoin.py
@@ -346,7 +346,8 @@ assert len(__b43chars) == 43
 def base_encode(v, base):
     """ encode v, which is a string of bytes, to base58."""
     assert_bytes(v)
-    assert base in (58, 43)
+    if base not in (58, 43):
+        raise ValueError(f'not supported base: {base}')
     chars = __b58chars
     if base == 43:
         chars = __b43chars
@@ -380,7 +381,8 @@ def base_decode(v, length, base):
     in string."""
     # assert_bytes(v)
     v = to_bytes(v, 'ascii')
-    assert base in (58, 43)
+    if base not in (58, 43):
+        raise ValueError(f'not supported base: {base}')
     chars = __b58chars
     if base == 43:
         chars = __b43chars
@@ -944,7 +946,8 @@ def xpub_from_pubkey(xtype, cK, *, net=None):
 
 
 def bip32_derivation(s):
-    assert s.startswith('m/')
+    if not s.startswith('m/'):
+        raise ValueError('invalid bip32 derivation path: {}'.format(s))
     s = s[2:]
     for n in s.split('/'):
         if n == '': continue
@@ -960,7 +963,9 @@ def is_bip32_derivation(x):
 
 def bip32_private_derivation(xprv, branch, sequence, *, net=None):
     if net is None: net = networks.net
-    assert sequence.startswith(branch)
+    if not sequence.startswith(branch):
+        raise ValueError('incompatible branch ({}) and sequence ({})'
+                         .format(branch, sequence))
     if branch == sequence:
         return xprv, xpub_from_xprv(xprv, net=net)
     xtype, depth, fingerprint, child_number, c, k = deserialize_xprv(xprv, net=net)

--- a/electroncash/daemon.py
+++ b/electroncash/daemon.py
@@ -274,6 +274,8 @@ class Daemon(DaemonThread):
             storage.decrypt(password)
         if storage.requires_split():
             return
+        if storage.requires_upgrade():
+            return
         if storage.get_action():
             return
         wallet = Wallet(storage)

--- a/electroncash/daemon.py
+++ b/electroncash/daemon.py
@@ -274,8 +274,6 @@ class Daemon(DaemonThread):
             storage.decrypt(password)
         if storage.requires_split():
             return
-        if storage.requires_upgrade():
-            return
         if storage.get_action():
             return
         wallet = Wallet(storage)

--- a/electroncash/json_db.py
+++ b/electroncash/json_db.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python
+#
+# Electrum - lightweight Bitcoin client
+# Copyright (C) 2015 Thomas Voegtlin
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import ast
+import json
+import copy
+
+from .address import Address
+from . import bitcoin
+from .keystore import bip44_derivation_btc
+from .plugins import plugin_loaders
+from . import util
+from .util import PrintError, WalletFileException, multisig_type, profiler
+
+
+# seed_version is now used for the version of the wallet file
+
+OLD_SEED_VERSION = 4        # electrum versions < 2.0
+NEW_SEED_VERSION = 11       # electrum versions >= 2.0
+FINAL_SEED_VERSION = 17     # electrum >= 2.7 will set this to prevent
+                            # old versions from overwriting new format
+
+
+class JsonDB(PrintError):
+
+    def __init__(self, raw, *, manual_upgrades):
+        self.data = {}
+        self.manual_upgrades = manual_upgrades
+        if raw:
+            self.load_data(raw)
+        else:
+            self.put('seed_version', FINAL_SEED_VERSION)
+
+        self.output_pretty_json: bool = True
+
+    def set_output_pretty_json(self, flag: bool):
+        self.output_pretty_json = flag
+
+    def get(self, key, default=None):
+        v = self.data.get(key)
+        if v is None:
+            v = default
+        else:
+            v = copy.deepcopy(v)
+        return v
+
+    def put(self, key, value) -> bool:
+        try:
+            json.dumps(key, cls=util.MyEncoder)
+            json.dumps(value, cls=util.MyEncoder)
+        except:
+            self.print_error(f"json error: cannot save {repr(key)} ({repr(value)})")
+            return False
+        if value is not None:
+            if self.data.get(key) != value:
+                self.data[key] = copy.deepcopy(value)
+                return True
+        elif key in self.data:
+            self.data.pop(key)
+            return True
+        return False
+
+    def commit(self):
+        pass
+
+    def dump(self):
+        return json.dumps(
+            self.data,
+            indent=4 if self.output_pretty_json else None,
+            sort_keys=self.output_pretty_json,
+            cls=util.MyEncoder
+        )
+
+    def load_data(self, s):
+        try:
+            self.data = json.loads(s)
+        except:
+            try:
+                d = ast.literal_eval(s)
+                labels = d.get('labels', {})
+            except Exception as e:
+                raise IOError("Cannot read wallet file")
+            self.data = {}
+            for key, value in d.items():
+                try:
+                    json.dumps(key)
+                    json.dumps(value)
+                except:
+                    self.print_error('Failed to convert label to json format', key)
+                    continue
+                self.data[key] = value
+
+        if not isinstance(self.data, dict):
+            raise WalletFileException("Malformed wallet file (not dict)")
+
+        # check here if I need to load a plugin
+        t = self.get('wallet_type')
+        l = plugin_loaders.get(t)
+        if l: l()
+
+        if not self.manual_upgrades:
+            if self.requires_split():
+                raise WalletFileException("This wallet has multiple accounts and must be split")
+            if self.requires_upgrade():
+                self.upgrade()
+
+    def requires_split(self):
+        d = self.get('accounts', {})
+        return len(d) > 1
+
+    def split_accounts(self):
+        result = []
+        # backward compatibility with old wallets
+        d = self.get('accounts', {})
+        if len(d) < 2:
+            return
+        wallet_type = self.get('wallet_type')
+        if wallet_type == 'old':
+            assert len(d) == 2
+            data1 = copy.deepcopy(self.data)
+            data1['accounts'] = {'0': d['0']}
+            data1['suffix'] = 'deterministic'
+            data2 = copy.deepcopy(self.data)
+            data2['accounts'] = {'/x': d['/x']}
+            data2['seed'] = None
+            data2['seed_version'] = None
+            data2['master_public_key'] = None
+            data2['wallet_type'] = 'imported'
+            data2['suffix'] = 'imported'
+            result = [data1, data2]
+        elif wallet_type in ['bip44', 'trezor', 'keepkey', 'ledger', 'btchip', 'digitalbitbox']:
+            mpk = self.get('master_public_keys')
+            for k in d.keys():
+                bip44_account = int(k)
+                x = d[k]
+                if x.get("pending"):
+                    continue
+                xpub = mpk[f"x/{bip44_account}'"]
+                new_data = copy.deepcopy(self.data)
+                # save account, derivation and xpub at index 0
+                new_data['accounts'] = {'0': x}
+                new_data['master_public_keys'] = {"x/0'": xpub}
+                new_data['derivation'] = bip44_derivation_btc(bip44_account)
+                new_data['suffix'] = k
+                result.append(new_data)
+        else:
+            raise WalletFileException("This wallet has multiple accounts and must be split")
+        return result
+
+    def requires_upgrade(self):
+        return self.get_seed_version() < FINAL_SEED_VERSION
+
+    @profiler
+    def upgrade(self):
+        self.print_error('upgrading wallet format')
+
+        self.convert_imported()
+        self.convert_wallet_type()
+        self.convert_account()
+        self.convert_version_13_b()
+        self.convert_version_14()
+        self.convert_version_15()
+        self.convert_version_16()
+        self.convert_version_17()
+
+        self.put('seed_version', FINAL_SEED_VERSION)  # just to be sure
+
+    def convert_wallet_type(self):
+        if not self._is_upgrade_method_needed(0, 13):
+            return
+
+        wallet_type = self.get('wallet_type')
+        if wallet_type == 'btchip': wallet_type = 'ledger'
+        if self.get('keystore') or self.get('x1/') or wallet_type == 'imported':
+            return False
+        assert not self.requires_split()
+        seed_version = self.get_seed_version()
+        seed = self.get('seed')
+        xpubs = self.get('master_public_keys')
+        xprvs = self.get('master_private_keys', {})
+        mpk = self.get('master_public_key')
+        keypairs = self.get('keypairs')
+        key_type = self.get('key_type')
+        if seed_version == OLD_SEED_VERSION or wallet_type == 'old':
+            d = {
+                'type': 'old',
+                'seed': seed,
+                'mpk': mpk,
+            }
+            self.put('wallet_type', 'standard')
+            self.put('keystore', d)
+
+        elif key_type == 'imported':
+            d = {
+                'type': 'imported',
+                'keypairs': keypairs,
+            }
+            self.put('wallet_type', 'standard')
+            self.put('keystore', d)
+
+        elif wallet_type in ['xpub', 'standard']:
+            xpub = xpubs["x/"]
+            xprv = xprvs.get("x/")
+            d = {
+                'type': 'bip32',
+                'xpub': xpub,
+                'xprv': xprv,
+                'seed': seed,
+            }
+            self.put('wallet_type', 'standard')
+            self.put('keystore', d)
+
+        elif wallet_type in ['bip44']:
+            xpub = xpubs["x/0'"]
+            xprv = xprvs.get("x/0'")
+            d = {
+                'type': 'bip32',
+                'xpub': xpub,
+                'xprv': xprv,
+            }
+            self.put('wallet_type', 'standard')
+            self.put('keystore', d)
+
+        elif wallet_type in ['trezor', 'keepkey', 'ledger', 'digitalbitbox']:
+            xpub = xpubs["x/0'"]
+            derivation = self.get('derivation', bip44_derivation_btc(0))
+            d = {
+                'type': 'hardware',
+                'hw_type': wallet_type,
+                'xpub': xpub,
+                'derivation': derivation,
+            }
+            self.put('wallet_type', 'standard')
+            self.put('keystore', d)
+
+        elif multisig_type(wallet_type):
+            for key in xpubs.keys():
+                d = {
+                    'type': 'bip32',
+                    'xpub': xpubs[key],
+                    'xprv': xprvs.get(key),
+                }
+                if key == 'x1/' and seed:
+                    d['seed'] = seed
+                self.put(key, d)
+        else:
+            raise WalletFileException('Unable to tell wallet type. Is this even a wallet file?')
+        # remove junk
+        self.put('master_public_key', None)
+        self.put('master_public_keys', None)
+        self.put('master_private_keys', None)
+        self.put('derivation', None)
+        self.put('seed', None)
+        self.put('keypairs', None)
+        self.put('key_type', None)
+
+    def convert_version_13_b(self):
+        # version 13 is ambiguous, and has an earlier and a later structure
+        if not self._is_upgrade_method_needed(0, 13):
+            return
+
+        if self.get('wallet_type') == 'standard':
+            if self.get('keystore').get('type') == 'imported':
+                pubkeys = self.get('keystore').get('keypairs').keys()
+                d = {'change': []}
+                receiving_addresses = []
+                for pubkey in pubkeys:
+                    addr = bitcoin.pubkey_to_address('p2pkh', pubkey)
+                    receiving_addresses.append(addr)
+                d['receiving'] = receiving_addresses
+                self.put('addresses', d)
+                self.put('pubkeys', None)
+
+        self.put('seed_version', 13)
+
+    def convert_version_14(self):
+        # convert imported wallets for 3.0
+        if not self._is_upgrade_method_needed(13, 13):
+            return
+
+        if self.get('wallet_type') =='imported':
+            addresses = self.get('addresses')
+            if type(addresses) is list:
+                addresses = dict([(x, None) for x in addresses])
+                self.put('addresses', addresses)
+        elif self.get('wallet_type') == 'standard':
+            if self.get('keystore').get('type')=='imported':
+                addresses = set(self.get('addresses').get('receiving'))
+                pubkeys = self.get('keystore').get('keypairs').keys()
+                assert len(addresses) == len(pubkeys)
+                d = {}
+                for pubkey in pubkeys:
+                    addr = bitcoin.pubkey_to_address('p2pkh', pubkey)
+                    assert addr in addresses
+                    d[addr] = {
+                        'pubkey': pubkey,
+                        'redeem_script': None,
+                        'type': 'p2pkh'
+                    }
+                self.put('addresses', d)
+                self.put('pubkeys', None)
+                self.put('wallet_type', 'imported')
+        self.put('seed_version', 14)
+
+    def convert_version_15(self):
+        if not self._is_upgrade_method_needed(14, 14):
+            return
+        self.put('seed_version', 15)
+
+    def convert_version_16(self):
+        # fixes issue #3193 for imported address wallets
+        # also, previous versions allowed importing any garbage as an address
+        #       which we now try to remove, see pr #3191
+        if not self._is_upgrade_method_needed(15, 15):
+            return
+
+        def remove_address(addr):
+            def remove_from_dict(dict_name):
+                d = self.get(dict_name, None)
+                if d is not None:
+                    d.pop(addr, None)
+                    self.put(dict_name, d)
+
+            def remove_from_list(list_name):
+                lst = self.get(list_name, None)
+                if lst is not None:
+                    s = set(lst)
+                    s -= {addr}
+                    self.put(list_name, list(s))
+
+            # note: we don't remove 'addr' from self.get('addresses')
+            remove_from_dict('addr_history')
+            remove_from_dict('labels')
+            remove_from_dict('payment_requests')
+            remove_from_list('frozen_addresses')
+
+        if self.get('wallet_type') == 'imported':
+            addresses = self.get('addresses')
+            assert isinstance(addresses, dict)
+            addresses_new = dict()
+            for address, details in addresses.items():
+                if not Address.is_valid(address):
+                    remove_address(address)
+                    continue
+                if details is None:
+                    addresses_new[address] = {}
+                else:
+                    addresses_new[address] = details
+            self.put('addresses', addresses_new)
+
+        self.put('seed_version', 16)
+
+    def convert_version_17(self):
+        if not self._is_upgrade_method_needed(16, 16):
+            return
+        if self.get('wallet_type') == 'imported':
+            addrs = self.get('addresses')
+            if all(v for v in addrs.values()):
+                self.put('wallet_type', 'imported_privkey')
+            else:
+                self.put('wallet_type', 'imported_addr')
+
+    def convert_imported(self):
+        if not self._is_upgrade_method_needed(0, 13):
+            return
+
+        # '/x' is the internal ID for imported accounts
+        d = self.get('accounts', {}).get('/x', {}).get('imported',{})
+        if not d:
+            return False
+        addresses = []
+        keypairs = {}
+        for addr, v in d.items():
+            pubkey, privkey = v
+            if privkey:
+                keypairs[pubkey] = privkey
+            else:
+                addresses.append(addr)
+        if addresses and keypairs:
+            raise WalletFileException('mixed addresses and privkeys')
+        elif addresses:
+            self.put('addresses', addresses)
+            self.put('accounts', None)
+        elif keypairs:
+            self.put('wallet_type', 'standard')
+            self.put('key_type', 'imported')
+            self.put('keypairs', keypairs)
+            self.put('accounts', None)
+        else:
+            raise WalletFileException('no addresses or privkeys')
+
+    def convert_account(self):
+        if not self._is_upgrade_method_needed(0, 13):
+            return
+
+        self.put('accounts', None)
+
+    def _is_upgrade_method_needed(self, min_version, max_version):
+        cur_version = self.get_seed_version()
+        if cur_version > max_version:
+            return False
+        elif cur_version < min_version:
+            raise WalletFileException(
+                'storage upgrade: unexpected version {} (should be {}-{})'
+                .format(cur_version, min_version, max_version))
+        else:
+            return True
+
+    def get_seed_version(self):
+        seed_version = self.get('seed_version')
+        if not seed_version:
+            seed_version = OLD_SEED_VERSION if len(self.get('master_public_key','')) == 128 else NEW_SEED_VERSION
+        if seed_version > FINAL_SEED_VERSION:
+            raise WalletFileException('This version of Electrum is too old to open this wallet.\n'
+                                      '(highest supported storage version: {}, version of this file: {})'
+                                      .format(FINAL_SEED_VERSION, seed_version))
+        if seed_version >=12:
+            return seed_version
+        if seed_version not in [OLD_SEED_VERSION, NEW_SEED_VERSION]:
+            self.raise_unsupported_version(seed_version)
+        return seed_version
+
+    def raise_unsupported_version(self, seed_version):
+        msg = "Your wallet has an unsupported seed version."
+        if seed_version in [5, 7, 8, 9, 10, 14]:
+            msg += "\n\nTo open this wallet, try 'git checkout seed_v%d'"%seed_version
+        if seed_version == 6:
+            # version 1.9.8 created v6 wallets when an incorrect seed was entered in the restore dialog
+            msg += '\n\nThis file was created because of a bug in version 1.9.8.'
+            if self.get('master_public_keys') is None and self.get('master_private_keys') is None and self.get('imported_keys') is None:
+                # pbkdf2 (at that time an additional dependency) was not included with the binaries, and wallet creation aborted.
+                msg += "\nIt does not contain any keys, and can safely be removed."
+            else:
+                # creation was complete if electrum was run from source
+                msg += "\nPlease open this file with Electrum 1.9.8, and move your coins to a new wallet."
+        raise WalletFileException(msg)

--- a/electroncash/json_db.py
+++ b/electroncash/json_db.py
@@ -31,7 +31,6 @@ import threading
 from .address import Address
 from . import bitcoin
 from .keystore import bip44_derivation_btc
-from .plugins import plugin_loaders
 from . import util
 from .util import PrintError, WalletFileException, multisig_type, profiler
 
@@ -132,11 +131,6 @@ class JsonDB(PrintError):
 
         if not isinstance(self.data, dict):
             raise WalletFileException("Malformed wallet file (not dict)")
-
-        # check here if I need to load a plugin
-        t = self.get('wallet_type')
-        l = plugin_loaders.get(t)
-        if l: l()
 
         if not self.manual_upgrades:
             if self.requires_split():

--- a/electroncash/json_db.py
+++ b/electroncash/json_db.py
@@ -74,6 +74,13 @@ class JsonDB(PrintError):
                 return func(self, *args, **kwargs)
         return wrapper
 
+    def locked(func):
+        def wrapper(self, *args, **kwargs):
+            with self.lock:
+                return func(self, *args, **kwargs)
+        return wrapper
+
+    @locked
     def get(self, key, default=None):
         v = self.data.get(key)
         if v is None:
@@ -102,6 +109,7 @@ class JsonDB(PrintError):
     def commit(self):
         pass
 
+    @locked
     def dump(self):
         return json.dumps(
             self.data,
@@ -440,6 +448,7 @@ class JsonDB(PrintError):
         else:
             return True
 
+    @locked
     def get_seed_version(self):
         seed_version = self.get('seed_version')
         if not seed_version:

--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -833,7 +833,7 @@ class InvalidSeed(Exception):
 def from_private_key_list(text):
     keystore = Imported_KeyStore({})
     for x in get_private_keys(text):
-        keystore.import_key(x, None)
+        keystore.import_privkey(x, None)
     return keystore
 
 

--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -35,7 +35,14 @@ from mnemonic import Mnemonic
 from . import bitcoin, mnemo, networks
 from .address import Address, PublicKey
 from .plugins import run_hook
-from .util import InvalidPassword, PrintError, bh2u, print_error
+from .util import (
+    BitcoinException,
+    InvalidPassword,
+    PrintError,
+    WalletFileException,
+    bh2u,
+    print_error,
+)
 
 
 class KeyStore(PrintError):
@@ -662,7 +669,7 @@ def xpubkey_to_address(x_pubkey):
         mpk, s = Old_KeyStore.parse_xpubkey(x_pubkey)
         pubkey = Old_KeyStore.get_pubkey_from_mpk(mpk, s[0], s[1])
     else:
-        raise BaseException("Cannot parse pubkey")
+        raise BitcoinException(f"Cannot parse pubkey. prefix: {x_pubkey[0:2]}")
     if pubkey:
         address = Address.from_pubkey(pubkey)
     return pubkey, address
@@ -685,14 +692,16 @@ def hardware_keystore(d):
     if hw_type in hw_keystores:
         constructor = hw_keystores[hw_type]
         return constructor(d)
-    raise BaseException("unknown hardware type", hw_type)
+    raise WalletFileException(f"unknown hardware type: {hw_type}")
 
 
 def load_keystore(storage, name):
     d = storage.get(name, {})
     t = d.get("type")
     if not t:
-        raise BaseException("wallet format requires update")
+        raise WalletFileException(
+            f"Wallet format requires update.\nCannot find keystore for name {name}"
+        )
     if t == "old":
         k = Old_KeyStore(d)
     elif t == "imported":
@@ -702,7 +711,7 @@ def load_keystore(storage, name):
     elif t == "hardware":
         k = hardware_keystore(d)
     else:
-        raise BaseException("unknown wallet type", t)
+        raise WalletFileException(f"Unknown type {t} for keystore named {name}")
     return k
 
 
@@ -856,5 +865,5 @@ def from_master_key(text):
     elif bitcoin.is_xpub(text):
         k = from_xpub(text)
     else:
-        raise BaseException("Invalid key")
+        raise BitcoinException("Invalid master key")
     return k

--- a/electroncash/mnemo.py
+++ b/electroncash/mnemo.py
@@ -399,7 +399,8 @@ class Mnemonic_Electrum(MnemonicBase):
             nonce += 1
             i = custom_entropy * (my_entropy + nonce)
             seed = self.mnemonic_encode(i)
-            assert i == self.mnemonic_decode(seed)
+            if i != self.mnemonic_decode(seed):
+                raise Exception('Cannot extract same entropy from mnemonic!')
             # avoid ambiguity between old-style seeds and new-style, as well as avoid clashes with BIP39 seeds
             if autodetect_seed_type(seed, self.lang, prefix=prefix) == {SeedType.Electrum}:
                 break

--- a/electroncash/network.py
+++ b/electroncash/network.py
@@ -187,7 +187,8 @@ def deserialize_proxy(s):
 
 def deserialize_server(server_str):
     host, port, protocol = str(server_str).rsplit(':', 2)
-    assert protocol in 'st'
+    if protocol not in 'st':
+        raise ValueError('invalid network protocol: {}'.format(protocol))
     int(port)    # Throw if cannot be converted to int
     return host, port, protocol
 

--- a/electroncash/storage.py
+++ b/electroncash/storage.py
@@ -158,7 +158,6 @@ class JsonDB(PrintError):
             assert not os.path.exists(self.path)
         os.replace(temp_path, self.path)
         os.chmod(self.path, mode)
-        self.raw = s
         self._file_exists = True
         self.print_error("saved", self.path)
         self.modified = False

--- a/electroncash/storage.py
+++ b/electroncash/storage.py
@@ -24,43 +24,20 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import os
-import ast
 import threading
-import json
-import copy
-import re
 import stat
 import hashlib
 import base64
 import zlib
 
-from .address import Address
-from . import util
+from .json_db import JsonDB
 from .util import InvalidPassword, PrintError, WalletFileException, profiler, standardize_path
-from .plugins import run_hook, plugin_loaders
-from .keystore import bip44_derivation_btc
+from .plugins import run_hook
 from . import bitcoin
 
 
-# seed_version is now used for the version of the wallet file
-
-OLD_SEED_VERSION = 4        # electrum versions < 2.0
-NEW_SEED_VERSION = 11       # electrum versions >= 2.0
-FINAL_SEED_VERSION = 17     # electrum >= 2.7 will set this to prevent
-                            # old versions from overwriting new format
-
 TMP_SUFFIX = ".tmp.{}".format(os.getpid())
 
-
-def multisig_type(wallet_type):
-    '''If wallet_type is mofn multi-sig, return [m, n],
-    otherwise return None.'''
-    if not wallet_type:
-        return None
-    match = re.match(r'(\d+)of(\d+)', wallet_type)
-    if match:
-        match = [int(x) for x in match.group(1, 2)]
-    return match
 
 def get_derivation_used_for_hw_device_encryption():
     return ("m"
@@ -72,43 +49,42 @@ def get_derivation_used_for_hw_device_encryption():
 STO_EV_PLAINTEXT, STO_EV_USER_PW, STO_EV_XPUB_PW = range(0, 3)
 
 
-class JsonDB(PrintError):
+class WalletStorage(PrintError):
 
-    def __init__(self, path):
+    def __init__(self, path, *, manual_upgrades=False, in_memory_only=False):
         self.db_lock = threading.RLock()
         self.path = standardize_path(path)
-        self._file_exists = self.path and os.path.exists(self.path)
-        self.data = {}
+        self._file_exists = in_memory_only or (self.path and os.path.exists(self.path))
         self.modified = False
-        self.output_pretty_json: bool = True
+
+        DB_Class = JsonDB
+        self.print_error("wallet path", path)
+        self.pubkey = None
+        self.raw = None
+        self._in_memory_only = in_memory_only
+        if self.file_exists() and not self._in_memory_only:
+            with open(self.path, "r", encoding='utf-8') as f:
+                self.raw = f.read()
+            self._encryption_version = self._init_encryption_version()
+            if not self.is_encrypted():
+                self.db = DB_Class(self.raw, manual_upgrades=manual_upgrades)
+        else:
+            self._encryption_version = STO_EV_PLAINTEXT
+            # avoid new wallets getting 'upgraded'
+            self.db = DB_Class('', manual_upgrades=False)
+
+    def put(self, key, value):
+        with self.db_lock:
+            self.modified |= self.db.put(key, value)
 
     def get(self, key, default=None):
         with self.db_lock:
-            v = self.data.get(key)
-            if v is None:
-                v = default
-            else:
-                v = copy.deepcopy(v)
-        return v
-
-    def put(self, key, value):
-        try:
-            json.dumps(key, cls=util.MyEncoder)
-            json.dumps(value, cls=util.MyEncoder)
-        except:
-            self.print_error("json error: cannot save", key)
-            return
-        with self.db_lock:
-            if value is not None:
-                if self.data.get(key) != value:
-                    self.modified = True
-                    self.data[key] = copy.deepcopy(value)
-            elif key in self.data:
-                self.modified = True
-                self.data.pop(key)
+            return self.db.get(key, default)
 
     @profiler
     def write(self):
+        if self._in_memory_only:
+            return
         with self.db_lock:
             self._write()
 
@@ -118,13 +94,8 @@ class JsonDB(PrintError):
             return
         if not self.modified:
             return
-        s = json.dumps(
-            self.data,
-            indent=4 if self.output_pretty_json else None,
-            sort_keys=self.output_pretty_json,
-            cls=util.MyEncoder
-        )
-        s = self.encrypt_before_writing(s)
+        self.db.commit()
+        s = self.encrypt_before_writing(self.db.dump())
 
         temp_path = self.path + TMP_SUFFIX
         with open(temp_path, "w", encoding='utf-8') as f:
@@ -148,72 +119,8 @@ class JsonDB(PrintError):
         self.print_error("saved", self.path)
         self.modified = False
 
-    def encrypt_before_writing(self, plaintext: str) -> str:
-        return plaintext
-
     def file_exists(self):
         return self._file_exists
-
-    def set_output_pretty_json(self, flag: bool):
-        self.output_pretty_json = flag
-
-
-class WalletStorage(JsonDB):
-
-    def __init__(self, path, *, manual_upgrades=False, in_memory_only=False):
-        self.print_error("wallet path", path)
-        JsonDB.__init__(self, path)
-        self.manual_upgrades = manual_upgrades
-        self._file_exists = in_memory_only or self._file_exists
-        self.pubkey = None
-        self.raw = None
-        self._in_memory_only = in_memory_only
-        if self.file_exists() and not self._in_memory_only:
-            try:
-                with open(self.path, "r", encoding='utf-8') as f:
-                    self.raw = f.read()
-                self._encryption_version = self._init_encryption_version()
-            except UnicodeDecodeError as e:
-                raise IOError("Error reading file: "+ str(e))
-            if not self.is_encrypted():
-                self.load_data(self.raw)
-        else:
-            self._encryption_version = STO_EV_PLAINTEXT
-            # avoid new wallets getting 'upgraded'
-            self.put('seed_version', FINAL_SEED_VERSION)
-
-    def load_data(self, s):
-        try:
-            self.data = json.loads(s)
-        except:
-            try:
-                d = ast.literal_eval(s)
-                labels = d.get('labels', {})
-            except Exception as e:
-                raise IOError("Cannot read wallet file")
-            self.data = {}
-            for key, value in d.items():
-                try:
-                    json.dumps(key)
-                    json.dumps(value)
-                except:
-                    self.print_error('Failed to convert label to json format', key)
-                    continue
-                self.data[key] = value
-
-        if not isinstance(self.data, dict):
-            raise WalletFileException("Malformed wallet file (not dict)")
-
-        # check here if I need to load a plugin
-        t = self.get('wallet_type')
-        l = plugin_loaders.get(t)
-        if l: l()
-
-        if not self.manual_upgrades:
-            if self.requires_split():
-                raise WalletFileException("This wallet has multiple accounts and must be split")
-            if self.requires_upgrade():
-                self.upgrade()
 
     def is_past_initial_decryption(self):
         """Return if storage is in a usable state for normal operations.
@@ -222,7 +129,7 @@ class WalletStorage(JsonDB):
             if encryption is disabled completely (self.is_encrypted() == False),
             or if encryption is enabled but the contents have already been decrypted.
         """
-        return bool(self.data)
+        return bool(self.data) # FIXME
 
     def is_encrypted(self):
         """Return if storage encryption is currently enabled."""
@@ -280,7 +187,7 @@ class WalletStorage(JsonDB):
             s = None
         self.pubkey = ec_key.get_public_key()
         s = s.decode('utf8')
-        self.load_data(s)
+        self.db = JsonDB(s, manual_upgrades=True)
 
     def encrypt_before_writing(self, plaintext: str) -> str:
         s = plaintext
@@ -312,323 +219,37 @@ class WalletStorage(JsonDB):
             self._encryption_version = enc_version
             # Encrypted wallets are not human readable, so we can gain some performance
             # by writing compact JSON.
-            self.set_output_pretty_json(False)
+            self.db.set_output_pretty_json(False)
         else:
             self.pubkey = None
             self._encryption_version = STO_EV_PLAINTEXT
-            self.set_output_pretty_json(True)
+            self.db.set_output_pretty_json(True)
         # make sure next storage.write() saves changes
         with self.db_lock:
             self.modified = True
 
-    def requires_split(self):
-        d = self.get('accounts', {})
-        return len(d) > 1
-
-    def split_accounts(storage):
-        result = []
-        # backward compatibility with old wallets
-        d = storage.get('accounts', {})
-        if len(d) < 2:
-            return
-        wallet_type = storage.get('wallet_type')
-        if wallet_type == 'old':
-            assert len(d) == 2
-            storage1 = WalletStorage(storage.path + '.deterministic')
-            storage1.data = copy.deepcopy(storage.data)
-            storage1.put('accounts', {'0': d['0']})
-            storage1.upgrade()
-            storage1.write()
-            storage2 = WalletStorage(storage.path + '.imported')
-            storage2.data = copy.deepcopy(storage.data)
-            storage2.put('accounts', {'/x': d['/x']})
-            storage2.put('seed', None)
-            storage2.put('seed_version', None)
-            storage2.put('master_public_key', None)
-            storage2.put('wallet_type', 'imported')
-            storage2.upgrade()
-            storage2.write()
-            result = [storage1.path, storage2.path]
-        elif wallet_type in ['bip44', 'trezor', 'keepkey', 'ledger', 'btchip', 'digitalbitbox']:
-            mpk = storage.get('master_public_keys')
-            for k in d.keys():
-                bip44_account = int(k)
-                x = d[k]
-                if x.get("pending"):
-                    continue
-                xpub = mpk[f"x/{bip44_account}'"]
-                new_path = storage.path + '.' + k
-                storage2 = WalletStorage(new_path)
-                storage2.data = copy.deepcopy(storage.data)
-                # save account, derivation and xpub at index 0
-                storage2.put('accounts', {'0': x})
-                storage2.put('master_public_keys', {"x/0'": xpub})
-                storage2.put('derivation', bip44_derivation_btc(bip44_account))
-                storage2.upgrade()
-                storage2.write()
-                result.append(new_path)
-        else:
-            raise WalletFileException("This wallet has multiple accounts and must be split")
-        return result
-
     def requires_upgrade(self):
-        return self.file_exists() and self.get_seed_version() < FINAL_SEED_VERSION
+        self.db.requires_upgrade()
 
     def upgrade(self):
-        self.print_error('upgrading wallet format')
-
-        self.convert_imported()
-        self.convert_wallet_type()
-        self.convert_account()
-        self.convert_version_13_b()
-        self.convert_version_14()
-        self.convert_version_15()
-        self.convert_version_16()
-        self.convert_version_17()
-
-        self.put('seed_version', FINAL_SEED_VERSION)  # just to be sure
+        self.db.upgrade()
         self.write()
 
-    def convert_wallet_type(self):
-        if not self._is_upgrade_method_needed(0, 13):
-            return
+    def requires_split(self):
+        return self.db.requires_split()
 
-        wallet_type = self.get('wallet_type')
-        if wallet_type == 'btchip': wallet_type = 'ledger'
-        if self.get('keystore') or self.get('x1/') or wallet_type=='imported':
-            return False
-        assert not self.requires_split()
-        seed_version = self.get_seed_version()
-        seed = self.get('seed')
-        xpubs = self.get('master_public_keys')
-        xprvs = self.get('master_private_keys', {})
-        mpk = self.get('master_public_key')
-        keypairs = self.get('keypairs')
-        key_type = self.get('key_type')
-        if seed_version == OLD_SEED_VERSION or wallet_type == 'old':
-            d = {
-                'type': 'old',
-                'seed': seed,
-                'mpk': mpk,
-            }
-            self.put('wallet_type', 'standard')
-            self.put('keystore', d)
-
-        elif key_type == 'imported':
-            d = {
-                'type': 'imported',
-                'keypairs': keypairs,
-            }
-            self.put('wallet_type', 'standard')
-            self.put('keystore', d)
-
-        elif wallet_type in ['xpub', 'standard']:
-            xpub = xpubs["x/"]
-            xprv = xprvs.get("x/")
-            d = {
-                'type': 'bip32',
-                'xpub': xpub,
-                'xprv': xprv,
-                'seed': seed,
-            }
-            self.put('wallet_type', 'standard')
-            self.put('keystore', d)
-
-        elif wallet_type in ['bip44']:
-            xpub = xpubs["x/0'"]
-            xprv = xprvs.get("x/0'")
-            d = {
-                'type': 'bip32',
-                'xpub': xpub,
-                'xprv': xprv,
-            }
-            self.put('wallet_type', 'standard')
-            self.put('keystore', d)
-
-        elif wallet_type in ['trezor', 'keepkey', 'ledger', 'digitalbitbox']:
-            xpub = xpubs["x/0'"]
-            derivation = self.get('derivation', bip44_derivation_btc(0))
-            d = {
-                'type': 'hardware',
-                'hw_type': wallet_type,
-                'xpub': xpub,
-                'derivation': derivation,
-            }
-            self.put('wallet_type', 'standard')
-            self.put('keystore', d)
-
-        elif multisig_type(wallet_type):
-            for key in xpubs.keys():
-                d = {
-                    'type': 'bip32',
-                    'xpub': xpubs[key],
-                    'xprv': xprvs.get(key),
-                }
-                if key == 'x1/' and seed:
-                    d['seed'] = seed
-                self.put(key, d)
-        else:
-            raise WalletFileException('Unable to tell wallet type. Is this even a wallet file?')
-        # remove junk
-        self.put('master_public_key', None)
-        self.put('master_public_keys', None)
-        self.put('master_private_keys', None)
-        self.put('derivation', None)
-        self.put('seed', None)
-        self.put('keypairs', None)
-        self.put('key_type', None)
-
-    def convert_version_13_b(self):
-        # version 13 is ambiguous, and has an earlier and a later structure
-        if not self._is_upgrade_method_needed(0, 13):
-            return
-
-        if self.get('wallet_type') == 'standard':
-            if self.get('keystore').get('type') == 'imported':
-                pubkeys = self.get('keystore').get('keypairs').keys()
-                d = {'change': []}
-                receiving_addresses = []
-                for pubkey in pubkeys:
-                    addr = bitcoin.pubkey_to_address('p2pkh', pubkey)
-                    receiving_addresses.append(addr)
-                d['receiving'] = receiving_addresses
-                self.put('addresses', d)
-                self.put('pubkeys', None)
-
-        self.put('seed_version', 13)
-
-    def convert_version_14(self):
-        # convert imported wallets for 3.0
-        if not self._is_upgrade_method_needed(13, 13):
-            return
-
-        if self.get('wallet_type') =='imported':
-            addresses = self.get('addresses')
-            if type(addresses) is list:
-                addresses = dict([(x, None) for x in addresses])
-                self.put('addresses', addresses)
-        elif self.get('wallet_type') == 'standard':
-            if self.get('keystore').get('type')=='imported':
-                addresses = set(self.get('addresses').get('receiving'))
-                pubkeys = self.get('keystore').get('keypairs').keys()
-                assert len(addresses) == len(pubkeys)
-                d = {}
-                for pubkey in pubkeys:
-                    addr = bitcoin.pubkey_to_address('p2pkh', pubkey)
-                    assert addr in addresses
-                    d[addr] = {
-                        'pubkey': pubkey,
-                        'redeem_script': None,
-                        'type': 'p2pkh'
-                    }
-                self.put('addresses', d)
-                self.put('pubkeys', None)
-                self.put('wallet_type', 'imported')
-        self.put('seed_version', 14)
-
-    def convert_version_15(self):
-        if not self._is_upgrade_method_needed(14, 14):
-            return
-        self.put('seed_version', 15)
-
-    def convert_version_16(self):
-        # fixes issue #3193 for imported address wallets
-        # also, previous versions allowed importing any garbage as an address
-        #       which we now try to remove, see pr #3191
-        if not self._is_upgrade_method_needed(15, 15):
-            return
-
-        def remove_address(addr):
-            def remove_from_dict(dict_name):
-                d = self.get(dict_name, None)
-                if d is not None:
-                    d.pop(addr, None)
-                    self.put(dict_name, d)
-
-            def remove_from_list(list_name):
-                lst = self.get(list_name, None)
-                if lst is not None:
-                    s = set(lst)
-                    s -= {addr}
-                    self.put(list_name, list(s))
-
-            # note: we don't remove 'addr' from self.get('addresses')
-            remove_from_dict('addr_history')
-            remove_from_dict('labels')
-            remove_from_dict('payment_requests')
-            remove_from_list('frozen_addresses')
-
-        if self.get('wallet_type') == 'imported':
-            addresses = self.get('addresses')
-            assert isinstance(addresses, dict)
-            addresses_new = dict()
-            for address, details in addresses.items():
-                if not Address.is_valid(address):
-                    remove_address(address)
-                    continue
-                if details is None:
-                    addresses_new[address] = {}
-                else:
-                    addresses_new[address] = details
-            self.put('addresses', addresses_new)
-
-        self.put('seed_version', 16)
-
-    def convert_version_17(self):
-        if not self._is_upgrade_method_needed(16, 16):
-            return
-        if self.get('wallet_type') == 'imported':
-            addrs = self.get('addresses')
-            if all(v for v in addrs.values()):
-                self.put('wallet_type', 'imported_privkey')
-            else:
-                self.put('wallet_type', 'imported_addr')
-
-    def convert_imported(self):
-        if not self._is_upgrade_method_needed(0, 13):
-            return
-
-        # '/x' is the internal ID for imported accounts
-        d = self.get('accounts', {}).get('/x', {}).get('imported',{})
-        if not d:
-            return False
-        addresses = []
-        keypairs = {}
-        for addr, v in d.items():
-            pubkey, privkey = v
-            if privkey:
-                keypairs[pubkey] = privkey
-            else:
-                addresses.append(addr)
-        if addresses and keypairs:
-            raise WalletFileException('mixed addresses and privkeys')
-        elif addresses:
-            self.put('addresses', addresses)
-            self.put('accounts', None)
-        elif keypairs:
-            self.put('wallet_type', 'standard')
-            self.put('key_type', 'imported')
-            self.put('keypairs', keypairs)
-            self.put('accounts', None)
-        else:
-            raise WalletFileException('no addresses or privkeys')
-
-    def convert_account(self):
-        if not self._is_upgrade_method_needed(0, 13):
-            return
-
-        self.put('accounts', None)
-
-    def _is_upgrade_method_needed(self, min_version, max_version):
-        cur_version = self.get_seed_version()
-        if cur_version > max_version:
-            return False
-        elif cur_version < min_version:
-            raise WalletFileException(
-                'storage upgrade: unexpected version {} (should be {}-{})'
-                .format(cur_version, min_version, max_version))
-        else:
-            return True
+    def split_accounts(self):
+        out = []
+        result = self.db.split_accounts()
+        for data in result:
+            path = self.path + '.' + data['suffix']
+            storage = WalletStorage(path)
+            storage.db.data = data
+            storage.db.upgrade()
+            storage.modified = True
+            storage.write()
+            out.append(path)
+        return out
 
     def get_action(self):
         action = run_hook('get_action', self)
@@ -640,38 +261,3 @@ class WalletStorage(JsonDB):
             return action
         if not self.file_exists():
             return 'new'
-
-    def get_seed_version(self):
-        seed_version = self.get('seed_version')
-        if not seed_version:
-            seed_version = OLD_SEED_VERSION if len(self.get('master_public_key','')) == 128 else NEW_SEED_VERSION
-        if seed_version > FINAL_SEED_VERSION:
-            raise WalletFileException('This version of Electrum is too old to open this wallet.\n'
-                                      '(highest supported storage version: {}, version of this file: {})'
-                                      .format(FINAL_SEED_VERSION, seed_version))
-        if seed_version >=12:
-            return seed_version
-        if seed_version not in [OLD_SEED_VERSION, NEW_SEED_VERSION]:
-            self.raise_unsupported_version(seed_version)
-        return seed_version
-
-    def raise_unsupported_version(self, seed_version):
-        msg = "Your wallet has an unsupported seed version."
-        if seed_version in [5, 7, 8, 9, 10, 14]:
-            msg += "\n\nTo open this wallet, try 'git checkout seed_v%d'"%seed_version
-        if seed_version == 6:
-            # version 1.9.8 created v6 wallets when an incorrect seed was entered in the restore dialog
-            msg += '\n\nThis file was created because of a bug in version 1.9.8.'
-            if self.get('master_public_keys') is None and self.get('master_private_keys') is None and self.get('imported_keys') is None:
-                # pbkdf2 (at that time an additional dependency) was not included with the binaries, and wallet creation aborted.
-                msg += "\nIt does not contain any keys, and can safely be removed."
-            else:
-                # creation was complete if electrum was run from source
-                msg += "\nPlease open this file with Electrum 1.9.8, and move your coins to a new wallet."
-        raise WalletFileException(msg)
-
-    @profiler
-    def write(self):
-        if self._in_memory_only:
-            return
-        JsonDB.write(self)

--- a/electroncash/storage.py
+++ b/electroncash/storage.py
@@ -605,17 +605,14 @@ class WalletStorage(PrintError):
             return True
 
     def get_action(self):
-        if self.file_exists():
-            action = run_hook('get_action', self)
-            if action and self.requires_upgrade():
-                raise WalletFileException('Incomplete wallet files cannot be upgraded.')
-            elif self.requires_upgrade():
-                return 'upgrade_storage'
-            elif action:
-                return action
-            else:
-                return None
-        else:
+        action = run_hook('get_action', self)
+        if self.file_exists() and self.requires_upgrade():
+            if action:
+                raise WalletFileException(_('Incomplete wallet files cannot be upgraded.'))
+            return 'upgrade_storage'
+        if action:
+            return action
+        if not self.file_exists():
             return 'new'
 
     def get_seed_version(self):

--- a/electroncash/storage.py
+++ b/electroncash/storage.py
@@ -605,10 +605,17 @@ class WalletStorage(PrintError):
             return True
 
     def get_action(self):
-        action = run_hook('get_action', self)
-        if action:
-            return action
-        if not self.file_exists():
+        if self.file_exists():
+            action = run_hook('get_action', self)
+            if action and self.requires_upgrade():
+                raise WalletFileException('Incomplete wallet files cannot be upgraded.')
+            elif self.requires_upgrade():
+                return 'upgrade_storage'
+            elif action:
+                return action
+            else:
+                return None
+        else:
             return 'new'
 
     def get_seed_version(self):

--- a/electroncash/storage.py
+++ b/electroncash/storage.py
@@ -176,9 +176,6 @@ class WalletStorage(JsonDB):
     def load_data(self, s):
         try:
             self.data = json.loads(s)
-
-            # Sanity check: wallet should be a quack like a dict. This throws if not.
-            self.data.get("dummy")
         except:
             try:
                 d = ast.literal_eval(s)
@@ -194,6 +191,9 @@ class WalletStorage(JsonDB):
                     self.print_error('Failed to convert label to json format', key)
                     continue
                 self.data[key] = value
+
+        if not isinstance(self.data, dict):
+            raise WalletFileException("Malformed wallet file (not dict)")
 
         # check here if I need to load a plugin
         t = self.get('wallet_type')

--- a/electroncash/storage.py
+++ b/electroncash/storage.py
@@ -35,7 +35,7 @@ import base64
 import zlib
 
 from .address import Address
-from .util import InvalidPassword, PrintError, profiler, standardize_path
+from .util import InvalidPassword, PrintError, WalletFileException, profiler, standardize_path
 from .plugins import run_hook, plugin_loaders
 from .keystore import bip44_derivation_btc
 from . import bitcoin
@@ -125,7 +125,7 @@ class WalletStorage(PrintError):
 
         if not self.manual_upgrades:
             if self.requires_split():
-                raise BaseException("This wallet has multiple accounts and must be split")
+                raise WalletFileException("This wallet has multiple accounts and must be split")
             if self.requires_upgrade():
                 self.upgrade()
 
@@ -186,7 +186,7 @@ class WalletStorage(PrintError):
         elif v == STO_EV_XPUB_PW:
             return b'BIE2'
         else:
-            raise Exception('no encryption magic for version: %s' % v)
+            raise WalletFileException('no encryption magic for version: %s' % v)
 
     def decrypt(self, password):
         ec_key = self.get_key(password)
@@ -342,7 +342,7 @@ class WalletStorage(PrintError):
                 storage2.write()
                 result.append(new_path)
         else:
-            raise BaseException("This wallet has multiple accounts and must be split")
+            raise WalletFileException("This wallet has multiple accounts and must be split")
         return result
 
     def requires_upgrade(self):
@@ -442,7 +442,7 @@ class WalletStorage(PrintError):
                     d['seed'] = seed
                 self.put(key, d)
         else:
-            raise Exception('Unable to tell wallet type. Is this even a wallet file?')
+            raise WalletFileException('Unable to tell wallet type. Is this even a wallet file?')
         # remove junk
         self.put('master_public_key', None)
         self.put('master_public_keys', None)
@@ -575,7 +575,7 @@ class WalletStorage(PrintError):
             else:
                 addresses.append(addr)
         if addresses and keypairs:
-            raise BaseException('mixed addresses and privkeys')
+            raise WalletFileException('mixed addresses and privkeys')
         elif addresses:
             self.put('addresses', addresses)
             self.put('accounts', None)
@@ -585,7 +585,7 @@ class WalletStorage(PrintError):
             self.put('keypairs', keypairs)
             self.put('accounts', None)
         else:
-            raise BaseException('no addresses or privkeys')
+            raise WalletFileException('no addresses or privkeys')
 
     def convert_account(self):
         if not self._is_upgrade_method_needed(0, 13):
@@ -598,9 +598,9 @@ class WalletStorage(PrintError):
         if cur_version > max_version:
             return False
         elif cur_version < min_version:
-            raise BaseException(
-                ('storage upgrade: unexpected version %d (should be %d-%d)'
-                 % (cur_version, min_version, max_version)))
+            raise WalletFileException(
+                'storage upgrade: unexpected version {} (should be {}-{})'
+                .format(cur_version, min_version, max_version))
         else:
             return True
 
@@ -616,7 +616,9 @@ class WalletStorage(PrintError):
         if not seed_version:
             seed_version = OLD_SEED_VERSION if len(self.get('master_public_key','')) == 128 else NEW_SEED_VERSION
         if seed_version > FINAL_SEED_VERSION:
-            raise BaseException('This version of Electrum is too old to open this wallet')
+            raise WalletFileException('This version of Electrum is too old to open this wallet.\n'
+                                      '(highest supported storage version: {}, version of this file: {})'
+                                      .format(FINAL_SEED_VERSION, seed_version))
         if seed_version >=12:
             return seed_version
         if seed_version not in [OLD_SEED_VERSION, NEW_SEED_VERSION]:
@@ -637,4 +639,4 @@ class WalletStorage(PrintError):
             else:
                 # creation was complete if electrum was run from source
                 msg += "\nPlease open this file with Electrum 1.9.8, and move your coins to a new wallet."
-        raise BaseException(msg)
+        raise WalletFileException(msg)

--- a/electroncash/storage.py
+++ b/electroncash/storage.py
@@ -107,6 +107,20 @@ class JsonDB(PrintError):
                 self.modified = True
                 self.data.pop(key)
 
+    def get_all_data(self) -> dict:
+        with self.db_lock:
+            return copy.deepcopy(self.data)
+
+    def overwrite_all_data(self, data: dict) -> None:
+        try:
+            json.dumps(data, cls=util.MyEncoder)
+        except:
+            self.print_error(f"json error: cannot save {repr(data)}")
+            return
+        with self.db_lock:
+            self.modified = True
+            self.data = copy.deepcopy(data)
+
     @profiler
     def write(self):
         with self.db_lock:

--- a/electroncash/tests/test_wallet.py
+++ b/electroncash/tests/test_wallet.py
@@ -7,8 +7,9 @@ import unittest
 from io import StringIO
 
 from ..address import Address
+from ..json_db import FINAL_SEED_VERSION
 from ..simple_config import SimpleConfig
-from ..storage import FINAL_SEED_VERSION, WalletStorage
+from ..storage import WalletStorage
 from ..wallet import (
     Abstract_Wallet,
     Standard_Wallet,

--- a/electroncash/util.py
+++ b/electroncash/util.py
@@ -29,6 +29,7 @@ import itertools
 import json
 import locale
 import os
+import re
 import stat
 import subprocess
 import sys
@@ -1058,3 +1059,15 @@ class Weak:
 # may wonder 'Why Weak.finaliztion_print_error'?. The fact that this relies on
 # weak refs is an implementation detail, really.
 finalization_print_error = Weak.finalization_print_error
+
+
+def multisig_type(wallet_type):
+    '''If wallet_type is mofn multi-sig, return [m, n],
+    otherwise return None.'''
+    if not wallet_type:
+        return None
+    match = re.match(r'(\d+)of(\d+)', wallet_type)
+    if match:
+        match = [int(x) for x in match.group(1, 2)]
+    return match
+

--- a/electroncash/util.py
+++ b/electroncash/util.py
@@ -104,6 +104,10 @@ class MyEncoder(json.JSONEncoder):
         from .transaction import Transaction
         if isinstance(obj, Transaction):
             return obj.as_dict()
+        if isinstance(obj, datetime):
+            return obj.isoformat(' ')[:-3]
+        if isinstance(obj, set):
+            return list(obj)
         return super(MyEncoder, self).default(obj)
 
 class PrintError:

--- a/electroncash/util.py
+++ b/electroncash/util.py
@@ -85,6 +85,14 @@ class FileImportFailedEncrypted(FileImportFailed):
                 _('Importing encrypted files is not supported.'))
 
 
+class WalletFileException(Exception):
+    pass
+
+
+class BitcoinException(Exception):
+    pass
+
+
 # Throw this exception to unwind the stack like when an error occurs.
 # However unlike other exceptions the user won't be informed.
 class UserCancelled(Exception):

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -45,7 +45,7 @@ from typing import Set, Tuple, Union
 from .constants import DUST_THRESHOLD
 from .i18n import ngettext
 from .util import (NotEnoughFunds, ExcessiveFee, PrintError,
-                   UserCancelled, InvalidPassword, profiler,
+                   UserCancelled, InvalidPassword, multisig_type, profiler,
                    format_satoshis, format_time, finalization_print_error,
                    to_string, bh2u, TimeoutException, WalletFileException)
 
@@ -55,7 +55,6 @@ from .keystore import load_keystore, Hardware_KeyStore, Imported_KeyStore, BIP32
 from . import mnemo
 from . import keystore
 from .storage import (
-    multisig_type,
     WalletStorage,
     STO_EV_PLAINTEXT,
     STO_EV_USER_PW,

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -166,7 +166,10 @@ class Abstract_Wallet(PrintError, SPVDelegate):
 
     max_change_outputs = 3
 
-    def __init__(self, storage):
+    def __init__(self, storage: WalletStorage):
+        if storage.requires_upgrade():
+            raise Exception("storage must be upgraded before constructing wallet")
+
         self.electrum_version = PACKAGE_VERSION
         self.storage = storage
         self.thread = None  # this is used by the qt main_window to store a QThread. We just make sure it's always defined as an attribute here.

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -62,7 +62,7 @@ from .storage import (
 )
 
 from .transaction import Transaction, InputValueMissing
-from .plugins import run_hook
+from .plugins import run_hook, plugin_loaders
 from . import bitcoin
 from . import coinchooser
 from .synchronizer import Synchronizer
@@ -3278,6 +3278,9 @@ class Wallet:
 
     def __new__(self, storage):
         wallet_type = storage.get('wallet_type')
+        # check here if I need to load a plugin
+        if wallet_type in plugin_loaders:
+            plugin_loaders[wallet_type]()
         WalletClass = Wallet.wallet_class(wallet_type)
         wallet = WalletClass(storage)
         # Convert hardware wallets restored with older versions of

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -47,7 +47,7 @@ from .i18n import ngettext
 from .util import (NotEnoughFunds, ExcessiveFee, PrintError,
                    UserCancelled, InvalidPassword, profiler,
                    format_satoshis, format_time, finalization_print_error,
-                   to_string, bh2u, TimeoutException)
+                   to_string, bh2u, TimeoutException, WalletFileException)
 
 from .address import Address, Script, ScriptOutput, PublicKey
 from .version import PACKAGE_VERSION
@@ -3267,9 +3267,6 @@ wallet_constructors = {
 def register_constructor(wallet_type, constructor):
     wallet_constructors[wallet_type] = constructor
 
-class UnknownWalletType(RuntimeError):
-    ''' Raised if encountering an unknown wallet type '''
-    pass
 
 # former WalletFactory
 class Wallet:
@@ -3297,7 +3294,7 @@ class Wallet:
             return Multisig_Wallet
         if wallet_type in wallet_constructors:
             return wallet_constructors[wallet_type]
-        raise UnknownWalletType("Unknown wallet type: " + str(wallet_type))
+        raise WalletFileException("Unknown wallet type: " + str(wallet_type))
 
 
 def create_new_wallet(*, path, passphrase=None, password=None,

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -2135,17 +2135,17 @@ class Abstract_Wallet(PrintError, SPVDelegate):
             self.set_up_to_date(False)
             while not self.is_up_to_date():
                 if callback:
-                    msg = "%s\n%s %d"%(
+                    msg = "{}\n{} {}".format(
                         _("Please wait..."),
                         _("Addresses generated:"),
-                        len(self.addresses(True)))
+                        len(self.get_addresses()))
                     callback(msg)
                 time.sleep(0.1)
                 check_timed_out()
         def wait_for_network():
             while not self.network.is_connected():
                 if callback:
-                    msg = "%s \n" % (_("Connecting..."))
+                    msg = "{} \n".format(_("Connecting..."))
                     callback(msg)
                 time.sleep(0.1)
                 check_timed_out()

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -620,10 +620,10 @@ class ElectrumGui(QtCore.QObject, PrintError):
                 return
 
         if not wallet:
-            storage = WalletStorage(path, manual_upgrades=True)
-            wizard = InstallWizard(self.config, self.app, self.plugins, storage)
+            wizard = InstallWizard(self.config, self.app, self.plugins, None)
             try:
-                wallet, password = wizard.run_and_get_wallet(self.daemon.get_wallet) or (None, None)
+                if wizard.select_storage(path, self.daemon.get_wallet):
+                    wallet = wizard.run_and_get_wallet()
             except UserCancelled:
                 pass
             except GoBack as e:

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -711,7 +711,7 @@ class ElectrumGui(QtCore.QObject, PrintError):
         # Show network dialog if config does not exist
         if self.daemon.network:
             if self.config.get('auto_connect') is None:
-                wizard = InstallWizard(self.config, self.app, self.plugins, None)
+                wizard = InstallWizard(self.config, self.app, self.plugins)
                 wizard.init_network(self.daemon.network)
                 wizard.terminate()
 

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -64,8 +64,10 @@ from electroncash import i18n
 from electroncash.plugins import run_hook
 from electroncash import WalletStorage
 from electroncash.util import (
+    BitcoinException,
     Handlers,
     UserCancelled,
+    WalletFileException,
     Weak,
     get_new_wallet_name,
     standardize_path,
@@ -636,6 +638,14 @@ class ElectrumGui(QtCore.QObject, PrintError):
                         pass
                     except GoBack as e:
                         self.print_error('[start_new_window] Exception caught (GoBack)', e)
+                    except (WalletFileException, BitcoinException) as e:
+                        traceback.print_exc(file=sys.stderr)
+                        d = QtWidgets.QMessageBox(
+                            QtWidgets.QMessageBox.Warning,
+                            _('Error'),
+                            _('Cannot load wallet') + ' (2):\n' + str(e))
+                        d.exec_()
+                        return
                     finally:
                         wizard.terminate()
                         del wizard
@@ -649,7 +659,7 @@ class ElectrumGui(QtCore.QObject, PrintError):
                 traceback.print_exc(file=sys.stdout)
                 self.warning(
                     title=_('Error'),
-                    message = 'Cannot load wallet:\n' + str(e),
+                    message = 'Cannot load wallet (1):\n' + str(e),
                     icon=QtWidgets.QMessageBox.Critical
                 )
                 return

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -300,17 +300,6 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
                 self.show_warning(_('The file was removed'))
             return
 
-        if self.storage.requires_upgrade():
-            self.hide()
-            msg = _(f"The format of your wallet {path} must be upgraded for "
-                    f"{PROJECT_NAME}. This change will not be backward "
-                    f"compatible")
-            if not self.question(msg):
-                return
-            self.storage.upgrade()
-            self.wallet = Wallet(self.storage)
-            return self.wallet, password
-
         action = self.storage.get_action()
         if action and action not in ('new', 'upgrade_storage'):
             self.hide()

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -313,7 +313,7 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
             return self.wallet, password
 
         action = self.storage.get_action()
-        if action and action != 'new':
+        if action and action not in ('new', 'upgrade_storage'):
             self.hide()
             msg = _("The file '{}' contains an incompletely created wallet.\n"
                     "Do you want to complete its creation now?").format(path)
@@ -508,12 +508,26 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
     def terminate(self):
         self.accept_signal.emit()
 
-    def waiting_dialog(self, task, msg):
-        self.please_wait.setText(MSG_GENERATING_WAIT)
-        self.refresh_gui()
-        t = threading.Thread(target = task)
+    def waiting_dialog(self, task, msg, on_finished=None):
+        label = WWLabel(msg)
+        vbox = QtWidgets.QVBoxLayout()
+        vbox.addSpacing(100)
+        label.setMinimumWidth(300)
+        label.setAlignment(Qt.AlignCenter)
+        vbox.addWidget(label)
+        self.set_layout(vbox, next_enabled=False)
+        self.back_button.setEnabled(False)
+
+        t = threading.Thread(target=task)
         t.start()
-        t.join()
+        while True:
+            t.join(1.0/60)
+            if t.is_alive():
+                self.refresh_gui()
+            else:
+                break
+        if on_finished:
+            on_finished()
 
     @wizard_dialog
     def choice_dialog(self, title, message, choices, run_next, extra_button=None):

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -435,7 +435,7 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
         return slayout.is_ext
 
     def pw_layout(self, msg, kind, force_disable_encrypt_cb):
-        playout = PasswordLayout(None, msg, kind, self.next_button,
+        playout = PasswordLayout(msg=msg, kind=kind, OK_button=self.next_button,
                                  force_disable_encrypt_cb=force_disable_encrypt_cb)
         playout.encrypt_cb.setChecked(True)
         self.exec_layout(playout.layout())
@@ -450,7 +450,7 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
 
     @wizard_dialog
     def request_storage_encryption(self, run_next):
-        playout = PasswordLayoutForHW(None, MSG_HW_STORAGE_ENCRYPTION, PW_NEW, self.next_button)
+        playout = PasswordLayoutForHW(MSG_HW_STORAGE_ENCRYPTION)
         playout.encrypt_cb.setChecked(True)
         self.exec_layout(playout.layout())
         return playout.encrypt_cb.isChecked()

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -107,8 +107,8 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
 
     accept_signal = pyqtSignal()
 
-    def __init__(self, config, app, plugins, storage):
-        BaseWizard.__init__(self, config, storage)
+    def __init__(self, config, app, plugins):
+        BaseWizard.__init__(self, config)
         QtWidgets.QDialog.__init__(self, None)
         self.setWindowTitle(f'{PROJECT_NAME}  -  ' + _('Install Wizard'))
         self.app = app
@@ -184,8 +184,8 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
         vbox.addLayout(hbox2)
         self.set_layout(vbox, title=_(f'{PROJECT_NAME} wallet'))
 
-        self.storage = WalletStorage(path, manual_upgrades=True)
-        wallet_folder = os.path.dirname(self.storage.path)
+        self.temp_storage = WalletStorage(path, manual_upgrades=True)
+        wallet_folder = os.path.dirname(self.temp_storage.path)
 
         def on_choose():
             path, __ = QtWidgets.QFileDialog.getOpenFileName(self, "Select your wallet file", wallet_folder)
@@ -197,24 +197,24 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
             wallet_from_memory = get_wallet_from_daemon(path)
             try:
                 if wallet_from_memory:
-                    self.storage = wallet_from_memory.storage
+                    self.temp_storage = wallet_from_memory.storage
                 else:
-                    self.storage = WalletStorage(path, manual_upgrades=True)
+                    self.temp_storage = WalletStorage(path, manual_upgrades=True)
                 self.next_button.setEnabled(True)
             except IOError:
-                self.storage = None
+                self.temp_storage = None
                 self.next_button.setEnabled(False)
-            if self.storage:
-                if not self.storage.file_exists():
+            if self.temp_storage:
+                if not self.temp_storage.file_exists():
                     msg =_("This file does not exist.") + '\n' \
                           + _("Press 'Next' to create this wallet, or choose another file.")
                     pw = False
                 elif not wallet_from_memory:
-                    if self.storage.is_encrypted_with_user_pw():
+                    if self.temp_storage.is_encrypted_with_user_pw():
                         msg = _("This file is encrypted with a password.") + '\n' \
                               + _('Enter your password or choose another file.')
                         pw = True
-                    elif self.storage.is_encrypted_with_hw_device():
+                    elif self.temp_storage.is_encrypted_with_hw_device():
                         msg = _("This file is encrypted using a hardware device.") + '\n' \
                               + _("Press 'Next' to choose device to decrypt.")
                         pw = False
@@ -239,24 +239,24 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
 
         button.clicked.connect(on_choose)
         self.name_e.textChanged.connect(on_filename)
-        n = os.path.basename(self.storage.path)
+        n = os.path.basename(self.temp_storage.path)
         self.name_e.setText(n)
 
         while True:
             if self.loop.exec_() != 2:  # 2 = next
-                return
-            if self.storage.file_exists() and not self.storage.is_encrypted():
+                raise UserCancelled
+            if self.temp_storage.file_exists() and not self.temp_storage.is_encrypted():
                 break
-            if not self.storage.file_exists():
+            if not self.temp_storage.file_exists():
                 break
-            wallet_from_memory = get_wallet_from_daemon(self.storage.path)
+            wallet_from_memory = get_wallet_from_daemon(self.temp_storage.path)
             if wallet_from_memory:
                 return wallet_from_memory
-            if self.storage.file_exists() and self.storage.is_encrypted():
-                if self.storage.is_encrypted_with_user_pw():
+            if self.temp_storage.file_exists() and self.temp_storage.is_encrypted():
+                if self.temp_storage.is_encrypted_with_user_pw():
                     password = self.pw_e.text()
                     try:
-                        self.storage.decrypt(password)
+                        self.temp_storage.decrypt(password)
                         break
                     except InvalidPassword as e:
                         QtWidgets.QMessageBox.information(None, _('Error'), str(e))
@@ -265,7 +265,7 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
                         traceback.print_exc(file=sys.stdout)
                         QtWidgets.QMessageBox.information(None, _('Error'), str(e))
                         return
-                elif self.storage.is_encrypted_with_hw_device():
+                elif self.temp_storage.is_encrypted_with_hw_device():
                     try:
                         self.run('choose_hw_device', HWD_SETUP_DECRYPT_WALLET)
                     except InvalidPassword as e:
@@ -279,31 +279,31 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
                         traceback.print_exc(file=sys.stdout)
                         QtWidgets.QMessageBox.information(None, _('Error'), str(e))
                         return
-                    if self.storage.is_past_initial_decryption():
+                    if self.temp_storage.is_past_initial_decryption():
                         break
                     else:
                         return
                 else:
                     raise Exception('Unexpected encryption version')
-        return True
+        return self.temp_storage.path, (self.temp_storage if self.temp_storage.file_exists() else None)
 
-    def run_and_get_wallet(self):
-        path = self.storage.path
-        if self.storage.requires_split():
+    def run_upgrades(self, storage):
+        path = storage.path
+        if storage.requires_split():
             self.hide()
             msg = _("The wallet '{}' contains multiple accounts, which are no longer supported since Electrum 2.7.\n\n"
                     "Do you want to split your wallet into multiple files?").format(path)
             if not self.question(msg):
                 return
-            file_list = '\n'.join(self.storage.split_accounts())
+            file_list = '\n'.join(storage.split_accounts())
             msg = _('Your accounts have been moved to') + ':\n' + file_list + '\n\n'+ _('Do you want to delete the old file') + ':\n' + path
             if self.question(msg):
                 os.remove(path)
                 self.show_warning(_('The file was removed'))
             return
 
-        action = self.storage.get_action()
-        if action and action not in ('new', 'upgrade_storage'):
+        action = storage.get_action()
+        if action: #< and action not in ('new', 'upgrade_storage'):
             self.hide()
             msg = _("The file '{}' contains an incompletely created wallet.\n"
                     "Do you want to complete its creation now?").format(path)
@@ -313,13 +313,16 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
                     self.show_warning(_('The file was removed'))
                 return
             self.show()
-        if action:
-            # self.wallet is set in run
-            self.run(action)
-            return self.wallet
+            self.data = storage.data
 
-        self.wallet = Wallet(self.storage)
-        return self.wallet
+            self.run(action)
+            for k, v in self.data.items():
+                storage.put(k, v)
+            storage.write()
+            return
+
+        if storage.requires_upgrade():
+            self.upgrade_storage(storage)
 
     def finished(self):
         """Called in hardware client wrapper, in order to close popups."""

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -38,21 +38,13 @@ from .util import (
 class GoBack(Exception):
     pass
 
-MSG_GENERATING_WAIT = _(f"{PROJECT_NAME} is generating your addresses, please wait...")
-MSG_ENTER_ANYTHING = _("Please enter a seed phrase, a master key, a list of "
-                       "Bitcoin addresses, or a list of private keys")
-MSG_ENTER_SEED_OR_MPK = _("Please enter a seed phrase or a master key (xpub or xprv):")
-MSG_COSIGNER = _("Please enter the master public key of cosigner #{}:")
+
 MSG_ENTER_PASSWORD = _("Choose a password to encrypt your wallet keys.") + '\n'\
                      + _("Leave this field empty if you want to disable encryption.")
 MSG_HW_STORAGE_ENCRYPTION = _("Set wallet file encryption.") + '\n'\
                           + _("Your wallet file does not contain secrets, mostly just metadata. ") \
                           + _("It also contains your master public key that allows watching your addresses.") + '\n\n'\
                           + _("Note: If you enable this setting, you will need your hardware device to open your wallet.")
-MSG_RESTORE_PASSPHRASE = \
-    _("Please enter your seed derivation passphrase. "
-      "Note: this is NOT your encryption password. "
-      "Leave this field empty if you did not use one or are unsure.")
 
 
 class CosignWidget(QtWidgets.QWidget):

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -114,7 +114,6 @@ def wizard_dialog(func):
 class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
 
     accept_signal = pyqtSignal()
-    synchronized_signal = pyqtSignal(str)
 
     def __init__(self, config, app, plugins, storage):
         BaseWizard.__init__(self, config, storage)

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -366,7 +366,7 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
         if not result and raise_on_cancel:
             raise UserCancelled
         if result == 1:
-            raise GoBack
+            raise GoBack from None
         self.title.setVisible(False)
         self.back_button.setEnabled(False)
         self.next_button.setEnabled(False)

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -259,8 +259,6 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
                     try:
                         self.run('choose_hw_device', HWD_SETUP_DECRYPT_WALLET)
                     except InvalidPassword as e:
-                        # FIXME if we get here because of mistyped passphrase
-                        # then that passphrase gets "cached"
                         QtWidgets.QMessageBox.information(
                             None, _('Error'),
                             _('Failed to decrypt using this hardware device.') + '\n' +

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -245,10 +245,10 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
 
         while True:
             password = None
-            if self.storage.file_exists() and not self.storage.is_encrypted():
-                break
             if self.loop.exec_() != 2:  # 2 = next
                 return
+            if self.storage.file_exists() and not self.storage.is_encrypted():
+                break
             if not self.storage.file_exists():
                 break
             if self.storage.file_exists() and self.storage.is_encrypted():
@@ -274,7 +274,7 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
                             None, _('Error'),
                             _('Failed to decrypt using this hardware device.') + '\n' +
                             _('If you use a passphrase, make sure it is correct.'))
-                        self.stack = []
+                        self.reset_stack()
                         return self.run_and_get_wallet()
                     except BaseException as e:
                         traceback.print_exc(file=sys.stdout)

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -637,11 +637,8 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         if filename in recent:
             recent.remove(filename)
         recent.insert(0, filename)
-        recent2 = []
-        for k in recent:
-            if os.path.exists(k):
-                recent2.append(k)
-        recent = recent2[:5]
+        recent = [path for path in recent if os.path.exists(path)]
+        recent = recent[:5]
         self.config.set_key('recently_open', recent)
         self.recently_visited_menu.clear()
         gui_object = self.gui_object

--- a/electroncash_gui/qt/password_dialog.py
+++ b/electroncash_gui/qt/password_dialog.py
@@ -69,10 +69,10 @@ class PasswordLayout:
 
     def __init__(
         self,
-        wallet,
         msg,
         kind,
         OK_button,
+        wallet=None,
         *,
         permit_empty: bool = True,
         force_disable_encrypt_cb: bool = False,
@@ -201,11 +201,8 @@ class PasswordLayout:
 
 class PasswordLayoutForHW(object):
 
-    def __init__(self, wallet, msg, kind, OK_button):
+    def __init__(self, msg, wallet=None):
         self.wallet = wallet
-
-        self.kind = kind
-        self.OK_button = OK_button
 
         vbox = QtWidgets.QVBoxLayout()
         label = QtWidgets.QLabel(msg + "\n")
@@ -287,7 +284,10 @@ class ChangePasswordDialogForSW(ChangePasswordDialogBase):
                 msg = _('Your wallet is password protected and encrypted.')
             msg += ' ' + _('Use this dialog to change your password.')
         self.playout = PasswordLayout(
-            wallet, msg, PW_CHANGE, OK_button,
+            msg=msg,
+            kind=PW_CHANGE,
+            OK_button=OK_button,
+            wallet=wallet,
             force_disable_encrypt_cb=not wallet.can_have_keystore_encryption())
 
     def run(self):
@@ -308,7 +308,7 @@ class ChangePasswordDialogForHW(ChangePasswordDialogBase):
             msg = _('Your wallet file is encrypted.')
         msg += '\n' + _('Note: If you enable this setting, you will need your hardware device to open your wallet.')
         msg += '\n' + _('Use this dialog to toggle encryption.')
-        self.playout = PasswordLayoutForHW(wallet, msg, PW_CHANGE, OK_button)
+        self.playout = PasswordLayoutForHW(msg)
 
     def run(self):
         if not self.exec_():

--- a/electroncash_plugins/hw_wallet/qt.py
+++ b/electroncash_plugins/hw_wallet/qt.py
@@ -30,7 +30,7 @@ import threading
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtGui import QIcon
 from PyQt5 import QtWidgets
-from electroncash_gui.qt.password_dialog import PasswordDialog, PW_PASSPHRASE
+from electroncash_gui.qt.password_dialog import PasswordLayout, PW_PASSPHRASE
 from electroncash_gui.qt.util import (
     Buttons,
     CancelButton,
@@ -128,11 +128,16 @@ class QtHandlerBase(QObject, PrintError):
     def passphrase_dialog(self, msg, confirm):
         # If confirm is true, require the user to enter the passphrase twice
         parent = self.top_level_window()
+        d = WindowModalDialog(parent, _("Enter Passphrase"))
         if confirm:
-            d = PasswordDialog(parent, None, msg, PW_PASSPHRASE)
-            confirmed, p, passphrase = d.run()
+            OK_button = OkButton(d)
+            playout = PasswordLayout(msg=msg, kind=PW_PASSPHRASE, OK_button=OK_button)
+            vbox = QtWidgets.QVBoxLayout()
+            vbox.addLayout(playout.layout())
+            vbox.addLayout(Buttons(CancelButton(d), OK_button))
+            d.setLayout(vbox)
+            passphrase = playout.new_password() if d.exec_() else None
         else:
-            d = WindowModalDialog(parent, _("Enter Passphrase"))
             pw = QtWidgets.QLineEdit()
             pw.setEchoMode(2)
             pw.setMinimumWidth(200)

--- a/electroncash_plugins/satochip/satochip.py
+++ b/electroncash_plugins/satochip/satochip.py
@@ -681,8 +681,8 @@ class SatochipPlugin(HW_PluginBase):
 
             hex_authentikey= authentikey.get_public_key_hex(compressed=True)
             self.print_error("setup_device(): authentikey=", hex_authentikey)#debugSatochip
-            wizard.storage.put('authentikey', hex_authentikey)
-            self.print_error("setup_device(): authentikey from storage=", wizard.storage.get('authentikey'))#debugSatochip
+            wizard.data['authentikey'] = hex_authentikey
+            self.print_error("setup_device(): authentikey from storage=", wizard.data['authentikey'])#debugSatochip
             break
 
     def get_xpub(self, device_id, derivation, xtype, wizard):


### PR DESCRIPTION
This PR cherry picks some refactoring commits from Electrum for storage.py. 

The goal here is to hopefully make it easier to address #144 in the future. Note that Electrum does not seem to intend to replace the JSON files with something more performant, but that's probably because they don't have a use case for wallets with tens of thousands of transactions.

To backport the storage updates, I had to also backport a stack of commits related to inbstallwizard.py, which interacts with the storage a lot when creating a new wallet or opening an existing wallet file.

I have reached a point where additional progress will requires to also backport a stack of wallet.py dependencies, so that I can create address_synchronizer.py, which has a lot of coupling with json_db.py. See:
 - https://github.com/spesmilo/electrum/commit/e3888752d6508ebbb9b4e9a8a09555914cd68fd2
 - https://github.com/spesmilo/electrum/commit/791e680a962f566ce4dba892fc0dfcb1b5ea2069
 
 I will stop this PR here for now. With the current state, we can already easily introduce a new database format in addition or replacement to JSON.