### PR TITLE
HW wallets and derivation paths

### DIFF
--- a/electroncash_plugins/hw_wallet/plugin.py
+++ b/electroncash_plugins/hw_wallet/plugin.py
@@ -39,6 +39,10 @@ class HW_PluginBase(BasePlugin):
     #     libraries_available, libraries_URL, minimum_firmware,
     #     wallet_class, ckd_public, types, HidTransport
 
+    # For now, Ledger and Trezor don't support the 899' derivation path.
+    # SatochipPlugin overrides this class attribute.
+    SUPPORTS_XEC_BIP44_DERIVATION: bool = False
+
     def __init__(self, parent, config, name):
         BasePlugin.__init__(self, parent, config, name)
         self.device = self.keystore_class.device
@@ -82,6 +86,10 @@ class HW_PluginBase(BasePlugin):
         if type(keystore) != self.keystore_class:
             return False
         return True
+
+    def supports_xec_bip44_derivation(self) -> bool:
+        return self.SUPPORTS_XEC_BIP44_DERIVATION
+
 
 def is_any_tx_output_on_change_branch(tx: Transaction) -> bool:
     if not tx.output_info:

--- a/electroncash_plugins/satochip/satochip.py
+++ b/electroncash_plugins/satochip/satochip.py
@@ -496,6 +496,8 @@ class Satochip_KeyStore(Hardware_KeyStore):
 
 
 class SatochipPlugin(HW_PluginBase):
+    SUPPORTS_XEC_BIP44_DERIVATION = True
+
     libraries_available = LIBS_AVAILABLE
     minimum_library = (0, 0, 0)
     keystore_class= Satochip_KeyStore


### PR DESCRIPTION
Satochip does not restrict the choices for derivation paths. At this time, using a Ledger device still requires to go through the BCH app, which requires the BCH derivation path.

As for Ledger devices, they seem to limit the choices to a whitelist. They unfortunately allow creating a wallet with a different path, but will refuse to sign transaction from it's keys.

- [x] don't suggest the BCH derivation path for satochip
- [ ] add a stronger warning about not using the XEC path for ledger
- [ ] check the latest status for Ledger via the BCH app, and apply the relevant improvement (suggest XEC path if possible, else show a stronger warning)