### PR TITLE
Delegation tool improvements

### DIFF
--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -307,12 +307,6 @@ class AvaProofWidget(CachedWalletPasswordWidget):
         self.generate_dg_button.setEnabled(proof is not None)
 
     def _build(self) -> Optional[str]:
-        if self.wallet.has_password() and self.pwd is None:
-            self.proof_display.setText(
-                '<p style="color:red;">Password dialog cancelled!</p>'
-            )
-            return
-
         master_wif = self.master_key_edit.text()
         if not is_private_key(master_wif):
             QtWidgets.QMessageBox.critical(
@@ -327,6 +321,12 @@ class AvaProofWidget(CachedWalletPasswordWidget):
             QtWidgets.QMessageBox.critical(self, "Invalid payout address", str(e))
             return
         payout_script = payout_address.to_script()
+
+        if self.wallet.has_password() and self.pwd is None:
+            self.proof_display.setText(
+                '<p style="color:red;">Password dialog cancelled!</p>'
+            )
+            return
 
         proofbuilder = ProofBuilder(
             sequence=self.sequence_sb.value(),

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -483,17 +483,6 @@ class AvaDelegationWidget(QtWidgets.QWidget):
     def set_master(self, master_wif: str):
         self.delegator_key_edit.setText(master_wif)
 
-    def compute_ltd_id_from_proof(self):
-        proof_hex = self.proof_edit.toPlainText()
-        try:
-            proof = Proof.from_hex(proof_hex)
-        except DeserializationError:
-            self.ltd_id_edit.setText("")
-            self.proof_title_label.setText("Proof ❌")
-        else:
-            self.ltd_id_edit.setText(proof.limitedid.get_hex())
-            self.proof_title_label.setText("Proof ✔")
-
     def on_generate_clicked(self):
         dg_hex = self._build()
         if dg_hex is not None:

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -3581,7 +3581,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         Alternatively, this dialog can be opened from the proof building dialog. It is
         then prefilled with the correct data (except the delegated public key).
         """
-        dialog = AvaDelegationDialog(parent=self)
+        dialog = AvaDelegationDialog(self.wallet, parent=self)
         dialog.show()
 
     def export_bip38_dialog(self):

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -757,7 +757,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         self.raw_transaction_menu = raw_transaction_menu
         tools_menu.addSeparator()
         avaproof_action = tools_menu.addAction(
-            "Build avalanche proof", self.build_avalanche_proof
+            "Build avalanche proof from coins file", self.build_avalanche_proof
         )
         tools_menu.addAction(
             "Build avalanche delegation", self.build_avalanche_delegation


### PR DESCRIPTION
Add a button to generate a delegated key, so the user does not need an external tool or a dummy wallet to generate safe keys.

The way to deterministically generate the key is the same as for the proof master key: use the wallet's seed with a BIP44 derivation path that is not used by wallet addresses (use `change_index = 2`).