### PR TITLE
fix password dialog for exporting BIP38 keys

### DIFF
--- a/electroncash_gui/qt/password_dialog.py
+++ b/electroncash_gui/qt/password_dialog.py
@@ -349,7 +349,9 @@ class PassphraseDialog(WindowModalDialog):
             self.setWindowModality(Qt.ApplicationModal)
 
         OK_button = OkButton(self)
-        self.playout = PasswordLayout(wallet, msg, PW_PASSPHRASE, OK_button, permit_empty=permit_empty)
+        self.playout = PasswordLayout(
+            msg, PW_PASSPHRASE, OK_button, wallet, permit_empty=permit_empty,
+        )
         self.setWindowTitle(title)
         vbox = QtWidgets.QVBoxLayout(self)
         vbox.addLayout(self.playout.layout())


### PR DESCRIPTION
This tool was broken in an electrum backport which changed the order of arguments for PasswordLayout.

