### PR TITLE
Fix pay-to-many tool

### DIFF
--- a/electroncash_gui/qt/paytoedit.py
+++ b/electroncash_gui/qt/paytoedit.py
@@ -33,7 +33,7 @@ import re
 import sys
 from decimal import Decimal as PyDecimal  # Qt 5.12 also exports Decimal
 from electroncash import bitcoin
-from electroncash.address import Address, ScriptOutput
+from electroncash.address import Address, AddressError, ScriptOutput
 from electroncash import networks
 from electroncash.util import PrintError
 from electroncash.contacts import Contact
@@ -169,7 +169,7 @@ class PayToEdit(PrintError, ScanQRTextEdit):
         for i, line in enumerate(lines):
             try:
                 _type, to_address, amount = self.parse_address_and_amount(line)
-            except:
+            except (AddressError, ArithmeticError, ValueError):
                 self.errors.append((i, line.strip()))
                 continue
 

--- a/electroncash_gui/qt/paytoedit.py
+++ b/electroncash_gui/qt/paytoedit.py
@@ -139,7 +139,7 @@ class PayToEdit(PrintError, ScanQRTextEdit):
     def parse_amount(self, x):
         if x.strip() == '!':
             return '!'
-        p = pow(10, self.amount_edit.decimal_point())
+        p = pow(10, self.amount_edit.decimal_point)
         return int(p * PyDecimal(x.strip()))
 
     def check_text(self):


### PR DESCRIPTION
The pay-to-many feature has been broken for a while. The error message about invalid input lines was misleading, the actual issue was a SyntaxError hidden by a `try:... except: ...` block.