### PR TITLE
qt high dpi: fix some text fields

### DIFF
--- a/electroncash_gui/qt/amountedit.py
+++ b/electroncash_gui/qt/amountedit.py
@@ -10,7 +10,7 @@ from PyQt5.QtGui import QPainter
 from electroncash.constants import BASE_UNITS_BY_DECIMALS
 from electroncash.util import format_satoshis_plain
 
-from .util import ColorScheme
+from .util import ColorScheme, char_width_in_lineedit
 
 
 class MyLineEdit(QtWidgets.QLineEdit):
@@ -33,7 +33,7 @@ class AmountEdit(MyLineEdit):
     ):
         QtWidgets.QLineEdit.__init__(self, parent)
         # This seems sufficient for 10,000 MXEC amounts with two decimals
-        self.setFixedWidth(160)
+        self.setFixedWidth(18 * char_width_in_lineedit())
         self.base_unit: str = base_unit
         self.decimal_point: int = 2
         self.textChanged.connect(self.numbify)

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -38,6 +38,7 @@ from .util import (
     MessageBoxMixin,
     OkButton,
     WWLabel,
+    char_width_in_lineedit,
     destroyed_print_error,
 )
 
@@ -196,7 +197,7 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
         vbox.addWidget(self.msg_label)
         hbox2 = QtWidgets.QHBoxLayout()
         self.pw_e = QtWidgets.QLineEdit('', self)
-        self.pw_e.setFixedWidth(150)
+        self.pw_e.setFixedWidth(17 * char_width_in_lineedit())
         self.pw_e.setEchoMode(2)
         self.pw_label = QtWidgets.QLabel(_('Password') + ':')
         hbox2.addWidget(self.pw_label)

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -109,6 +109,7 @@ from .util import (
     WindowModalDialog,
     WWLabel,
     address_combo,
+    char_width_in_lineedit,
     destroyed_print_error,
     expiration_values,
     filename_field,
@@ -1717,7 +1718,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             lambda: self.fiat_send_e.setFrozen(self.amount_e.isReadOnly()))
 
         self.max_button = EnterButton(_("&Max"), self.spend_max)
-        self.max_button.setFixedWidth(140)
+        self.max_button.setFixedWidth(self.amount_e.width())
         self.max_button.setCheckable(True)
         grid.addWidget(self.max_button, 5, 3)
         hbox = self.send_tab_extra_plugin_controls_hbox = QtWidgets.QHBoxLayout()
@@ -1744,13 +1745,13 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
 
         self.fee_slider = FeeSlider(self, self.config, fee_cb)
         self.fee_e_label.setBuddy(self.fee_slider)
-        self.fee_slider.setFixedWidth(140)
+        self.fee_slider.setFixedWidth(self.amount_e.width())
 
         self.fee_custom_lbl = HelpLabel(self.get_custom_fee_text(),
                                         _('This is the fee rate that will be used for this transaction.')
                                         + "\n\n" + _('It is calculated from the Custom Fee Rate in preferences, but can be overridden from the manual fee edit on this form (if enabled).')
                                         + "\n\n" + _('Generally, a fee of 1.0 sats/B is a good minimal rate to ensure your transaction will make it into the next block.'))
-        self.fee_custom_lbl.setFixedWidth(140)
+        self.fee_custom_lbl.setFixedWidth(self.amount_e.width())
 
         self.fee_slider_mogrifier()
 
@@ -3118,9 +3119,9 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         vbox.addWidget(QtWidgets.QLabel(_('New Contact') + ':'))
         grid = QtWidgets.QGridLayout()
         line1 = QtWidgets.QLineEdit()
-        line1.setFixedWidth(350)
+        line1.setFixedWidth(38 * char_width_in_lineedit())
         line2 = QtWidgets.QLineEdit()
-        line2.setFixedWidth(350)
+        line2.setFixedWidth(38 * char_width_in_lineedit())
         grid.addWidget(QtWidgets.QLabel(_("Name")), 1, 0)
         grid.addWidget(line1, 1, 1)
         grid.addWidget(QtWidgets.QLabel(_("Address")), 2, 0)

--- a/electroncash_gui/qt/network_dialog.py
+++ b/electroncash_gui/qt/network_dialog.py
@@ -51,6 +51,7 @@ from .util import (
     MessageBoxMixin,
     WindowModalDialog,
     WWLabel,
+    char_width_in_lineedit,
     rate_limited,
 )
 from .utils import UserPortValidator
@@ -422,6 +423,9 @@ class NetworkChoiceLayout(QObject, PrintError):
         tabs.addTab(server_tab, _('Server'))
         tabs.addTab(proxy_tab, _('Proxy'))
 
+        fixed_width_hostname = 24 * char_width_in_lineedit()
+        fixed_width_port = 6 * char_width_in_lineedit()
+
         if wizard:
             tabs.setCurrentIndex(1)
 
@@ -430,9 +434,9 @@ class NetworkChoiceLayout(QObject, PrintError):
         grid.setSpacing(8)
 
         self.server_host = QtWidgets.QLineEdit()
-        self.server_host.setFixedWidth(200)
+        self.server_host.setFixedWidth(fixed_width_hostname)
         self.server_port = QtWidgets.QLineEdit()
-        self.server_port.setFixedWidth(60)
+        self.server_port.setFixedWidth(fixed_width_port)
         self.ssl_cb = QtWidgets.QCheckBox(_('Use SSL'))
         self.autoconnect_cb = QtWidgets.QCheckBox(_('Select server automatically'))
         self.autoconnect_cb.setEnabled(self.config.is_modifiable('auto_connect'))
@@ -520,15 +524,14 @@ class NetworkChoiceLayout(QObject, PrintError):
         self.proxy_mode = QtWidgets.QComboBox()
         self.proxy_mode.addItems(['SOCKS4', 'SOCKS5', 'HTTP'])
         self.proxy_host = QtWidgets.QLineEdit()
-        self.proxy_host.setFixedWidth(200)
+        self.proxy_host.setFixedWidth(fixed_width_hostname)
         self.proxy_port = QtWidgets.QLineEdit()
-        self.proxy_port.setFixedWidth(60)
+        self.proxy_port.setFixedWidth(fixed_width_port)
         self.proxy_user = QtWidgets.QLineEdit()
         self.proxy_user.setPlaceholderText(_("Proxy user"))
         self.proxy_password = QtWidgets.QLineEdit()
         self.proxy_password.setPlaceholderText(_("Password"))
         self.proxy_password.setEchoMode(QtWidgets.QLineEdit.Password)
-        self.proxy_password.setFixedWidth(60)
 
         self.proxy_mode.currentIndexChanged.connect(self.set_proxy)
         self.proxy_host.editingFinished.connect(self.set_proxy)
@@ -565,7 +568,7 @@ class NetworkChoiceLayout(QObject, PrintError):
         self.network.tor_controller.status_changed.append_weak(self.on_tor_status_changed)
 
         self.tor_socks_port = QtWidgets.QLineEdit()
-        self.tor_socks_port.setFixedWidth(60)
+        self.tor_socks_port.setFixedWidth(fixed_width_port)
         self.tor_socks_port.editingFinished.connect(self.set_tor_socks_port)
         self.tor_socks_port.setText(str(self.network.tor_controller.get_socks_port()))
         self.tor_socks_port.setToolTip(custom_port_tooltip)
@@ -597,8 +600,10 @@ class NetworkChoiceLayout(QObject, PrintError):
         grid.addWidget(self.proxy_mode, 6, 1)
         grid.addWidget(self.proxy_host, 6, 2)
         grid.addWidget(self.proxy_port, 6, 3)
-        grid.addWidget(self.proxy_user, 7, 2)
-        grid.addWidget(self.proxy_password, 7, 3)
+        sublayout = QtWidgets.QHBoxLayout()
+        sublayout.addWidget(self.proxy_user)
+        sublayout.addWidget(self.proxy_password)
+        grid.addLayout(sublayout, 7, 2, 1, 2)
         grid.setRowStretch(8, 1)
 
         # Blockchain Tab

--- a/electroncash_gui/qt/util.py
+++ b/electroncash_gui/qt/util.py
@@ -133,6 +133,7 @@ class HelpLabel(HelpMixin, QtWidgets.QLabel):
         self.setFont(self.font)
         return QtWidgets.QLabel.leaveEvent(self, event)
 
+
 class HelpButton(HelpMixin, QtWidgets.QPushButton):
     def __init__(self, text, *, button_text='?', fixed_size=True, icon=None,
                  tool_tip=None, custom_parent=None):
@@ -142,7 +143,7 @@ class HelpButton(HelpMixin, QtWidgets.QPushButton):
         self.setCursor(QCursor(Qt.PointingHandCursor))
         self.setFocusPolicy(Qt.NoFocus)
         if fixed_size:
-            self.setFixedWidth(20)
+            self.setFixedWidth(round(2.2 * char_width_in_lineedit()))
         if icon:
             self.setIcon(icon)
         self.clicked.connect(self.show_help)
@@ -1366,6 +1367,13 @@ class TextBrowserKeyboardFocusFilter(QtWidgets.QTextBrowser):
     def keyPressEvent(self, e: QKeyEvent):
         self.setTextInteractionFlags(self.textInteractionFlags() | Qt.TextSelectableByKeyboard)
         super().keyPressEvent(e)
+
+
+def char_width_in_lineedit() -> int:
+    char_width = QFontMetrics(QtWidgets.QLineEdit().font()).averageCharWidth()
+    # 'averageCharWidth' seems to underestimate on Windows, hence 'max()'
+    return max(9, char_width)
+
 
 if __name__ == "__main__":
     app = QtWidgets.QApplication([])

--- a/electroncash_plugins/hw_wallet/qt.py
+++ b/electroncash_plugins/hw_wallet/qt.py
@@ -38,6 +38,7 @@ from electroncash_gui.qt.util import (
     TaskThread,
     WindowModalDialog,
     WWLabel,
+    char_width_in_lineedit,
 )
 
 from electroncash.i18n import _
@@ -155,7 +156,7 @@ class QtHandlerBase(QObject, PrintError):
         hbox = QtWidgets.QHBoxLayout(dialog)
         hbox.addWidget(QtWidgets.QLabel(msg))
         text = QtWidgets.QLineEdit()
-        text.setMaximumWidth(100)
+        text.setMaximumWidth(12 * char_width_in_lineedit())
         text.returnPressed.connect(dialog.accept)
         hbox.addWidget(text)
         hbox.addStretch(1)


### PR DESCRIPTION
This is a backport of https://github.com/spesmilo/electrum/commit/37809bed7459eb7cffff0b1f03954a6b3dc3a616
It fixes some widget size issues on high resolution displays, when widgets are sometimes too small to be conveniently used, by setting the widget width as a multiple of the character width.

Also fix the proxy password widget width in the networks dialog. It was set to use the same width as the proxy widget above, to avoid making the grid layout wider. Instead of fitting the proxy user and password widgets in individual grid cells, put them in a QHBoxLayout and fit the layout in two cells of the grid layout, so the two widgets together take the same width as the host and port of the previous line.