### PR TITLE
Deal with problematic coins when building proof (unconfirmed or low amounts)

### DIFF
--- a/electroncash/avalanche/proof.py
+++ b/electroncash/avalanche/proof.py
@@ -62,6 +62,8 @@ class Stake(SerializableObject):
         """Amount in satoshis (int64)"""
         self.height = height
         """Block height containing this utxo (uint32)"""
+        # Electrum ABC uses 0 and -1 for unconfirmed coins.
+        assert height > 0
         self.pubkey = pubkey
         """Public key"""
         self.is_coinbase = is_coinbase

--- a/electroncash/constants.py
+++ b/electroncash/constants.py
@@ -1,3 +1,4 @@
+from decimal import Decimal
 from typing import List, Mapping, Sequence
 
 PROJECT_NAME: str = "Electrum ABC"
@@ -41,6 +42,9 @@ class Unit:
     def __str__(self):
         return self.ticker
 
+    def unit_to_satoshis(self, amount: Decimal) -> int:
+        return int((amount * 10 ** self.decimals).quantize(Decimal("1")))
+
 
 SAT = Unit("sats", 0)
 XEC = Unit("XEC", 2, "bits")
@@ -73,3 +77,6 @@ DUST_THRESHOLD: int = 546
 Change < dust threshold is added to the tx fee.
 The unit is satoshis.
 """
+
+PROOF_DUST_THRESHOLD: int = XEC.unit_to_satoshis(Decimal("1_000_000.00"))
+"""Lowest amount in satoshis that can be used as stake in a proof."""

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, List, Optional
 
-from PyQt5 import QtCore, QtWidgets
+from PyQt5 import QtCore, QtGui, QtWidgets
 
 from electroncash.address import Address, AddressError
 from electroncash.avalanche.delegation import (
@@ -14,6 +14,7 @@ from electroncash.avalanche.primitives import Key, PublicKey
 from electroncash.avalanche.proof import LimitedProofId, Proof, ProofBuilder
 from electroncash.avalanche.serialize import DeserializationError
 from electroncash.bitcoin import is_private_key
+from electroncash.constants import PROOF_DUST_THRESHOLD
 from electroncash.uint256 import UInt256
 
 from .password_dialog import PasswordDialog
@@ -133,7 +134,7 @@ class AvaProofWidget(QtWidgets.QWidget):
         layout.addSpacing(10)
 
         self.utxos_wigdet = QtWidgets.QTableWidget(len(utxos), 3)
-        self.utxos_wigdet.setHorizontalHeaderLabels(["txid", "vout", "amount"])
+        self.utxos_wigdet.setHorizontalHeaderLabels(["txid", "vout", "amount (sats)"])
         self.utxos_wigdet.verticalHeader().setVisible(False)
         self.utxos_wigdet.setSelectionMode(QtWidgets.QTableWidget.NoSelection)
         self.utxos_wigdet.horizontalHeader().setSectionResizeMode(
@@ -143,9 +144,13 @@ class AvaProofWidget(QtWidgets.QWidget):
         for i, utxo in enumerate(utxos):
             txid_item = QtWidgets.QTableWidgetItem(utxo["prevout_hash"])
             self.utxos_wigdet.setItem(i, 0, txid_item)
+
             vout_item = QtWidgets.QTableWidgetItem(str(utxo["prevout_n"]))
             self.utxos_wigdet.setItem(i, 1, vout_item)
+
             amount_item = QtWidgets.QTableWidgetItem(str(utxo["value"]))
+            if utxo["value"] < PROOF_DUST_THRESHOLD:
+                amount_item.setForeground(QtGui.QColor("red"))
             self.utxos_wigdet.setItem(i, 2, amount_item)
 
         self.generate_button = QtWidgets.QPushButton("Generate proof")

--- a/electroncash_gui/qt/utxo_list.py
+++ b/electroncash_gui/qt/utxo_list.py
@@ -256,6 +256,12 @@ class UTXOList(MyTreeWidget):
                 avaproof_action.setToolTip(
                     _("Cannot build avalanche proof for hardware, multisig or "
                       "watch-only wallet (Schnorr signature is required)."))
+            elif any(c["height"] <= 0 for c in coins):
+                # A block height is required when serializing a stake.
+                avaproof_action.setEnabled(False)
+                avaproof_action.setToolTip(
+                    _("Cannot build avalanche proof with unconfirmed coins"))
+
             if len(selected) == 1:
                 # "Copy ..."
                 item = self.itemAt(position)


### PR DESCRIPTION
We need to exclude unconfirmed coins when building an Avalanche proof, because the block height is needed when serializing the stakes.
We should also exclude coins with values that are below the minimum threshold of 1,000,000.00 XEC for stakes, but this will make interactive testing less convenient, so for now let's just show a warning if such a coin is selected. The user can bypass the warning by clicking a **"Continue, I'm just testing"** button.