### PR TITLE
make address.to_ui_string print addresses with CashAddr prefixes

### DIFF
--- a/electroncash/address.py
+++ b/electroncash/address.py
@@ -428,9 +428,6 @@ class ScriptOutput(namedtuple("ScriptAddressTuple", "script")):
                 parts.append(lookup(op))
         return ', '.join(parts)
 
-    def to_full_ui_string(self):
-        return self.to_ui_string()
-
     def to_script(self):
         return self.script
 
@@ -690,7 +687,8 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
         )
         return verbyte in legacy_formats
 
-    def to_cashaddr(self, *, net=None):
+    def to_cashaddr(self, *, net=None) -> str:
+        """Return address string in CashAddr format (without prefix)"""
         if net is None: net = networks.net
         if self.kind == self.ADDR_P2PKH:
             kind  = cashaddr.PUBKEY_TYPE
@@ -698,7 +696,7 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
             kind  = cashaddr.SCRIPT_TYPE
         return cashaddr.encode(net.CASHADDR_PREFIX, kind, self.hash160)
 
-    def to_cashaddr_bch(self, *, net=None):
+    def to_cashaddr_bch(self, *, net=None) -> str:
         if net is None: net = networks.net
         if self.kind == self.ADDR_P2PKH:
             kind  = cashaddr.PUBKEY_TYPE
@@ -706,8 +704,11 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
             kind  = cashaddr.SCRIPT_TYPE
         return cashaddr.encode(net.CASHADDR_PREFIX_BCH, kind, self.hash160)
 
-    def to_string(self, fmt, *, net=None):
-        '''Converts to a string of the given format.'''
+    def to_string(self, fmt, *, net=None) -> str:
+        """Converts to a string of the given format.
+        CashAddr formats are produced without prefix.
+        """
+
         if net is None: net = networks.net
         if net is networks.net:
             try:
@@ -747,7 +748,7 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
             if cached is not None and net is networks.net:
                 self._addr2str_cache[fmt] = cached
 
-    def to_full_string(self, fmt, *, net=None):
+    def to_full_string(self, fmt, *, net=None) -> str:
         '''Convert to text, with a URI prefix for cashaddr format.'''
         if net is None: net = networks.net
         text = self.to_string(fmt, net=net)
@@ -757,13 +758,14 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
             text = ':'.join([net.CASHADDR_PREFIX_BCH, text])
         return text
 
-    def to_ui_string(self, *, net=None):
-        '''Convert to text in the current UI format choice.'''
+    def to_ui_string_without_prefix(self, *, net=None) -> str:
+        """Convert to text in the current UI format choice.
+        If the format is CashAddr, it is produced without the prefix."""
         if net is None: net = networks.net
         return self.to_string(self.FMT_UI, net=net)
 
-    def to_full_ui_string(self, *, net=None):
-        '''Convert to text, with a URI prefix if cashaddr.'''
+    def to_ui_string(self, *, net=None) -> str:
+        """Convert to text, with a URI prefix if cashaddr."""
         if net is None: net = networks.net
         return self.to_full_string(self.FMT_UI, net=net)
 
@@ -777,7 +779,7 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
             # keep producing bitcoincash: URIs when requested by users
             # until the ecosystem widely supports the new prefix
             scheme = net.CASHADDR_PREFIX_BCH
-        path = self.to_ui_string(net=net)
+        path = self.to_string(self.FMT_UI, net=net)
         return scheme, path
 
     def to_storage_string(self, *, net=None):

--- a/electroncash/address.py
+++ b/electroncash/address.py
@@ -27,6 +27,7 @@
 from collections import namedtuple
 import hashlib
 import struct
+from typing import Tuple
 
 from . import cashaddr, networks
 from enum import IntEnum
@@ -708,7 +709,6 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
         """Converts to a string of the given format.
         CashAddr formats are produced without prefix.
         """
-
         if net is None: net = networks.net
         if net is networks.net:
             try:
@@ -749,7 +749,7 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
                 self._addr2str_cache[fmt] = cached
 
     def to_full_string(self, fmt, *, net=None) -> str:
-        '''Convert to text, with a URI prefix for cashaddr format.'''
+        """Convert to text, with a URI prefix for cashaddr format."""
         if net is None: net = networks.net
         text = self.to_string(fmt, net=net)
         if fmt == self.FMT_CASHADDR:
@@ -769,16 +769,10 @@ class Address(namedtuple("AddressTuple", "hash160 kind")):
         if net is None: net = networks.net
         return self.to_full_string(self.FMT_UI, net=net)
 
-    def to_URI_components(self, *, net=None):
-        '''Returns a (scheme, path) pair for building a URI.'''
+    def to_URI_components(self, *, net=None) -> Tuple[str, str]:
+        """Returns a (scheme, path) pair for building a URI."""
         if net is None: net = networks.net
-
-        if self.FMT_UI != self.FMT_CASHADDR_BCH:
-            scheme = net.CASHADDR_PREFIX
-        else:
-            # keep producing bitcoincash: URIs when requested by users
-            # until the ecosystem widely supports the new prefix
-            scheme = net.CASHADDR_PREFIX_BCH
+        scheme = net.CASHADDR_PREFIX
         path = self.to_string(self.FMT_UI, net=net)
         return scheme, path
 

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -149,8 +149,6 @@ class Commands:
                 for i in range(0,len(l)): l[i] = DoChk(l[i]) # recurse
                 return l
             def EncodeNamedTupleObject(nt):
-                if hasattr(nt, 'to_full_ui_string'):
-                    return nt.to_full_ui_string()
                 if hasattr(nt, 'to_ui_string'):
                     return nt.to_ui_string()
                 return nt
@@ -292,7 +290,7 @@ class Commands:
         for i in l:
             v = i["value"]
             i["value"] = str(PyDecimal(v)/CASH) if v is not None else None
-            i["address"] = i["address"].to_full_ui_string()
+            i["address"] = i["address"].to_ui_string()
         return l
 
     @command('n')
@@ -663,7 +661,7 @@ class Commands:
                 continue
             if funded and self.wallet.is_empty(addr):
                 continue
-            item = addr.to_full_ui_string()
+            item = addr.to_ui_string()
             if labels or balance:
                 item = (item,)
             if balance:
@@ -719,7 +717,7 @@ class Commands:
             PR_EXPIRED: 'Expired',
             PR_UNCONFIRMED: 'Unconfirmed'
         }
-        out['address'] = out.get('address').to_full_ui_string()
+        out['address'] = out.get('address').to_ui_string()
         out[f'amount ({XEC.ticker})'] = format_satoshis(out.get('amount'))
         out['status'] = pr_str[out.get('status', PR_UNKNOWN)]
         return out
@@ -756,13 +754,13 @@ class Commands:
     @command('w')
     def createnewaddress(self):
         """Create a new receiving address, beyond the gap limit of the wallet"""
-        return self.wallet.create_new_address(False).to_full_ui_string()
+        return self.wallet.create_new_address(False).to_ui_string()
 
     @command('w')
     def getunusedaddress(self):
         """Returns the first unused address of the wallet, or None if all addresses are used.
         An address is considered as used if it has received a transaction, or if it is used in a payment request."""
-        return self.wallet.get_unused_address().to_full_ui_string()
+        return self.wallet.get_unused_address().to_ui_string()
 
     @command('w')
     def addrequest(self, amount, memo='', expiration=None, force=False, payment_url=None, index_url=None):

--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -159,9 +159,7 @@ class Imported_KeyStore(Software_KeyStore):
     def get_addresses(self):
         if not self._sorted:
             addresses = [pubkey.address for pubkey in self.keypairs]
-            self._sorted = sorted(
-                addresses, key=lambda address: address.to_full_ui_string()
-            )
+            self._sorted = sorted(addresses, key=lambda address: address.to_ui_string())
         return self._sorted
 
     def address_to_pubkey(self, address):

--- a/electroncash/paymentrequest.py
+++ b/electroncash/paymentrequest.py
@@ -261,7 +261,7 @@ class PaymentRequest:
     def get_address(self):
         o = self.outputs[0]
         assert o[0] == TYPE_ADDRESS
-        return o[1].to_full_ui_string()
+        return o[1].to_ui_string()
 
     def get_requestor(self):
         return self.requestor if self.requestor else self.get_address()
@@ -860,7 +860,7 @@ class PaymentRequest_BitPay20(PaymentRequest, PrintError):
                 else:
                     # TODO: Fixme -- for now this branch will always be taken because we turned off key download in _get_signing_keys() above
                     self.print_error('Warning: Could not verify whether signing public key is valid:', pubkey.hex(), "(PGP verification is currently disabled)")
-                self.requestor = sig_addr.to_full_ui_string()
+                self.requestor = sig_addr.to_ui_string()
                 break
         else:
             self.error = 'failed to verify signature against retrieved keys'

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -678,7 +678,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         if txs:
             self._addr_bal_cache = {}  # this is probably not necessary -- as the receive_history_callback will invalidate bad cache items -- but just to be paranoid we clear the whole balance cache on reorg anyway as a safety measure
         for tx_hash in txs:
-            self._update_request_statuses_touched_by_tx(tx_hash)    
+            self._update_request_statuses_touched_by_tx(tx_hash)
         return txs
 
     def get_local_height(self):
@@ -1683,9 +1683,9 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                     if x['type'] == 'coinbase': continue
                     addr = x.get('address')
                     if addr == None: continue
-                    input_addresses.append(addr.to_full_ui_string())
+                    input_addresses.append(addr.to_ui_string())
                 for _type, addr, v in tx.outputs():
-                    output_addresses.append(addr.to_full_ui_string())
+                    output_addresses.append(addr.to_ui_string())
                 item['input_addresses'] = input_addresses
                 item['output_addresses'] = output_addresses
             if fx is not None:
@@ -2354,7 +2354,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         if not r:
             return
         out = copy.copy(r)
-        addr_text = addr.to_full_ui_string()
+        addr_text = addr.to_ui_string()
         amount_text = format_satoshis(r['amount'])  # fixme: this should not be localized
         out['URI'] = '{}?amount={}'.format(addr_text, amount_text)
         status, conf = self.get_request_status(addr)
@@ -2490,7 +2490,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
                 f.write(pr.SerializeToString())
             # reload
             req = self.get_payment_request(addr, config)
-            req['address'] = req['address'].to_full_ui_string()
+            req['address'] = req['address'].to_ui_string()
             with open(os.path.join(path, key + '.json'), 'w', encoding='utf-8') as f:
                 f.write(json.dumps(req))
 
@@ -2878,7 +2878,7 @@ class ImportedAddressWallet(ImportedWalletBase):
     def get_addresses(self):
         if not self._sorted:
             self._sorted = sorted(self.addresses,
-                                  key=lambda addr: addr.to_full_ui_string())
+                                  key=lambda addr: addr.to_ui_string())
         return self._sorted
 
     def import_address(self, address):
@@ -2969,7 +2969,7 @@ class ImportedPrivkeyWallet(ImportedWalletBase):
         self.cashacct.save()
         self.save_addresses()
         self.storage.write()  # no-op if above already wrote
-        return pubkey.address.to_full_ui_string()
+        return pubkey.address.to_ui_string()
 
     def export_private_key(self, address, password):
         '''Returned in WIF format.'''

--- a/electroncash_gui/qt/address_dialog.py
+++ b/electroncash_gui/qt/address_dialog.py
@@ -157,7 +157,7 @@ class AddressDialog(PrintError, WindowModalDialog):
             self.update_cash_accounts()
 
     def update_addr(self):
-        self.addr_e.setText(self.address.to_full_ui_string())
+        self.addr_e.setText(self.address.to_ui_string())
 
     def update_cash_accounts(self, ca_infos=None):
         gb = self.cashacct_gb
@@ -184,7 +184,7 @@ class AddressDialog(PrintError, WindowModalDialog):
         return [self.address]
 
     def show_qr(self):
-        text = self.address.to_full_ui_string()
+        text = self.address.to_ui_string()
         try:
             self.parent.show_qrcode(text, 'Address', parent=self)
         except Exception as e:

--- a/electroncash_gui/qt/address_list.py
+++ b/electroncash_gui/qt/address_list.py
@@ -238,7 +238,7 @@ class AddressList(MyTreeWidget):
                 else:
                     is_hidden = self.wallet.is_used(address)
                 balance = sum(self.wallet.get_addr_balance(address))
-                address_text = address.to_full_ui_string()
+                address_text = address.to_ui_string()
                 # Cash Accounts
                 ca_info, ca_list = None, ca_by_addr.get(address)
                 if ca_list:
@@ -345,7 +345,7 @@ class AddressList(MyTreeWidget):
 
             alt_copy_text, alt_column_title = None, None
             if col == 0:
-                copy_text = addr.to_full_ui_string()
+                copy_text = addr.to_ui_string()
                 if Address.FMT_UI == Address.FMT_LEGACY:
                     alt_copy_text, alt_column_title = addr.to_full_string(
                         Address.FMT_CASHADDR
@@ -414,7 +414,7 @@ class AddressList(MyTreeWidget):
             # multi-select
             texts, alt_copy, alt_copy_text = None, None, None
             if col == 0:  # address column
-                texts = [a.to_full_ui_string() for a in addrs]
+                texts = [a.to_ui_string() for a in addrs]
                 # Add additional copy option: "Address, Balance (n)"
                 alt_copy = (
                     _("Copy {}").format(_("Address") + ", " + _("Balance"))
@@ -422,7 +422,7 @@ class AddressList(MyTreeWidget):
                 )
                 alt_copy_text = "\n".join(
                     [
-                        a.to_full_ui_string()
+                        a.to_ui_string()
                         + ", "
                         + self.parent.format_amount(
                             sum(self.wallet.get_addr_balance(a))
@@ -518,7 +518,7 @@ class AddressList(MyTreeWidget):
         if event.matches(QKeySequence.Copy) and self.currentColumn() == 0:
             addrs = [i.data(0, self.DataRoles.address) for i in self.selectedItems()]
             if addrs and isinstance(addrs[0], Address):
-                text = addrs[0].to_full_ui_string()
+                text = addrs[0].to_ui_string()
                 self.parent.app.clipboard().setText(text)
         else:
             super().keyPressEvent(event)
@@ -566,7 +566,7 @@ class AddressList(MyTreeWidget):
             return
         items = (
             self.findItems(
-                ca_info.address.to_full_ui_string(),
+                ca_info.address.to_ui_string(),
                 Qt.MatchContains | Qt.MatchWrap | Qt.MatchRecursive,
                 0,
             )

--- a/electroncash_gui/qt/bip38_importer.py
+++ b/electroncash_gui/qt/bip38_importer.py
@@ -189,7 +189,7 @@ class Bip38Importer(WindowModalDialog, util.PrintError):
         self.wif_lbl.setText((is_ok and self.decoded_wif) or bad_txt)
         # set adr_lbl font
         f = self.adr_lbl.font(); f.setFamily(MONOSPACE_FONT if is_ok else QFont().family()); f.setItalic(not is_ok); self.adr_lbl.setFont(f)
-        self.adr_lbl.setText((is_ok and self.decoded_address.to_full_ui_string()) or bad_txt)
+        self.adr_lbl.setText((is_ok and self.decoded_address.to_ui_string()) or bad_txt)
 
         self.ok.setEnabled(isinstance(self.decoded_address, address.Address))
         self.ok.setText(_('OK') if cur+1 == num else _("Next"))

--- a/electroncash_gui/qt/cashacctqt.py
+++ b/electroncash_gui/qt/cashacctqt.py
@@ -474,12 +474,12 @@ class InfoGroupBox(PrintError, QtWidgets.QGroupBox):
                 addr_lbl = ButtonAssociatedLabel('', button=rb)
                 if is_valid:
                     if is_mine:
-                        addr_lbl.setText(f'<a href="{info.address.to_full_ui_string()}"><pre>{info.address.to_full_ui_string()}</pre></a>')
+                        addr_lbl.setText(f'<a href="{info.address.to_ui_string()}"><pre>{info.address.to_ui_string()}</pre></a>')
                         addr_lbl.linkActivated.connect(view_addr_link_activated)
                         addr_lbl.setToolTip(_('Wallet') + ' - ' + (_('Change Address') if is_change else _('Receiving Address')))
                         addr_lbl.setButton(None)  # disable click to select
                     else:
-                        addr_lbl.setText(f'<pre>{info.address.to_full_ui_string()}</pre>')
+                        addr_lbl.setText(f'<pre>{info.address.to_ui_string()}</pre>')
                 else:
                     addr_lbl.setText('<i>' + _('Unsupported Account Type') + '</i>')
                     addr_lbl.setToolTip(rb.toolTip())
@@ -867,7 +867,7 @@ def cash_account_detail_dialog(parent : MessageBoxMixin,  # Should be an Electru
                                     parent.copy_to_clipboard(text=ca_string_em, tooltip=_('Cash Account copied to clipboard'), widget=copy_but) )
     grid.addWidget(copy_name_but, 0, 2, 1, 1)
     # address label
-    addr_lbl = QtWidgets.QLabel(f'<span style="white-space:nowrap; font-size:15pt;"><a href="{info.address.to_full_ui_string()}"><pre>{info.address.to_full_ui_string()}</pre></a></span>')
+    addr_lbl = QtWidgets.QLabel(f'<span style="white-space:nowrap; font-size:15pt;"><a href="{info.address.to_ui_string()}"><pre>{info.address.to_ui_string()}</pre></a></span>')
     addr_lbl.linkActivated.connect(open_link)
     grid.addWidget(addr_lbl, 1, 1, 1, 1)
     # copy address label
@@ -875,7 +875,7 @@ def cash_account_detail_dialog(parent : MessageBoxMixin,  # Should be an Electru
     copy_addr_but.setIcon(QIcon(":icons/copy.png"))
     button_make_naked(copy_addr_but)
     copy_addr_but.setToolTip(_("Copy {}").format(_("Address")))
-    copy_addr_but.clicked.connect(lambda ignored=None, text=info.address.to_full_ui_string(), copy_but=copy_addr_but:
+    copy_addr_but.clicked.connect(lambda ignored=None, text=info.address.to_ui_string(), copy_but=copy_addr_but:
                                     parent.copy_to_clipboard(text=text, tooltip=_('Address copied to clipboard'), widget=copy_but) )
     grid.addWidget(copy_addr_but, 1, 2, 1, 1)
 
@@ -895,7 +895,7 @@ def cash_account_detail_dialog(parent : MessageBoxMixin,  # Should be an Electru
 
     # QR
     tabs = QtWidgets.QTabWidget()
-    full_addr_str = info.address.to_full_ui_string()
+    full_addr_str = info.address.to_ui_string()
     qr_address = QRCodeWidget(full_addr_str, fixedSize=True)
     qr_address.setToolTip(full_addr_str)
     tabs.addTab(qr_address, _("Address"))

--- a/electroncash_gui/qt/consolidate_coins_dialog.py
+++ b/electroncash_gui/qt/consolidate_coins_dialog.py
@@ -110,9 +110,7 @@ class ConsolidateCoinsWizard(QtWidgets.QWizard, MessageBoxMixin):
         parent: Optional[QtWidgets.QWidget] = None,
     ):
         super().__init__(parent)
-        self.setWindowTitle(
-            f"Consolidate coins for address {address.to_full_ui_string()}"
-        )
+        self.setWindowTitle(f"Consolidate coins for address {address.to_ui_string()}")
 
         self.tx_thread: Optional[QtCore.QThread] = None
 

--- a/electroncash_gui/qt/contact_list.py
+++ b/electroncash_gui/qt/contact_list.py
@@ -354,7 +354,7 @@ class ContactList(PrintError, MyTreeWidget):
                 continue
             wallet_cashaccts.append(Contact(
                 name = name,
-                address = ca_info.address.to_full_ui_string(),
+                address = ca_info.address.to_ui_string(),
                 type = 'cashacct_W'
             ))
         # Add the [Pend] pseudo-contacts
@@ -367,7 +367,7 @@ class ContactList(PrintError, MyTreeWidget):
             name, address = tup
             wallet_cashaccts.append(Contact(
                 name = name,
-                address = address.to_full_ui_string(),
+                address = address.to_ui_string(),
                 type = 'cashacct_T'
             ))
         return wallet_cashaccts
@@ -412,7 +412,7 @@ class ContactList(PrintError, MyTreeWidget):
                 try:
                     # try and re-parse and re-display the address based on current UI string settings
                     addy = Address.from_string(address)
-                    address = addy.to_full_ui_string()
+                    address = addy.to_ui_string()
                     label_key = addy.to_storage_string()
                     del addy
                 except:
@@ -476,7 +476,7 @@ class ContactList(PrintError, MyTreeWidget):
         )
         if items:
             info, min_chash, name = items[0]
-            self.parent.set_contact(name, info.address.to_full_ui_string(), typ='cashacct')
+            self.parent.set_contact(name, info.address.to_ui_string(), typ='cashacct')
             run_hook('update_contacts_tab', self)
 
     def ca_update_potentially_unconfirmed_registrations(self, d : Dict[str, Tuple[str, Address]]):

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -800,7 +800,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             desc, address = tup
             if (desc and address and isinstance(desc, str) and isinstance(address, Address)
                     and desc not in d and not desc.lower().startswith(spv_prefix.lower())):
-                d[desc] = address.to_full_ui_string()
+                d[desc] = address.to_ui_string()
         def do_payto(desc):
             addr = d[desc]
             # The message is intentionally untranslated, leave it like that
@@ -1511,7 +1511,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
     def update_receive_address_widget(self):
         text = ''
         if self.receive_address:
-            text = self.receive_address.to_full_ui_string()
+            text = self.receive_address.to_ui_string()
         self.receive_address_e.setText(text)
         self.cash_account_e.set_cash_acct()
 
@@ -1596,7 +1596,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         # Special case hack -- see #1473. Omit bitcoincash: prefix from
         # legacy address if no other params present in receive request.
         if Address.FMT_UI == Address.FMT_LEGACY and not kwargs and not amount and not message:
-            uri = self.receive_address.to_ui_string()
+            uri = self.receive_address.to_ui_string_without_prefix()
         else:
             # Otherwise proceed as normal, prepending bitcoincash: to URI
             uri = web.create_URI(self.receive_address, amount, message, **kwargs)
@@ -2701,7 +2701,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
 
     def remove_address(self, addr):
         if self.question(_("Do you want to remove {} from your wallet?"
-                           .format(addr.to_full_ui_string()))):
+                           .format(addr.to_ui_string()))):
             self.wallet.delete_address(addr)
             self.update_tabs()
             self.update_status()
@@ -2793,7 +2793,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
                 self.contact_list.update() # Displays original
                 return
             info, label = tup
-            address = info.address.to_full_ui_string()
+            address = info.address.to_ui_string()
             contact = Contact(name=label, address=address, type=typ)
         elif not Address.is_valid(address):
             # Bad 'address' code path
@@ -2862,7 +2862,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         grid.addWidget(QtWidgets.QLabel(_("Requestor") + ':'), 0, 0)
         grid.addWidget(QtWidgets.QLabel(pr.get_requestor()), 0, 1)
         grid.addWidget(QtWidgets.QLabel(_("Amount") + ':'), 1, 0)
-        outputs_str = '\n'.join(map(lambda x: self.format_amount(x[2])+ self.base_unit() + ' @ ' + x[1].to_full_ui_string(), pr.get_outputs()))
+        outputs_str = '\n'.join(map(lambda x: self.format_amount(x[2])+ self.base_unit() + ' @ ' + x[1].to_ui_string(), pr.get_outputs()))
         grid.addWidget(QtWidgets.QLabel(outputs_str), 1, 1)
         expires = pr.get_expiration_date()
         grid.addWidget(QtWidgets.QLabel(_("Memo") + ':'), 2, 0)
@@ -3351,7 +3351,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         layout.setRowStretch(2,3)
 
         address_e = QtWidgets.QLineEdit()
-        address_e.setText(address.to_full_ui_string() if address else '')
+        address_e.setText(address.to_ui_string() if address else '')
         layout.addWidget(QtWidgets.QLabel(_('Address')), 2, 0)
         layout.addWidget(address_e, 2, 1)
 
@@ -3715,7 +3715,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
                 except InvalidPassword:
                     # See #921 -- possibly a corrupted wallet or other strangeness
                     privkey = 'INVALID_PASSWORD'
-                private_keys[addr.to_full_ui_string()] = privkey
+                private_keys[addr.to_ui_string()] = privkey
                 strong_d = weak_d()
                 try:
                     if strong_d and not stop:
@@ -5226,7 +5226,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             le.addWidget(help_but)
             name = line_dialog(self.top_level_window(),
                                _("Register A New Cash Account"),
-                               (_("You are registering a new <a href='ca'>Cash Account</a> for your address <a href='addr'><b><pre>{address}</pre></b></a>").format(address=addr.to_full_ui_string())
+                               (_("You are registering a new <a href='ca'>Cash Account</a> for your address <a href='addr'><b><pre>{address}</pre></b></a>").format(address=addr.to_ui_string())
                                 + _("The current block height is <b><i>{block_height}</i></b>, so the new cash account will likely look like: <b><u><i>AccountName<i>#{number}</u></b>.")
                                 .format(block_height=lh or '???', number=max(cashacct.bh2num(lh or 0)+1, 0) or '???')
                                 + "<br><br><br>" + _("Specify the <b>account name</b> below (limited to 99 characters):") ),
@@ -5268,7 +5268,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         # Set a default description -- this we allow them to edit
         self.message_e.setText(
             _("Cash Accounts Registration: '{name}' -> {address}").format(
-                name=name, address=addr.to_full_ui_string()
+                name=name, address=addr.to_ui_string()
             )
         )
 

--- a/electroncash_gui/qt/paytoedit.py
+++ b/electroncash_gui/qt/paytoedit.py
@@ -356,7 +356,7 @@ class PayToEdit(PrintError, ScanQRTextEdit):
         if isinstance(address, str):
             address_str = address
         elif isinstance(address, Address):
-            address_str = address.to_full_ui_string()
+            address_str = address.to_ui_string()
         else:
             raise RuntimeError('unknown address type')
 
@@ -410,7 +410,7 @@ class PayToEdit(PrintError, ScanQRTextEdit):
                 parts = [ca_string]  # strip down to JUST ca_string
             ca_info = wallet.cashacct.get_verified(ca_string)
             if ca_info:
-                resolved = wallet.cashacct.fmt_info(ca_info) + " " + ca_info.emoji + " <" + ca_info.address.to_full_ui_string() + ">"
+                resolved = wallet.cashacct.fmt_info(ca_info) + " " + ca_info.emoji + " <" + ca_info.address.to_ui_string() + ">"
                 lines[n] = line = resolved + " ".join(parts[1:])  # rewrite line, putting the resolved cash account + <address> at the beginning, amount at the end (if any)
             else:
                 lines[n] = line = " ".join(parts)  # rewrite line, possibly stripping <> address here

--- a/electroncash_gui/qt/request_list.py
+++ b/electroncash_gui/qt/request_list.py
@@ -63,7 +63,7 @@ class RequestList(MyTreeWidget):
         opr_is_raw = bool(req.get('op_return_raw'))
         message = self.wallet.labels.get(addr.to_storage_string(), '')
         self.parent.receive_address = addr
-        self.parent.receive_address_e.setText(addr.to_full_ui_string())
+        self.parent.receive_address_e.setText(addr.to_ui_string())
         self.parent.receive_message_e.setText(message)
         self.parent.receive_amount_e.setAmount(amount)
         self.parent.expires_combo.hide()
@@ -129,7 +129,7 @@ class RequestList(MyTreeWidget):
             signature = req.get('sig')
             requestor = req.get('name', '')
             amount_str = self.parent.format_amount(amount) if amount else ""
-            item = QtWidgets.QTreeWidgetItem([date, address.to_full_ui_string(), '', message,
+            item = QtWidgets.QTreeWidgetItem([date, address.to_ui_string(), '', message,
                                     amount_str, _(pr_tooltips.get(status,''))])
             item.setData(0, Qt.UserRole, address)
             if signature is not None:

--- a/electroncash_gui/qt/transaction_dialog.py
+++ b/electroncash_gui/qt/transaction_dialog.py
@@ -637,12 +637,12 @@ class TxDialog(QtWidgets.QDialog, MessageBoxMixin, PrintError):
                 if self.wallet.is_change(addr):
                     chg_ct += 1
                     chg2 = QTextCharFormat(chg)
-                    chg2.setAnchorHref(addr.to_full_ui_string())
+                    chg2.setAnchorHref(addr.to_ui_string())
                     return chg2
                 else:
                     rec_ct += 1
                     rec2 = QTextCharFormat(rec)
-                    rec2.setAnchorHref(addr.to_full_ui_string())
+                    rec2.setAnchorHref(addr.to_ui_string())
                     return rec2
             return ext
 
@@ -673,7 +673,7 @@ class TxDialog(QtWidgets.QDialog, MessageBoxMixin, PrintError):
                 if addr is None:
                     addr_text = _('unknown')
                 else:
-                    addr_text = addr.to_full_ui_string()
+                    addr_text = addr.to_ui_string()
                 cursor.insertText(addr_text, text_format(addr))
                 if x.get('value'):
                     cursor.insertText(format_amount(x['value']), ext)
@@ -719,7 +719,7 @@ class TxDialog(QtWidgets.QDialog, MessageBoxMixin, PrintError):
             # Format Cash Accounts address *in* script to be highlighted with
             # our preferred yellow/green for change/receiving and also
             # linkify it.
-            addrstr = addr.to_full_ui_string()
+            addrstr = addr.to_ui_string()
             my_addr_in_script_str = my_addr_in_script and my_addr_in_script.to_ui_string()
             idx = my_addr_in_script_str and addrstr.find(my_addr_in_script_str)
             if idx is not None and idx > -1:
@@ -846,8 +846,8 @@ class TxDialog(QtWidgets.QDialog, MessageBoxMixin, PrintError):
         menu.exec_(global_pos)
 
     def _add_addr_to_io_menu_lists_for_widget(self, addr, show_list, copy_list, widget):
-        if hasattr(addr, 'to_full_ui_string'):
-            addr_text = addr.to_full_ui_string()
+        if hasattr(addr, 'to_ui_string'):
+            addr_text = addr.to_ui_string()
             if isinstance(addr, Address) and self.wallet.is_mine(addr):
                 show_list += [ ( _("Address Details"), lambda: self._open_internal_link(addr_text) ) ]
                 addr_URL = web.BE_URL(self.main_window.config, web.ExplorerUrlParts.ADDR, addr)
@@ -889,7 +889,7 @@ class TxDialog(QtWidgets.QDialog, MessageBoxMixin, PrintError):
                 value_fmtd = self.main_window.format_amount(value)
                 copy_list += [ ( _("Copy Amount"), lambda: self._copy_to_clipboard(value_fmtd, o_text) ) ]
             if ca_script:
-                copy_list += [ ( _("Copy Address (Embedded)"), lambda: self._copy_to_clipboard(ca_script.address.to_full_ui_string(), o_text) ) ]
+                copy_list += [ ( _("Copy Address (Embedded)"), lambda: self._copy_to_clipboard(ca_script.address.to_ui_string(), o_text) ) ]
                 if ca_script.is_complete() and self.tx_hash:
                     text_getter = lambda: self.wallet.cashacct.fmt_info(cashacct.Info.from_script(ca_script, self.tx_hash), emoji=True)
                     text_getter()  # go out to network to cache the shortest encoding for cash account name ahead of time...

--- a/electroncash_gui/qt/util.py
+++ b/electroncash_gui/qt/util.py
@@ -516,7 +516,7 @@ class ChoicesLayout(object):
 
 def address_combo(addresses):
     addr_combo = QtWidgets.QComboBox()
-    addr_combo.addItems(addr.to_full_ui_string() for addr in addresses)
+    addr_combo.addItems(addr.to_ui_string() for addr in addresses)
     addr_combo.setCurrentIndex(0)
 
     hbox = QtWidgets.QHBoxLayout()

--- a/electroncash_gui/qt/utxo_list.py
+++ b/electroncash_gui/qt/utxo_list.py
@@ -140,7 +140,7 @@ class UTXOList(MyTreeWidget):
             self.utxos = self.wallet.get_utxos(exclude_slp=False)
         for x in self.utxos:
             address = x['address']
-            address_text = address.to_full_ui_string()
+            address_text = address.to_ui_string()
             ca_info = None
             ca_list = ca_by_addr.get(address)
             tool_tip0 = None
@@ -255,7 +255,7 @@ class UTXOList(MyTreeWidget):
                     copy_text = item.data(0, self.DataRoles.name)
                 elif col == self.Col.address:
                     # Determine the "alt copy text" "Legacy Address" or "Cash Address"
-                    copy_text = addr.to_full_ui_string()
+                    copy_text = addr.to_ui_string()
                     if Address.FMT_UI == Address.FMT_LEGACY:
                         alt_copy_text, alt_column_title = addr.to_full_string(Address.FMT_CASHADDR), _('Cash Address')
                     else:

--- a/electroncash_gui/text.py
+++ b/electroncash_gui/text.py
@@ -154,7 +154,7 @@ class ElectrumGui:
         self.stdscr.addstr(self.maxy -1, self.maxx-30, ' '.join([_("Settings"), _("Network"), _("Quit")]))
 
     def print_receive(self):
-        addr = self.wallet.get_receiving_address().to_full_ui_string()
+        addr = self.wallet.get_receiving_address().to_ui_string()
         self.stdscr.addstr(2, 1, "Address: "+addr)
         self.print_qr(addr)
 

--- a/electroncash_plugins/fusion/server.py
+++ b/electroncash_plugins/fusion/server.py
@@ -324,7 +324,7 @@ class FusionServer(GenericServer):
 
         donation_address = ''
         if isinstance(self.donation_address, Address):
-            donation_address = self.donation_address.to_full_ui_string()
+            donation_address = self.donation_address.to_ui_string()
 
         client.send(pb.ServerHello( num_components = Params.num_components,
                                     component_feerate = Params.component_feerate,

--- a/electroncash_plugins/ledger/auth2fa.py
+++ b/electroncash_plugins/ledger/auth2fa.py
@@ -110,7 +110,7 @@ class LedgerAuthDialog(QtWidgets.QDialog):
 
                 # We also show the UI address if it is different
                 if networks.net.TESTNET or not Address.FMT_UI == Address.FMT_LEGACY:
-                    addressstr = address.to_full_ui_string() + '\n' + addressstr
+                    addressstr = address.to_ui_string() + '\n' + addressstr
 
                 self.addrtext.setHtml(str(addressstr))
             else:


### PR DESCRIPTION
We started using `to_full_ui_string` almost everywhere in #61, so it makes sense to rename `to_full_ui_string` to `to_ui_string`, and use `to_ui_string_without_prefix` for the rare instances when we don't wan't the prefix.

This fixes also a bug because `to_full_ui_string` was called on a `PublicKey` object, which does not implement this method (but it has `to_ui_string`). Closes #172.