### PR TITLE
use the correct purpose when choosing hw device

### DIFF
--- a/electroncash/base_wizard.py
+++ b/electroncash/base_wizard.py
@@ -294,7 +294,7 @@ class BaseWizard(util.PrintError):
                 # This prevents showing an empty "UserCancelled" message
                 self.print_error(traceback.format_exc())
                 self.show_error(str(e))
-            self.choose_hw_device()
+            self.choose_hw_device(purpose)
             return
         if purpose == HWD_SETUP_NEW_WALLET:
             if self.wallet_type == 'multisig':


### PR DESCRIPTION

When for some reason the hw device fails setup (#170 for instance), make sure the hw selection is done again  with the same purpose. This prevents calling `on_device(purpose=HWD_SETUP_NEW_WALLET)` when the real purpose is to decrypt an existing wallet file (`HWD_SETUP_DECRYPT_WALLET`)
Closes #168