### PR TITLE
Remove "fuse depth" setting from CashFusion

### DIFF
--- a/electroncash/transaction.py
+++ b/electroncash/transaction.py
@@ -418,12 +418,6 @@ class Transaction:
         # there!
         self.ephemeral = dict()
 
-    def is_memory_compact(self):
-        """Returns True if the tx is stored in memory only as self.raw (serialized) and has no deserialized data
-        structures currently in memory. """
-        return (self.raw is not None
-                and self._inputs is None and self._outputs is None and self.locktime == 0 and self.version == 1)
-
     def set_sign_schnorr(self, b):
         self._sign_schnorr = b
 

--- a/electroncash_plugins/fusion/conf.py
+++ b/electroncash_plugins/fusion/conf.py
@@ -53,7 +53,6 @@ class Conf:
         CoinbaseSeenLatch = False
         FusionMode = 'normal'
         QueudAutofuse = 4
-        FuseDepth = 0  # Fuse forever by default
         Selector = ('fraction', 0.1)  # coin selector options
         SelfFusePlayers = 1 # self-fusing control (1 = just self, more than 1 = self fuse up to N times)
         SpendOnlyFusedCoins = False  # spendable_coin_filter @hook
@@ -121,16 +120,6 @@ class Conf:
             assert i >= 1
             i = int(i)
         self.wallet.storage.put('cashfusion_queued_autofuse', i)
-
-    @property
-    def fuse_depth(self) -> int:
-        return int(self.wallet.storage.get('cashfusion_fuse_depth', self.Defaults.FuseDepth))
-    @fuse_depth.setter
-    def fuse_depth(self, i : Optional[int]):
-        if i is not None:
-            assert i >= 0
-            i = int(i)
-        self.wallet.storage.put('cashfusion_fuse_depth', i)
 
     @property
     def selector(self) -> Tuple[str, Union[int,float]]:

--- a/electroncash_plugins/fusion/plugin.py
+++ b/electroncash_plugins/fusion/plugin.py
@@ -771,16 +771,6 @@ class FusionPlugin(BasePlugin):
         return answer
 
     @classmethod
-    def get_coin_known_fuz_count(cls, wallet, coin, *, require_depth=0):
-        res = cls.is_fuz_coin(wallet, coin, require_depth=require_depth)
-        if require_depth > 0:
-            # check if has at least 1 fusion
-            res = cls.is_fuz_coin(wallet, coin, require_depth=0)
-        if res:
-            return wallet._cashfusion_is_fuz_txid_cache.get(coin['prevout_hash'], 0) + 1
-        return 0
-
-    @classmethod
     def is_fuz_address(cls, wallet, address, *, require_depth=0):
         """ Returns True if address contains any fused UTXOs.
             Optionally, specify require_depth, in which case True is returned

--- a/electroncash_plugins/fusion/plugin.py
+++ b/electroncash_plugins/fusion/plugin.py
@@ -74,9 +74,6 @@ MAX_AUTOFUSIONS_PER_WALLET = 10
 
 CONSOLIDATE_MAX_OUTPUTS = MIN_TX_COMPONENTS // 3
 
-# Threshold for the amount (sats) for a wallet to be fully fused. This is to avoid refuse when dusted.
-FUSE_DEPTH_THRESHOLD = 0.95
-
 pnp = None
 def get_upnp():
     """ return an initialized UPnP singleton """
@@ -592,19 +589,6 @@ class FusionPlugin(BasePlugin):
                     for f in list(wallet._fusions_auto):
                         f.stop('Wallet has unconfirmed coins... waiting.', not_if_running = True)
                     continue
-
-                fuse_depth = Conf(wallet).fuse_depth
-                if fuse_depth > 0:
-                    sum_eligible_values = 0
-                    sum_fuz_values = 0
-                    for eaddr, ecoins in eligible:
-                        ecoins_value = sum(ecoin['value'] for ecoin in ecoins)
-                        sum_eligible_values += ecoins_value
-                        if self.is_fuz_address(wallet, eaddr, fuse_depth - 1):
-                            sum_fuz_values += ecoins_value
-                    if sum_eligible_values != 0 and sum_fuz_values / sum_eligible_values >= FUSE_DEPTH_THRESHOLD:
-                        continue
-
                 if not dont_start_fusions and num_auto < min(target_num_auto, MAX_AUTOFUSIONS_PER_WALLET):
                     # we don't have enough auto-fusions running, so start one
                     fraction = get_target_params_2(wallet_conf, sum_value)
@@ -667,11 +651,10 @@ class FusionPlugin(BasePlugin):
         return can_fuse_from(wallet) and can_fuse_to(wallet)
 
     @staticmethod
-    def is_fuz_coin(wallet, coin, fuz_parents=0) -> Optional[bool]:
+    def is_fuz_coin(wallet, coin) -> Optional[bool]:
         """ Returns True if the coin in question is definitely a CashFusion coin (uses heuristic matching),
         or False if the coin in question is not from a CashFusion tx. Returns None if the tx for the coin
-        is not (yet) known to the wallet (None == inconclusive answer, caller may wish to try again later).
-        Optionally check recursively if the depth of fused coins is sufficient. """
+        is not (yet) known to the wallet (None == inconclusive answer, caller may wish to try again later). """
         cache = getattr(wallet, "_cashfusion_is_fuz_coin_cache", None)
         if cache is None:
             cache = wallet._cashfusion_is_fuz_coin_cache = dict()
@@ -680,8 +663,6 @@ class FusionPlugin(BasePlugin):
         if answer is not None:
             # check cache, if cache hit, return answer and avoid the lookup below
             return answer
-
-        fuz_parents = min(fuz_parents, 900)  # paranoia: clamp recursion to 900
 
         def check_is_fuz_tx():
             tx = wallet.transactions.get(tx_id, None)
@@ -698,18 +679,10 @@ class FusionPlugin(BasePlugin):
                     # Nope, lokad prefix not found
                     return False
                 # Step 2 - are at least 1 of the inputs from me? (DoS prevention measure)
-                fuz_input_found = False
                 for inp in inputs:
                     inp_addr = inp.get('address', None)
                     if inp_addr is not None and wallet.is_mine(inp_addr):
-                        fuz_input_found = True
-                        if fuz_parents <= 0:
-                            return True  # This transaction is a CashFusion tx
-                        # [Optional] Step 3 - Check if all inputs from the wallet are also fusions
-                        if not FusionPlugin.is_fuz_coin(wallet, inp, fuz_parents - 1):
-                            return False  # Not all parents were CashFusion transactions
-                if fuz_input_found:
-                    return True  # All parents where CashFusion transactions with sufficient depth
+                        return True  # Success! This tx matches our heuristics
                 # Failure -- this tx has the lokad but no inputs are "from me".
                 print_error(f"CashFusion: txid \"{tx_id}\" has a CashFusion-style OP_RETURN but none of the "
                             "inputs are from this wallet. This is UNEXPECTED!")
@@ -735,7 +708,7 @@ class FusionPlugin(BasePlugin):
         return answer
 
     @classmethod
-    def is_fuz_address(cls, wallet, address, fuz_parents=0):
+    def is_fuz_address(cls, wallet, address):
         """ Returns True if address contains any fused UTXOs.
             If you want thread safety, caller must hold wallet locks. """
         assert isinstance(address, Address)
@@ -747,7 +720,7 @@ class FusionPlugin(BasePlugin):
             return True
         utxos = wallet.get_addr_utxo(address)
         for coin in utxos.values():
-            if cls.is_fuz_coin(wallet, coin, fuz_parents):
+            if cls.is_fuz_coin(wallet, coin):
                 cache.add(address)
                 return True
         return False

--- a/electroncash_plugins/fusion/plugin.py
+++ b/electroncash_plugins/fusion/plugin.py
@@ -690,10 +690,7 @@ class FusionPlugin(BasePlugin):
         or False if the coin in question is not from a CashFusion tx. Returns None if the tx for the coin
         is not (yet) known to the wallet (None == inconclusive answer, caller may wish to try again later).
         If require_depth is > 0, check recursively; will return True if all ancestors of the coin
-        up to require_depth are also CashFusion transactions belonging to this wallet.
-
-        Precondition: wallet must be a fusion wallet. """
-
+        up to require_depth are also CashFusion transactions belonging to this wallet. """
         require_depth = min(max(0, require_depth), 900)  # paranoia: clamp to [0, 900]
 
         cache = wallet._cashfusion_is_fuz_txid_cache
@@ -777,15 +774,12 @@ class FusionPlugin(BasePlugin):
         return answer
 
     @classmethod
-    def get_coin_fuz_count(cls, wallet, coin, *, require_depth=0):
+    def get_coin_known_fuz_count(cls, wallet, coin, *, require_depth=0):
         """ Will return a fuz count for a coin. Unfused or unknown coins have count 0, coins
         that appear in a fuz tx have count 1, coins whose wallet parent txs are all fuz are 2, 3, etc
         depending on how far back the fuz perdicate is satisfied.
 
-        This function only checks up to 10 ancestors deep so tha maximum return value is 10.
-
-        Precondition: wallet must be a fusion wallet. """
-
+        This function only checks up to 10 ancestors deep so tha maximum return value is 10. """
         require_depth = min(max(require_depth, 0), MAX_LIMIT_FUSE_DEPTH - 1)
         cached_ct = wallet._cashfusion_is_fuz_txid_cache.get(coin['prevout_hash'])
         if isinstance(cached_ct, int) and cached_ct >= require_depth:
@@ -804,10 +798,7 @@ class FusionPlugin(BasePlugin):
             if any UTXOs for this address are sufficiently fused to the
             specified depth.
 
-            If you want thread safety, caller must hold wallet locks.
-
-            Precondition: wallet must be a fusion wallet. """
-
+            If you want thread safety, caller must hold wallet locks."""
         assert isinstance(address, Address)
         require_depth = max(require_depth, 0)
 

--- a/electroncash_plugins/fusion/plugin.py
+++ b/electroncash_plugins/fusion/plugin.py
@@ -77,9 +77,6 @@ CONSOLIDATE_MAX_OUTPUTS = MIN_TX_COMPONENTS // 3
 # Threshold for the amount (sats) for a wallet to be fully fused. This is to avoid refuse when dusted.
 FUSE_DEPTH_THRESHOLD = 0.95
 
-# We don't allow a fuse depth beyond this in the wallet UI
-MAX_LIMIT_FUSE_DEPTH = 10
-
 pnp = None
 def get_upnp():
     """ return an initialized UPnP singleton """
@@ -775,21 +772,13 @@ class FusionPlugin(BasePlugin):
 
     @classmethod
     def get_coin_known_fuz_count(cls, wallet, coin, *, require_depth=0):
-        """ Will return a fuz count for a coin. Unfused or unknown coins have count 0, coins
-        that appear in a fuz tx have count 1, coins whose wallet parent txs are all fuz are 2, 3, etc
-        depending on how far back the fuz perdicate is satisfied.
-
-        This function only checks up to 10 ancestors deep so tha maximum return value is 10. """
-        require_depth = min(max(require_depth, 0), MAX_LIMIT_FUSE_DEPTH - 1)
-        cached_ct = wallet._cashfusion_is_fuz_txid_cache.get(coin['prevout_hash'])
-        if isinstance(cached_ct, int) and cached_ct >= require_depth:
-            return cached_ct + 1
-        ret = 0
-        for i in range(cached_ct or 0, require_depth + 1, 1):
-            ret = i
-            if not cls.is_fuz_coin(wallet, coin, require_depth=i):
-                break
-        return ret
+        res = cls.is_fuz_coin(wallet, coin, require_depth=require_depth)
+        if require_depth > 0:
+            # check if has at least 1 fusion
+            res = cls.is_fuz_coin(wallet, coin, require_depth=0)
+        if res:
+            return wallet._cashfusion_is_fuz_txid_cache.get(coin['prevout_hash'], 0) + 1
+        return 0
 
     @classmethod
     def is_fuz_address(cls, wallet, address, *, require_depth=0):

--- a/electroncash_plugins/fusion/plugin.py
+++ b/electroncash_plugins/fusion/plugin.py
@@ -39,8 +39,8 @@ from electroncash.bitcoin import COINBASE_MATURITY, TYPE_SCRIPT
 from electroncash.constants import PROJECT_NAME
 from electroncash.plugins import BasePlugin, hook, daemon_command
 from electroncash.i18n import _, ngettext, pgettext
-from electroncash.util import profiler, PrintError, InvalidPassword
-from electroncash import Network, Transaction
+from electroncash.util import profiler, PrintError, InvalidPassword, print_error
+from electroncash import Network
 
 from .conf import Conf, Global
 from .fusion import Fusion, can_fuse_from, can_fuse_to, is_tor_port, MIN_TX_COMPONENTS
@@ -299,7 +299,6 @@ class FusionPlugin(BasePlugin):
 
         self.fusions = weakref.WeakKeyDictionary()
         self.autofusing_wallets = weakref.WeakKeyDictionary()  # wallet -> password
-        self.registered_network_callback = False
 
         self.t_last_net_ok = time.monotonic()
 
@@ -308,11 +307,6 @@ class FusionPlugin(BasePlugin):
     def on_close(self,):
         super().on_close()
         self.stop_fusion_server()
-        if self.registered_network_callback:
-            self.registered_network_callback = False
-            network = Network.get_instance()
-            if network:
-                network.unregister_callback(self.on_wallet_transaction)
         self.active = False
 
     def fullname(self):
@@ -466,10 +460,6 @@ class FusionPlugin(BasePlugin):
             wallet._fusions = weakref.WeakSet()
             # fusions that were auto-started.
             wallet._fusions_auto = weakref.WeakSet()
-            # caache: stores a map of txid -> fusion_depth (or False if txid is not a fuz tx)
-            wallet._cashfusion_is_fuz_txid_cache = dict()
-            # cache: stores a map of address -> fusion_depth if the address has fuz utxos
-            wallet._cashfusion_address_cache = dict()
             # all accesses to the above must be protected by wallet.lock
 
         if Conf(wallet).autofuse:
@@ -477,9 +467,6 @@ class FusionPlugin(BasePlugin):
                 self.enable_autofusing(wallet, password)
             except InvalidPassword:
                 self.disable_autofusing(wallet)
-        if not self.registered_network_callback and wallet.network:
-            wallet.network.register_callback(self.on_wallet_transaction, ['new_transaction'])
-            self.registered_network_callback = True
 
     def remove_wallet(self, wallet):
         ''' Detach the provided wallet; returns list of active fusion threads. '''
@@ -491,8 +478,6 @@ class FusionPlugin(BasePlugin):
                 fusions = list(wallet._fusions)
                 del wallet._fusions
                 del wallet._fusions_auto
-                del wallet._cashfusion_is_fuz_txid_cache
-                del wallet._cashfusion_address_cache
         except AttributeError:
             pass
         return [f for f in fusions if f.is_alive()]
@@ -615,7 +600,7 @@ class FusionPlugin(BasePlugin):
                     for eaddr, ecoins in eligible:
                         ecoins_value = sum(ecoin['value'] for ecoin in ecoins)
                         sum_eligible_values += ecoins_value
-                        if self.is_fuz_address(wallet, eaddr, require_depth=fuse_depth-1):
+                        if self.is_fuz_address(wallet, eaddr, fuse_depth - 1):
                             sum_fuz_values += ecoins_value
                     if sum_eligible_values != 0 and sum_fuz_values / sum_eligible_values >= FUSE_DEPTH_THRESHOLD:
                         continue
@@ -682,129 +667,90 @@ class FusionPlugin(BasePlugin):
         return can_fuse_from(wallet) and can_fuse_to(wallet)
 
     @staticmethod
-    def is_fuz_coin(wallet, coin, *, require_depth=0) -> Optional[bool]:
+    def is_fuz_coin(wallet, coin, fuz_parents=0) -> Optional[bool]:
         """ Returns True if the coin in question is definitely a CashFusion coin (uses heuristic matching),
         or False if the coin in question is not from a CashFusion tx. Returns None if the tx for the coin
         is not (yet) known to the wallet (None == inconclusive answer, caller may wish to try again later).
-        If require_depth is > 0, check recursively; will return True if all ancestors of the coin
-        up to require_depth are also CashFusion transactions belonging to this wallet. """
-        require_depth = min(max(0, require_depth), 900)  # paranoia: clamp to [0, 900]
+        Optionally check recursively if the depth of fused coins is sufficient. """
+        cache = getattr(wallet, "_cashfusion_is_fuz_coin_cache", None)
+        if cache is None:
+            cache = wallet._cashfusion_is_fuz_coin_cache = dict()
+        name, tx_id, n = get_coin_name(coin, True)
+        answer = cache.get(name, None)
+        if answer is not None:
+            # check cache, if cache hit, return answer and avoid the lookup below
+            return answer
 
-        cache = wallet._cashfusion_is_fuz_txid_cache
-        assert isinstance(cache, dict)
-        txid = coin['prevout_hash']
-        # check cache, if cache hit, return answer and avoid the lookup below
-        cached_val = cache.get(txid, None)
-        if cached_val is not None:
-            # cache stores either False, or a depth for which the predicate is true
-            if cached_val is False:
-                return False
-            elif cached_val >= require_depth:
-                return True
-
-        my_addresses_seen = set()
+        fuz_parents = min(fuz_parents, 900)  # paranoia: clamp recursion to 900
 
         def check_is_fuz_tx():
-            tx = wallet.transactions.get(txid, None)
-            if tx is None:
+            tx = wallet.transactions.get(tx_id, None)
+            if tx is not None:
+                inputs = tx.inputs()
+                outputs = tx.outputs()
+                # We expect: OP_RETURN (4) FUZ\x00
+                fuz_prefix = bytes((OpCodes.OP_RETURN, len(Protocol.FUSE_ID))) + Protocol.FUSE_ID
+                # Step 1 - does it have the proper OP_RETURN lokad prefix?
+                for typ, dest, amt in outputs:
+                    if amt == 0 and typ == TYPE_SCRIPT and dest.script.startswith(fuz_prefix):
+                        break  # lokad found, proceed to Step 2 below
+                else:
+                    # Nope, lokad prefix not found
+                    return False
+                # Step 2 - are at least 1 of the inputs from me? (DoS prevention measure)
+                fuz_input_found = False
+                for inp in inputs:
+                    inp_addr = inp.get('address', None)
+                    if inp_addr is not None and wallet.is_mine(inp_addr):
+                        fuz_input_found = True
+                        if fuz_parents <= 0:
+                            return True  # This transaction is a CashFusion tx
+                        # [Optional] Step 3 - Check if all inputs from the wallet are also fusions
+                        if not FusionPlugin.is_fuz_coin(wallet, inp, fuz_parents - 1):
+                            return False  # Not all parents were CashFusion transactions
+                if fuz_input_found:
+                    return True  # All parents where CashFusion transactions with sufficient depth
+                # Failure -- this tx has the lokad but no inputs are "from me".
+                print_error(f"CashFusion: txid \"{tx_id}\" has a CashFusion-style OP_RETURN but none of the "
+                            "inputs are from this wallet. This is UNEXPECTED!")
+                return False
+            else:
                 # Not found in wallet.transactions so its fuz status is as yet "unknown". Indicate this.
                 return None
-            inputs = tx.inputs()
-            outputs = tx.outputs()
-            # We expect: OP_RETURN (4) FUZ\x00
-            fuz_prefix = bytes((OpCodes.OP_RETURN, len(Protocol.FUSE_ID))) + Protocol.FUSE_ID
-            # Step 1 - does it have the proper OP_RETURN lokad prefix?
-            for typ, dest, amt in outputs:
-                if amt == 0 and typ == TYPE_SCRIPT and dest.script.startswith(fuz_prefix):
-                    break  # lokad found, proceed to Step 2 below
-            else:
-                # Nope, lokad prefix not found
-                return False
-            # Step 2 - are at least 1 of the inputs from me? (DoS prevention measure)
-            for inp in inputs:
-                inp_addr = inp.get('address', None)
-                if inp_addr is not None and (inp_addr in my_addresses_seen or wallet.is_mine(inp_addr)):
-                    my_addresses_seen.add(inp_addr)
-                    if require_depth == 0:
-                        return True  # This transaction is a CashFusion tx
-                    # [Optional] Step 3 - Check if all ancestors up to required_depth are also fusions
-                    if not FusionPlugin.is_fuz_coin(wallet, inp, require_depth=require_depth-1):
-                        # require_depth specified and not all required_depth parents were CashFusion
-                        return False
-            if my_addresses_seen:
-                # require_depth > 0: This tx + all wallet ancestors were CashFusion transactions up to require_depth
-                return True
-            # Failure -- this tx has the lokad but no inputs are "from me".
-            wallet.print_error(f"CashFusion: txid \"{txid}\" has a CashFusion-style OP_RETURN but none of the "
-                               f"inputs are from this wallet. This is UNEXPECTED!")
-            return False
         # /check_is_fuz_tx
 
         answer = check_is_fuz_tx()
-        if isinstance(answer, bool):
-            # maybe cache the answer if it's a definitive answer True/False
-            if require_depth == 0:
-                # we got an answer for this coin's tx itself
-                if not answer:
-                    cache[txid] = False
-                elif not cached_val:
-                    # only set the cached val if it was missing previously, to avoid overwriting higher values
-                    cache[txid] = 0
-            elif answer and (cached_val is None or cached_val < require_depth):
-                # indicate true up to the depth we just checked
-                cache[txid] = require_depth
-            elif not answer and isinstance(cached_val, int) and cached_val >= require_depth:
-                # this should never happen
-                wallet.print_error(f"CashFusion: WARNING txid \"{txid}\" has inconsistent state in "
-                                   f"the _cashfusion_is_fuz_txid_cache")
+        if answer is not None:
+            # cache the answer iff it's a definitive answer True/False only
+            cache[name] = answer
             if answer:
-                # remember this address as being a "fuzed" address and cache the positive reply
-                cache2 = wallet._cashfusion_address_cache
-                assert isinstance(cache2, dict)
-                addr = coin.get('address', None)
+                # coin['address'] may be undefined if caller is doing funny stuff.
+                addr = coin.get('address')
+                # rememebr this address as being a "fuzed" address and cache the positive reply
                 if addr:
-                    my_addresses_seen.add(addr)
-                for addr in my_addresses_seen:
-                    depth = cache2.get(addr, None)
-                    if depth is None or depth < require_depth:
-                        cache2[addr] = require_depth
+                    cache2 = getattr(wallet, "_cashfusion_address_cache", None)
+                    if cache2 is None:
+                        cache2 = wallet._cashfusion_address_cache = set()
+                    cache2.add(addr)
         return answer
 
     @classmethod
-    def is_fuz_address(cls, wallet, address, *, require_depth=0):
+    def is_fuz_address(cls, wallet, address, fuz_parents=0):
         """ Returns True if address contains any fused UTXOs.
-            Optionally, specify require_depth, in which case True is returned
-            if any UTXOs for this address are sufficiently fused to the
-            specified depth.
-
-            If you want thread safety, caller must hold wallet locks."""
+            If you want thread safety, caller must hold wallet locks. """
         assert isinstance(address, Address)
-        require_depth = max(require_depth, 0)
-
-        cache = wallet._cashfusion_address_cache
-        assert isinstance(cache, dict)
-        cached_val = cache.get(address, None)
-        if cached_val is not None and cached_val >= require_depth:
+        cache = getattr(wallet, '_cashfusion_address_cache', None)
+        if cache is None:
+            cache = wallet._cashfusion_address_cache = set()
+        assert isinstance(cache, set)
+        if address in cache:
             return True
-
         utxos = wallet.get_addr_utxo(address)
         for coin in utxos.values():
-            if cls.is_fuz_coin(wallet, coin, require_depth=require_depth):
-                if cached_val is None or cached_val < require_depth:
-                    cache[address] = require_depth
+            if cls.is_fuz_coin(wallet, coin, fuz_parents):
+                cache.add(address)
                 return True
         return False
-
-    @staticmethod
-    def on_wallet_transaction(event, *args):
-        """ Network object callback. Always called in the Network object's thread. """
-        if event == 'new_transaction':
-            # if this is a fusion wallet, clear the is_fuz_address() cache when new transactions arrive
-            # since we may have spent some utxos and so the cache needs to be invalidated
-            wallet = args[1]
-            if hasattr(wallet, '_cashfusion_address_cache'):
-                with wallet.lock:
-                    wallet._cashfusion_address_cache.clear()
 
     @daemon_command
     def fusion_server_start(self, daemon, config):

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -330,11 +330,9 @@ class Plugin(FusionPlugin, QObject):
             return
 
         wallet = utxo_list.wallet
-        fuse_depth = Conf(wallet).fuse_depth
         frozenstring = item.data(0, utxo_list.DataRoles.frozen_flags) or ""
         is_slp = 's' in frozenstring
-        is_fused = self.is_fuz_coin(wallet, utxo, require_depth=fuse_depth-1)
-        is_partially_fused = is_fused if fuse_depth <= 1 else self.is_fuz_coin(wallet, utxo)
+        is_fused = self.is_fuz_coin(wallet, utxo)
 
         item.setIcon(col, QIcon())
         if is_slp:
@@ -342,12 +340,6 @@ class Plugin(FusionPlugin, QObject):
         elif is_fused:
             item.setText(col, _("Fused"))
             item.setIcon(col, icon_fusion_logo)
-        elif is_partially_fused:
-            count = self.get_coin_known_fuz_count(wallet, utxo, require_depth=fuse_depth-1)
-            item.setText(col, _("Partial {count}/{total}").format(count=count, total=fuse_depth))
-            item.setIcon(col, icon_fusion_logo_gray)
-        elif self.is_fuz_address(wallet, utxo['address'], require_depth=fuse_depth-1):
-            item.setText(col, _("Fusion Addr"))
         elif utxo['height'] <= 0:
             item.setText(col, _("Unconfirmed"))
         elif utxo['coinbase']:

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -190,28 +190,8 @@ class Plugin(FusionPlugin, QObject):
                 do_it(password)
 
         if coins:
-            menu.addAction(ngettext("Input one coin to CashFusion",
-                                    "Input {count} coins to CashFusion",
-                                    len(coins)).format(count=len(coins)),
+            menu.addAction(ngettext("Input one coin to CashFusion", "Input {count} coins to CashFusion", len(coins)).format(count = len(coins)),
                            start_fusion)
-
-    @staticmethod
-    def get_spend_only_fused_coins_checkbox_attributes(wallet):
-        fuse_depth = Conf(wallet).fuse_depth
-        if fuse_depth > 0:
-            label = ngettext("Spend only fused coins, minimum {min} fusion",
-                             "Spend only fused coins, minimum {min} fusions",
-                             fuse_depth).format(min=fuse_depth)
-            tooltip = ngettext("If checked, only spend coins that have been anonymized by\n"
-                               "CashFusion, after having been fused at least {min} time.",
-                               "If checked, only spend coins that have been anonymized by\n"
-                               "CashFusion, after having been fused at least {min} times.",
-                               fuse_depth).format(min=fuse_depth)
-        else:
-            label = _("Spend only fused coins")
-            tooltip = _("If checked, only spend coins that have been\n"
-                        "anonymized by CashFusion at least once.")
-        return label, tooltip
 
     @hook
     def on_new_window(self, window):
@@ -224,8 +204,7 @@ class Plugin(FusionPlugin, QObject):
             self.server_status_changed_signal.connect(sbbtn.update_server_error)
         else:
             # If we can not fuse we create a dummy fusion button that just displays a message
-            sbmsg = _('This wallet type ({wtype}) cannot be used with CashFusion.\n\n'
-                      'Please use a standard deterministic spending wallet with CashFusion.').format(wtype=wallet.wallet_type)
+            sbmsg = _('This wallet type ({wtype}) cannot be used with CashFusion.\n\nPlease use a standard deterministic spending wallet with CashFusion.').format(wtype=wallet.wallet_type)
             sbbtn = DisabledFusionButton(wallet, sbmsg)
 
         # bit of a dirty hack, to insert our status bar icon (always using index 4, should put us just after the password-changer icon)
@@ -242,10 +221,9 @@ class Plugin(FusionPlugin, QObject):
         # NEW! Set up the send tab "Spend only fused coins" checkbox/control
         if hasattr(window, 'send_tab_extra_plugin_controls_hbox'):
             hbox = window.send_tab_extra_plugin_controls_hbox
-            label, tooltip = self.get_spend_only_fused_coins_checkbox_attributes(wallet)
-            spend_only_fused_chk = QtWidgets.QCheckBox(label)
-            spend_only_fused_chk.setObjectName('spend_only_fused_chk')
-            spend_only_fused_chk.setToolTip(tooltip)
+            spend_only_fused_chk = QtWidgets.QCheckBox(_("Spend only fused coins"))
+            spend_only_fused_chk.setToolTip(_("If checked, coins that have not yet been anonymized "
+                                              "by CashFusion will be unavailable for spending."))
             hbox.insertWidget(0, spend_only_fused_chk)
             spend_only_fused_chk.setChecked(Conf(wallet).spend_only_fused_coins)
             weak_window = weakref.ref(window)
@@ -370,31 +348,30 @@ class Plugin(FusionPlugin, QObject):
         # we can ONLY spend fused coins + ununfused living on a fused coin address
         fuz_adrs_seen = set()
         fuz_coins_seen = set()
-        with wallet.lock:
-            for coin in coins.copy():
-                if coin['address'] in external_coin_addresses:
-                    # completely bypass this filter for external keypair dict
-                    # which is only used for sweep dialog in send tab
-                    continue
-                fuse_depth = Conf(wallet).fuse_depth
-                is_fuz_adr = self.is_fuz_address(wallet, coin['address'], require_depth=fuse_depth-1)
-                if is_fuz_adr:
-                    fuz_adrs_seen.add(coin['address'])
-                # we allow coins sitting on a fused address to be "spent as fused"
-                if not self.is_fuz_coin(wallet, coin, require_depth=fuse_depth-1) and not is_fuz_adr:
-                    coins.remove(coin)
-                else:
-                    fuz_coins_seen.add(get_coin_name(coin))
-            # Force co-spending of other coins sitting on a fuzed address
-            for adr in fuz_adrs_seen:
-                adr_coins = wallet.get_addr_utxo(adr)
-                for name, adr_coin in adr_coins.items():
-                    if (name not in fuz_coins_seen
-                            and not adr_coin['is_frozen_coin']
-                            and adr_coin.get('slp_token') is None
-                            and not adr_coin.get('coinbase')):
-                        coins.append(adr_coin)
-                        fuz_coins_seen.add(name)
+        for coin in coins.copy():
+            if coin['address'] in external_coin_addresses:
+                # completely bypass this filter for external keypair dict
+                # which is only used for sweep dialog in send tab
+                continue
+            fuse_depth = Conf(wallet).fuse_depth
+            is_fuz_adr = self.is_fuz_address(wallet, coin['address'], fuse_depth - 1)
+            if is_fuz_adr:
+                fuz_adrs_seen.add(coin['address'])
+            # we allow coins sitting on a fused address to be "spent as fused"
+            if not self.is_fuz_coin(wallet, coin, fuse_depth - 1) and not is_fuz_adr:
+                coins.remove(coin)
+            else:
+                fuz_coins_seen.add(get_coin_name(coin))
+        # Force co-spending of other coins sitting on a fuzed address
+        for adr in fuz_adrs_seen:
+            adr_coins = wallet.get_addr_utxo(adr)
+            for name, adr_coin in adr_coins.items():
+                if (name not in fuz_coins_seen
+                        and not adr_coin['is_frozen_coin']
+                        and adr_coin.get('slp_token') is None
+                        and not adr_coin.get('coinbase')):
+                    coins.append(adr_coin)
+                    fuz_coins_seen.add(name)
 
     @hook
     def not_enough_funds_extra(self, window) -> Optional[str]:
@@ -402,12 +379,11 @@ class Plugin(FusionPlugin, QObject):
         wallet = window.wallet
         if not self.wallet_can_fuse(wallet):
             return
-        conf = Conf(wallet)
-        if not conf.spend_only_fused_coins:
+        if not Conf(wallet).spend_only_fused_coins:
             return
         needs_fuz = [coin for coin in wallet.get_utxos(exclude_frozen=True, mature=True,
                                                        confirmed_only=bool(window.config.get('confirmed_only', False)))
-                     if not self.is_fuz_coin(wallet, coin, require_depth=conf.fuse_depth-1)]
+                     if not self.is_fuz_coin(wallet, coin)]
         total = sum(c['value'] for c in needs_fuz)
         n_coins = len(needs_fuz)
         if total and needs_fuz:
@@ -1167,29 +1143,24 @@ class WalletSettingsDialog(WindowModalDialog):
 
         main_layout.addLayout(hbox)
 
-        self.gb_fuse_depth = gb = QtWidgets.QGroupBox(_("Fusion Rounds"))
-        gb.setToolTip(_("If checked, CashFusion will fuse each coin this many times.\n"
-                        "If unchecked, Cashfusion will fuse indefinitely until paused."))
-        hbox = QtWidgets.QHBoxLayout(gb)
-        self.chk_fuse_depth = chk = QtWidgets.QCheckBox(_("Fuse coins this many times"))
-        hbox.addWidget(chk, 1)
-        self.sb_fuse_depth = sb = QtWidgets.QSpinBox()
-        sb.setRange(1, 10)
-        sb.setMinimumWidth(75)
-        hbox.addWidget(sb)
-        chk.toggled.connect(self.edited_fuse_depth)
-        sb.valueChanged.connect(self.edited_fuse_depth)
-        main_layout.addWidget(gb)
+        hbox = QtWidgets.QHBoxLayout()
+        hbox.addWidget(QtWidgets.QLabel(_("Minimum fuse depth (0 = infinite fusing)")))
+        self.sb_fuse_depth = QtWidgets.QSpinBox()
+        self.sb_fuse_depth.setRange(0, 10)
+        self.sb_fuse_depth.setMinimumWidth(50)
+        hbox.addWidget(self.sb_fuse_depth)
+        self.sb_fuse_depth.valueChanged.connect(self.edited_fuse_depth)
+        main_layout.addLayout(hbox)
 
         self.gb_coinbase = gb = QtWidgets.QGroupBox(_("Coinbase Coins"))
         vbox = QtWidgets.QVBoxLayout(gb)
         self.cb_coinbase = QtWidgets.QCheckBox(_('Auto-fuse coinbase coins (if mature)'))
         self.cb_coinbase.clicked.connect(self._on_cb_coinbase)
         vbox.addWidget(self.cb_coinbase)
-        # The coinbase-related group box is hidden by default. It becomes
-        # visible permanently when the wallet settings dialog has seen at least
-        # one coinbase coin, indicating a miner's wallet. For most users the
-        # coinbase checkbox is confusing, which is why we prefer to hide it.
+         # The coinbase-related group box is hidden by default. It becomes
+         # visible permanently when the wallet settings dialog has seen at least
+         # one coinbase coin, indicating a miner's wallet. For most users the
+         # coinbase checkbox is confusing, which is why we prefer to hide it.
         gb.setHidden(True)
         main_layout.addWidget(gb)
 
@@ -1388,7 +1359,7 @@ class WalletSettingsDialog(WindowModalDialog):
 
         edit_widgets = [self.amt_selector_size, self.sb_selector_fraction, self.sb_selector_count, self.sb_queued_autofuse,
                         self.cb_autofuse_only_all_confirmed, self.combo_self_fuse, self.stacked_layout, self.mode_cb,
-                        self.cb_coinbase, self.sb_fuse_depth, self.chk_fuse_depth]
+                        self.cb_coinbase]
         try:
             for w in edit_widgets:
                 # Block spurious editingFinished signals and valueChanged signals as
@@ -1416,10 +1387,7 @@ class WalletSettingsDialog(WindowModalDialog):
             self.combo_self_fuse.setCurrentIndex(idx)
             del idx
 
-            if self.conf.fuse_depth > 0:
-                self.sb_fuse_depth.setValue(self.conf.fuse_depth)
-            self.chk_fuse_depth.setChecked(self.conf.fuse_depth > 0)
-            self.sb_fuse_depth.setEnabled(self.conf.fuse_depth > 0)
+            self.sb_fuse_depth.setValue(self.conf.fuse_depth)
 
             if is_custom_page:
                 self.amt_selector_size.setEnabled(select_type == 'size')
@@ -1485,18 +1453,14 @@ class WalletSettingsDialog(WindowModalDialog):
 
     def edited_fuse_depth(self,):
         prevval = self.conf.fuse_depth
-        newval = self.sb_fuse_depth.value() if self.chk_fuse_depth.isChecked() else 0
-        self.conf.fuse_depth = newval
-        if prevval == 0 or (prevval > newval and newval != 0):
+        numstop = self.sb_fuse_depth.value()
+        self.conf.fuse_depth = numstop
+        with self.wallet.lock:
+            self.wallet._cashfusion_address_cache = set()  # The cache is calculated with old depth
+            self.wallet._cashfusion_is_fuz_coin_cache = dict()
+        if prevval == 0 or (prevval > numstop and numstop != 0):
             for f in list(self.wallet._fusions_auto):
                 f.stop('User decreased fuse depth limit', not_if_running = False)
-        # update the send tab label for the "spend only confirmed coins" checkbox
-        label, tooltip = self.plugin.get_spend_only_fused_coins_checkbox_attributes(self.wallet)
-        for w in self.plugin.widgets:
-            if isinstance(w, QtWidgets.QCheckBox) and w.objectName() == 'spend_only_fused_chk':
-                chk: QtWidgets.QCheckBox = w
-                chk.setText(label)
-                chk.setToolTip(tooltip)
         self.refresh()
         # Coins tab may need redisplay if we changed these settings
         if prevval != newval:

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -60,7 +60,7 @@ from electroncash_gui.qt.utils import PortValidator, UserPortValidator
 from .conf import Conf, Global
 from .fusion import can_fuse_from, can_fuse_to
 from .server import Params
-from .plugin import FusionPlugin, TOR_PORTS, COIN_FRACTION_FUDGE_FACTOR, select_coins, MAX_LIMIT_FUSE_DEPTH
+from .plugin import FusionPlugin, TOR_PORTS, COIN_FRACTION_FUDGE_FACTOR, select_coins
 from .util import get_coin_name
 
 from pathlib import Path
@@ -1182,7 +1182,7 @@ class WalletSettingsDialog(WindowModalDialog):
         self.chk_fuse_depth = chk = QtWidgets.QCheckBox(_("Fuse coins this many times"))
         hbox.addWidget(chk, 1)
         self.sb_fuse_depth = sb = QtWidgets.QSpinBox()
-        sb.setRange(1, MAX_LIMIT_FUSE_DEPTH)
+        sb.setRange(1, 10)
         sb.setMinimumWidth(75)
         hbox.addWidget(sb)
         chk.toggled.connect(self.edited_fuse_depth)

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -347,9 +347,7 @@ class Plugin(FusionPlugin, QObject):
             item.setText(col, _("Partial {count}/{total}").format(count=count, total=fuse_depth))
             item.setIcon(col, icon_fusion_logo_gray)
         elif self.is_fuz_address(wallet, utxo['address'], require_depth=fuse_depth-1):
-            item.setText(col, _("Fuse Addr"))
-            item.setIcon(col, icon_fusion_logo)
-            item.setToolTip(col, _("This coin shares an address with a fused coin. Do not spend separately."))
+            item.setText(col, _("Fusion Addr"))
         elif utxo['height'] <= 0:
             item.setText(col, _("Unconfirmed"))
         elif utxo['coinbase']:

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -1152,8 +1152,6 @@ class SettingsWidget(QtWidgets.QWidget):
 
 
 class WalletSettingsDialog(WindowModalDialog):
-    GUI_DEFAULT_FUSE_DEPTH = 3  # This what the fuse depth spinbox defaults to, if checked (on new installs)
-
     def __init__(self, parent, plugin, wallet):
         super().__init__(parent=parent, title=_("CashFusion - Wallet Settings"))
         self.setWindowIcon(get_icon_fusion_logo())
@@ -1187,9 +1185,6 @@ class WalletSettingsDialog(WindowModalDialog):
         hbox.addWidget(chk, 1)
         self.sb_fuse_depth = sb = QtWidgets.QSpinBox()
         sb.setRange(1, MAX_LIMIT_FUSE_DEPTH)
-        if self.conf.fuse_depth <= 0:
-            # Default it to this if unchecked
-            self.sb_fuse_depth.setValue(self.GUI_DEFAULT_FUSE_DEPTH)
         sb.setMinimumWidth(75)
         hbox.addWidget(sb)
         chk.toggled.connect(self.edited_fuse_depth)

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -1499,17 +1499,18 @@ class WalletSettingsDialog(WindowModalDialog):
             for f in list(self.wallet._fusions_auto):
                 f.stop('User decreased fuse depth limit', not_if_running = False)
         # update the send tab label for the "spend only confirmed coins" checkbox
-        main_window = self.wallet.weak_window and self.wallet.weak_window()
-        if main_window:
-            chk = main_window.findChild(QtWidgets.QCheckBox, 'spend_only_fused_chk', Qt.FindChildrenRecursively)
-            if chk:
-                label, tooltip = self.plugin.get_spend_only_fused_coins_checkbox_attributes(self.wallet)
+        label, tooltip = self.plugin.get_spend_only_fused_coins_checkbox_attributes(self.wallet)
+        for w in self.plugin.widgets:
+            if isinstance(w, QtWidgets.QCheckBox) and w.objectName() == 'spend_only_fused_chk':
+                chk: QtWidgets.QCheckBox = w
                 chk.setText(label)
                 chk.setToolTip(tooltip)
-            # Coins tab may need redisplay if we changed these settings
-            if prevval != newval:
-                main_window.utxo_list.update()
         self.refresh()
+        # Coins tab may need redisplay if we changed these settings
+        if prevval != newval:
+            main_window = self.wallet.weak_window()
+            if main_window:
+                main_window.utxo_list.update()
 
     def clicked_confirmed_only(self, checked):
         self.conf.autofuse_confirmed_only = checked

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -343,7 +343,7 @@ class Plugin(FusionPlugin, QObject):
             item.setText(col, _("Fused"))
             item.setIcon(col, icon_fusion_logo)
         elif is_partially_fused:
-            count = self.get_coin_fuz_count(wallet, utxo, require_depth=fuse_depth-1)
+            count = self.get_coin_known_fuz_count(wallet, utxo, require_depth=fuse_depth-1)
             item.setText(col, _("Partial {count}/{total}").format(count=count, total=fuse_depth))
             item.setIcon(col, icon_fusion_logo_gray)
         elif self.is_fuz_address(wallet, utxo['address'], require_depth=fuse_depth-1):


### PR DESCRIPTION
This PR reverts a few recent CashFusion commits to remove the fuse depth setting. This may leak information about different wallets if they choose different settings.

I hopefully managed to remove it cleanly without breaking the "show fusion status in coins tab" feature added more recently.