### PR TITLE
Use fallback ripemd160 implementation when hashlib fails to find it (OpenSSL3.0)

### DIFF
--- a/electroncash/address.py
+++ b/electroncash/address.py
@@ -40,10 +40,11 @@ hex_to_bytes = bytes.fromhex
 
 
 class AddressError(Exception):
-    '''Exception used for Address errors.'''
+    """Exception used for Address errors."""
+
 
 class ScriptError(Exception):
-    '''Exception used for Script errors.'''
+    """Exception used for Script errors."""
 
 
 P2PKH_prefix = bytes([OpCodes.OP_DUP, OpCodes.OP_HASH160, 20])
@@ -55,39 +56,46 @@ P2SH_suffix = bytes([OpCodes.OP_EQUAL])
 # Utility functions
 
 def to_bytes(x):
-    '''Convert to bytes which is hashable.'''
+    """Convert to bytes which is hashable."""
     if isinstance(x, bytes):
         return x
     if isinstance(x, bytearray):
         return bytes(x)
     raise TypeError('{} is not bytes ({})'.format(x, type(x)))
 
+
 def hash_to_hex_str(x):
-    '''Convert a big-endian binary hash to displayed hex string.
+    """Convert a big-endian binary hash to displayed hex string.
 
     Display form of a binary hash is reversed and converted to hex.
-    '''
+    """
     return bytes(reversed(x)).hex()
 
+
 def hex_str_to_hash(x):
-    '''Convert a displayed hex string to a binary hash.'''
+    """Convert a displayed hex string to a binary hash."""
     return bytes(reversed(hex_to_bytes(x)))
 
+
 def bytes_to_int(be_bytes):
-    '''Interprets a big-endian sequence of bytes as an integer'''
+    """Interprets a big-endian sequence of bytes as an integer"""
     return int.from_bytes(be_bytes, 'big')
 
+
 def int_to_bytes(value):
-    '''Converts an integer to a big-endian sequence of bytes'''
+    """Converts an integer to a big-endian sequence of bytes"""
     return value.to_bytes((value.bit_length() + 7) // 8, 'big')
 
+
 def sha256(x):
-    '''Simple wrapper of hashlib sha256.'''
+    """Simple wrapper of hashlib sha256."""
     return _sha256(x).digest()
 
+
 def double_sha256(x):
-    '''SHA-256 of SHA-256, as used extensively in bitcoin.'''
+    """SHA-256 of SHA-256, as used extensively in bitcoin."""
     return sha256(sha256(x))
+
 
 def ripemd160(x):
     '''Simple wrapper of hashlib ripemd160.'''

--- a/electroncash/bitcoin.py
+++ b/electroncash/bitcoin.py
@@ -460,7 +460,7 @@ def i2o_ECPublicKey(pubkey, compressed=False):
 
 
 ############ functions from pywallet #####################
-def hash_160(public_key):
+def hash_160(public_key: bytes) -> bytes:
     try:
         md = hashlib.new('ripemd160')
         md.update(sha256(public_key))

--- a/electroncash/bitcoin.py
+++ b/electroncash/bitcoin.py
@@ -465,7 +465,7 @@ def hash_160(public_key: bytes) -> bytes:
         md = hashlib.new('ripemd160')
         md.update(sha256(public_key))
         return md.digest()
-    except BaseException:
+    except ValueError:
         from . import ripemd
         md = ripemd.new(sha256(public_key))
         return md.digest()

--- a/electroncash/ripemd.py
+++ b/electroncash/ripemd.py
@@ -57,7 +57,7 @@ class RIPEMD160:
         RMD160Update(self.ctx, arg, len(arg))
         self.dig = None
 
-    def digest(self):
+    def digest(self) -> bytes:
         """digest()"""
         if self.dig:
             return self.dig
@@ -375,7 +375,7 @@ def RMD160Update(ctx, inp, inplen):
         for i in range(inplen - off):
             ctx.buffer[have+i] = inp[off+i]
 
-def RMD160Final(ctx):
+def RMD160Final(ctx: RMDContext) -> bytes:
     size = struct.pack("<Q", ctx.count)
     padlen = 64 - ((ctx.count // 8) % 64)
     if padlen < 1+8:

--- a/electroncash/transaction.py
+++ b/electroncash/transaction.py
@@ -35,7 +35,7 @@ from .util import print_error, profiler
 from .caches import ExpiringCache
 
 from . import bitcoin
-from .address import (PublicKey, Address, Script, ScriptOutput, hash160,
+from .address import (PublicKey, Address, Script, ScriptOutput,
                       UnknownAddress, P2PKH_prefix, P2PKH_suffix, P2SH_prefix,
                       P2SH_suffix)
 from .bitcoin import OpCodes as opcodes
@@ -254,7 +254,7 @@ def parse_scriptSig(d, _bytes):
     d['x_pubkeys'] = x_pubkeys
     d['pubkeys'] = pubkeys
     d['redeemScript'] = redeemScript
-    d['address'] = Address.from_P2SH_hash(hash160(redeemScript))
+    d['address'] = Address.from_P2SH_hash(bitcoin.hash_160(redeemScript))
 
 
 def parse_redeemScript(s):

--- a/electroncash_plugins/fusion/util.py
+++ b/electroncash_plugins/fusion/util.py
@@ -29,8 +29,8 @@ Some pieces of fusion that can be reused in the server.
 """
 
 from electroncash.transaction import Transaction, get_address_from_output_script
-from electroncash.address import Address, ScriptOutput, hash160, OpCodes
-from electroncash.bitcoin import TYPE_SCRIPT, TYPE_ADDRESS
+from electroncash.address import Address, ScriptOutput, OpCodes
+from electroncash.bitcoin import TYPE_SCRIPT, TYPE_ADDRESS, hash_160
 
 from . import fusion_pb2 as pb
 from .protocol import Protocol
@@ -133,7 +133,7 @@ def tx_from_components(all_components, session_hash):
             inp = comp.input
             if len(inp.prev_txid) != 32:
                 raise FusionError("bad component prevout")
-            inputs.append(dict(address = Address.from_P2PKH_hash(hash160(inp.pubkey)),
+            inputs.append(dict(address = Address.from_P2PKH_hash(hash_160(inp.pubkey)),
                                prevout_hash = inp.prev_txid[::-1].hex(),
                                prevout_n = inp.prev_index,
                                num_sig = 1,

--- a/electroncash_plugins/ledger/ledger.py
+++ b/electroncash_plugins/ledger/ledger.py
@@ -116,9 +116,8 @@ class Ledger_Client:
             prevPath = "/".join(splitPath[0:len(splitPath) - 1])
             nodeData = self.dongleObject.getWalletPublicKey(prevPath)
             publicKey = compress_public_key(nodeData['publicKey'])
-            h = hashlib.new('ripemd160')
-            h.update(hashlib.sha256(publicKey).digest())
-            fingerprint = unpack(">I", h.digest()[0:4])[0]
+            h = bitcoin.hash_160(publicKey)
+            fingerprint = unpack(">I", h[0:4])[0]
         nodeData = self.dongleObject.getWalletPublicKey(bip32_path)
         publicKey = compress_public_key(nodeData['publicKey'])
         depth = len(splitPath)


### PR DESCRIPTION
This fixes a bug on Ubuntu 22.04:
```

 File "/home/theuser/dev/ElectrumABC/electroncash/address.py", line 94, in ripemd160
    h = _new_hash('ripemd160')
  File "/usr/lib/python3.10/hashlib.py", line 166, in __hash_new
    return __get_builtin_constructor(name)(data)
  File "/usr/lib/python3.10/hashlib.py", line 123, in __get_builtin_constructor
    raise ValueError('unsupported hash type ' + name)
ValueError: unsupported hash type ripemd160
```
 
OpenSSL 3 deprecated ripemd160 so it is no longer available for `hashlib` by default.