### PR TITLE
Support legacy message signatures

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,8 @@ files: |
         electroncash_gui/qt/amountedit.py|
         electroncash_gui/qt/consolidate_coins_dialog.py|
         electroncash_gui/qt/exception_window.py|
-        electroncash_gui/qt/multi_transactions_dialog.py
+        electroncash_gui/qt/multi_transactions_dialog.py|
+        electroncash_gui/qt/sign_verify_dialog.py
     )$
 repos:
 -   repo: https://github.com/pycqa/isort

--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -34,6 +34,7 @@ from mnemonic import Mnemonic
 
 from . import bitcoin, mnemo, networks
 from .address import Address, PublicKey
+from .bitcoin import SignatureType
 from .plugins import run_hook
 from .util import InvalidPassword, PrintError, bh2u, print_error
 
@@ -99,10 +100,10 @@ class Software_KeyStore(KeyStore):
     def may_have_password(self):
         return not self.is_watching_only()
 
-    def sign_message(self, sequence, message, password):
+    def sign_message(self, sequence, message, password, sigtype=SignatureType.ECASH):
         privkey, compressed = self.get_private_key(sequence, password)
         key = bitcoin.regenerate_key(privkey)
-        return key.sign_message(message, compressed)
+        return key.sign_message(message, compressed, sigtype)
 
     def decrypt_message(self, sequence, message, password):
         privkey, compressed = self.get_private_key(sequence, password)

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -2623,9 +2623,11 @@ class Abstract_Wallet(PrintError, SPVDelegate):
 
         self.storage.write()
 
-    def sign_message(self, address, message, password):
+    def sign_message(
+        self, address, message, password, sigtype=bitcoin.SignatureType.ECASH
+    ):
         index = self.get_address_index(address)
-        return self.keystore.sign_message(index, message, password)
+        return self.keystore.sign_message(index, message, password, sigtype)
 
     def decrypt_message(self, pubkey, message, password):
         addr = self.pubkeys_to_address(pubkey)

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -2719,6 +2719,9 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         # 'ask me per tx', so for now True -> 2.
         self.storage.put('sign_schnorr', 2 if b else 0)
 
+    def is_watching_only(self):
+        raise NotImplementedError()
+
 
 class Simple_Wallet(Abstract_Wallet):
     # wallet with a single keystore

--- a/electroncash_gui/qt/password_dialog.py
+++ b/electroncash_gui/qt/password_dialog.py
@@ -339,6 +339,7 @@ class PasswordDialog(WindowModalDialog):
             return
         return self.pw.text()
 
+
 class PassphraseDialog(WindowModalDialog):
     ''' Use this window to query the user to input a passphrase eg for
     things like the Bip38 export facility in the GUI. '''

--- a/electroncash_gui/qt/sign_verify_dialog.py
+++ b/electroncash_gui/qt/sign_verify_dialog.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import base64
+from functools import partial
+from typing import TYPE_CHECKING, Optional
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import (
+    QDialog,
+    QGridLayout,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QTextEdit,
+)
+
+from electroncash import bitcoin
+from electroncash.address import Address
+from electroncash.constants import CURRENCY, PROJECT_NAME
+from electroncash.i18n import _
+
+from .password_dialog import PasswordDialog
+from .util import MessageBoxMixin
+
+if TYPE_CHECKING:
+    from electroncash.wallet import Abstract_Wallet
+
+
+class SignVerifyDialog(QDialog, MessageBoxMixin):
+    def __init__(
+        self, wallet: Abstract_Wallet, address: Optional[Address] = None, parent=None
+    ):
+        super().__init__(parent)
+        self.setWindowModality(Qt.WindowModal)
+        self.setWindowTitle(_("Sign/verify Message"))
+        self.setMinimumSize(610, 290)
+
+        self.wallet = wallet
+
+        layout = QGridLayout(self)
+        self.setLayout(layout)
+
+        self.message_e = QTextEdit()
+        self.message_e.setAcceptRichText(False)
+        layout.addWidget(QLabel(_("Message")), 1, 0)
+        layout.addWidget(self.message_e, 1, 1)
+        layout.setRowStretch(2, 3)
+
+        self.address_e = QLineEdit()
+        self.address_e.setText(address.to_ui_string() if address else "")
+        layout.addWidget(QLabel(_("Address")), 2, 0)
+        layout.addWidget(self.address_e, 2, 1)
+
+        self.signature_e = QTextEdit()
+        self.signature_e.setAcceptRichText(False)
+        layout.addWidget(QLabel(_("Signature")), 3, 0)
+        layout.addWidget(self.signature_e, 3, 1)
+        layout.setRowStretch(3, 1)
+
+        hbox = QHBoxLayout()
+
+        b = QPushButton(_("Sign"))
+        b.clicked.connect(lambda: self.do_sign())
+        hbox.addWidget(b)
+
+        b = QPushButton(_("Verify"))
+        b.clicked.connect(lambda: self.do_verify())
+        hbox.addWidget(b)
+
+        b = QPushButton(_("Close"))
+        b.clicked.connect(self.accept)
+        hbox.addWidget(b)
+        layout.addLayout(hbox, 4, 1)
+
+    def _get_password(self) -> Optional[str]:
+        password = None
+        while self.wallet.has_keystore_encryption():
+            password = PasswordDialog(self).run()
+            if password is None:
+                return
+            try:
+                self.wallet.check_password(password)
+                break
+            except Exception as e:
+                self.show_error(str(e))
+                continue
+        return password
+
+    def do_sign(self):
+        password = self._get_password()
+        address = self.address_e.text().strip()
+        message = self.message_e.toPlainText().strip()
+        try:
+            addr = Address.from_string(address)
+        except Exception:
+            self.show_message(_(f"Invalid {CURRENCY} address."))
+            return
+        if addr.kind != addr.ADDR_P2PKH:
+            msg_sign = (
+                _(
+                    "Signing with an address actually means signing with the corresponding "
+                    "private key, and verifying with the corresponding public key. The "
+                    "address you have entered does not have a unique public key, so these "
+                    "operations cannot be performed."
+                )
+                + "\n\n"
+                + _(
+                    f"The operation is undefined. Not just in "
+                    f"{PROJECT_NAME}, but in general."
+                )
+            )
+            self.show_message(
+                _("Cannot sign messages with this type of address.") + "\n\n" + msg_sign
+            )
+            return
+        if self.wallet.is_watching_only():
+            self.show_message(_("This is a watching-only wallet."))
+            return
+        if not self.wallet.is_mine(addr):
+            self.show_message(_("Address not in wallet."))
+            return
+        task = partial(self.wallet.sign_message, addr, message, password)
+
+        def show_signed_message(sig):
+            self.signature_e.setText(base64.b64encode(sig).decode("ascii"))
+
+        self.wallet.thread.add(task, on_success=show_signed_message)
+
+    def do_verify(self):
+        try:
+            address = Address.from_string(self.address_e.text().strip())
+        except Exception:
+            self.show_message(_(f"Invalid {CURRENCY} address."))
+            return
+        message = self.message_e.toPlainText().strip().encode("utf-8")
+        try:
+            # This can throw on invalid base64
+            sig = base64.b64decode(self.signature_e.toPlainText())
+            verified = bitcoin.verify_message(address, sig, message)
+        except Exception:
+            verified = False
+
+        if verified:
+            self.show_message(_("Signature verified"))
+        else:
+            self.show_error(_("Wrong signature"))

--- a/electroncash_plugins/digitalbitbox/digitalbitbox.py
+++ b/electroncash_plugins/digitalbitbox/digitalbitbox.py
@@ -5,7 +5,7 @@
 
 try:
     from electroncash.bitcoin import TYPE_ADDRESS, push_script, var_int, msg_magic, Hash, verify_message, pubkey_from_signature, point_to_ser, public_key_to_p2pkh, EncodeAES_base64, MyVerifyingKey, int_to_hex, hmac_oneshot, EncodeAES_bytes, DecodeAES_bytes
-    from electroncash.bitcoin import serialize_xpub, deserialize_xpub
+    from electroncash.bitcoin import serialize_xpub, deserialize_xpub, SignatureType
     from electroncash.transaction import Transaction
     from electroncash.i18n import _
     from electroncash.keystore import Hardware_KeyStore
@@ -451,7 +451,11 @@ class DigitalBitbox_KeyStore(Hardware_KeyStore):
         raise RuntimeError(_('Encryption and decryption are currently not supported for {}').format(self.device))
 
 
-    def sign_message(self, sequence, message, password):
+    def sign_message(self, sequence, message, password, sigtype=SignatureType.BITCOIN):
+        if sigtype == SignatureType.ECASH:
+            raise RuntimeError(
+                _('eCash message signing is not available for {}').format(self.device)
+            )
         sig = None
         try:
             message = message.encode('utf8')

--- a/electroncash_plugins/keepkey/keepkey.py
+++ b/electroncash_plugins/keepkey/keepkey.py
@@ -1,7 +1,7 @@
 from binascii import hexlify, unhexlify
 
 from electroncash.util import bfh, bh2u, UserCancelled
-from electroncash.bitcoin import TYPE_ADDRESS, TYPE_SCRIPT, deserialize_xpub
+from electroncash.bitcoin import TYPE_ADDRESS, TYPE_SCRIPT, SignatureType, deserialize_xpub
 from electroncash import networks
 from electroncash.i18n import _
 from electroncash.transaction import deserialize, Transaction
@@ -33,7 +33,11 @@ class KeepKey_KeyStore(Hardware_KeyStore):
     def decrypt_message(self, sequence, message, password):
         raise RuntimeError(_('Encryption and decryption are not implemented by {}').format(self.device))
 
-    def sign_message(self, sequence, message, password):
+    def sign_message(self, sequence, message, password, sigtype=SignatureType.BITCOIN):
+        if sigtype == SignatureType.ECASH:
+            raise RuntimeError(
+                _('eCash message signing is not available for {}').format(self.device)
+            )
         client = self.get_client()
         address_path = self.get_derivation() + "/%d/%d"%sequence
         address_n = client.expand_path(address_path)

--- a/electroncash_plugins/ledger/ledger.py
+++ b/electroncash_plugins/ledger/ledger.py
@@ -6,7 +6,7 @@ import inspect
 
 from electroncash import bitcoin
 from electroncash.address import Address, OpCodes
-from electroncash.bitcoin import TYPE_ADDRESS, TYPE_SCRIPT, int_to_hex, var_int
+from electroncash.bitcoin import TYPE_ADDRESS, TYPE_SCRIPT, int_to_hex, var_int, SignatureType
 from electroncash.i18n import _
 from electroncash.plugins import BasePlugin
 from electroncash.keystore import Hardware_KeyStore
@@ -300,7 +300,11 @@ class Ledger_KeyStore(Hardware_KeyStore):
 
     @test_pin_unlocked
     @set_and_unset_signing
-    def sign_message(self, sequence, message, password):
+    def sign_message(self, sequence, message, password, sigtype=SignatureType.BITCOIN):
+        if sigtype == SignatureType.ECASH:
+            raise RuntimeError(
+                _('eCash message signing is not available for {}').format(self.device)
+            )
         message = message.encode('utf8')
         message_hash = hashlib.sha256(message).hexdigest().upper()
         # prompt for the PIN before displaying the dialog if necessary

--- a/electroncash_plugins/satochip/satochip.py
+++ b/electroncash_plugins/satochip/satochip.py
@@ -16,7 +16,7 @@ from electroncash.keystore import Hardware_KeyStore
 from electroncash.transaction import Transaction
 from electroncash.wallet import Standard_Wallet
 from electroncash.util import print_error, bfh, bh2u, PrintError, is_verbose
-from electroncash.bitcoin import hash_160, Hash
+from electroncash.bitcoin import hash_160, Hash, SignatureType
 from electroncash.mnemo import (
     Mnemonic_Electrum, seed_type_name, is_seed, bip39_mnemonic_to_seed)
 from electroncash.bitcoin import serialize_xpub
@@ -301,8 +301,7 @@ class Satochip_KeyStore(Hardware_KeyStore):
     def decrypt_message(self, pubkey, message, password):
         raise RuntimeError(_('Encryption and decryption are currently not supported for {}').format(self.device))
 
-    def sign_message(self, sequence, message, password):
-
+    def sign_message(self, sequence, message, password, sigtype=SignatureType.ECASH):
         message_byte = message.encode('utf8')
         message_hash = hashlib.sha256(message_byte).hexdigest().upper()
         client = self.get_client()
@@ -356,7 +355,10 @@ class Satochip_KeyStore(Hardware_KeyStore):
                 # self.handler.show_error(_("Wrong signature!\nThe 2FA device may have rejected the action."))
             # else:
                 # compsig=client.parser.parse_message_signature(response2, message_byte, pubkey)
-            (response2, sw1, sw2, compsig) = client.cc.card_sign_message(keynbr, pubkey, message_byte, hmac, altcoin="eCash")
+            altcoin = "eCash" if sigtype == SignatureType.ECASH else None
+            (response2, sw1, sw2, compsig) = client.cc.card_sign_message(
+                keynbr, pubkey, message_byte, hmac, altcoin=altcoin
+            )
             if (compsig==b''):
                 self.handler.show_error(_("Wrong signature!\nThe 2FA device may have rejected the action."))
 

--- a/electroncash_plugins/trezor/trezor.py
+++ b/electroncash_plugins/trezor/trezor.py
@@ -5,7 +5,7 @@ import sys
 
 from electroncash.util import bfh, bh2u, versiontuple, UserCancelled
 from electroncash.bitcoin import (b58_address_to_hash160, xpub_from_pubkey, deserialize_xpub,
-                                  TYPE_ADDRESS, TYPE_SCRIPT)
+                                  TYPE_ADDRESS, TYPE_SCRIPT, SignatureType)
 from electroncash.i18n import _
 from electroncash.networks import NetworkConstants
 from electroncash.plugins import BasePlugin, Device
@@ -62,7 +62,11 @@ class TrezorKeyStore(Hardware_KeyStore):
     def decrypt_message(self, sequence, message, password):
         raise RuntimeError(_('Encryption and decryption are not implemented by {}').format(self.device))
 
-    def sign_message(self, sequence, message, password):
+    def sign_message(self, sequence, message, password, sigtype=SignatureType.BITCOIN):
+        if sigtype == SignatureType.ECASH:
+            raise RuntimeError(
+                _('eCash message signing is not available for {}').format(self.device)
+            )
         client = self.get_client()
         address_path = self.get_derivation() + "/%d/%d"%sequence
         msg_sig = client.sign_message(address_path, message)


### PR DESCRIPTION
This adds support for both bitcoin signed messages and eCash signed messages in the user interface. The default remains eCash signed messages, but now there is an "advanced settings" menu to select the Bitcoin option and allow users to verify signatures generated by Electron Cash, Electrum, older versions of Electrum ABC, hardware wallets that are still incompatible with eCash signed messages, other BTC or BCH libraries...

Closes #167 

This also disables eCash message signing for hardware wallet that don't support it, and enables both signature schemes for satochip wallets.