### PR TITLE
fix reading QR code from camera

### DIFF
--- a/electroncash_gui/qt/utils/image_effect.py
+++ b/electroncash_gui/qt/utils/image_effect.py
@@ -28,17 +28,18 @@ from PyQt5 import QtWidgets
 from PyQt5.QtGui import QImage, QPainter, QPixmap
 from PyQt5.QtCore import QObject, Qt
 
+
 class ImageGraphicsEffect(QObject):
     """
     Applies a QGraphicsEffect to a QImage
     """
 
-    def __init__(self, parent: QObject, effect:QtWidgets.QGraphicsEffect):
+    def __init__(self, parent: QObject, effect: QtWidgets.QGraphicsEffect):
         super().__init__(parent)
         assert effect, 'effect must be set'
         self.effect = effect
-        self.graphics_scene =QtWidgets.QGraphicsScene()
-        self.graphics_item =QtWidgets.QGraphicsScene()
+        self.graphics_scene = QtWidgets.QGraphicsScene()
+        self.graphics_item = QtWidgets.QGraphicsPixmapItem()
         self.graphics_item.setGraphicsEffect(effect)
         self.graphics_scene.addItem(self.graphics_item)
 


### PR DESCRIPTION
Use a graphics item instead of a graphics scene. 
This code was broken in #146 when I removed all the `from PyQt4.QtWidgets import *`.

Closes #178