### PR TITLE
Detect and pre-fill delegator key when adding a delegation level

### DIFF
--- a/electroncash/address.py
+++ b/electroncash/address.py
@@ -23,6 +23,7 @@
 # SOFTWARE.
 
 # Many of the functions in this file are copied from ElectrumX
+from __future__ import annotations
 
 import hashlib
 import struct
@@ -165,9 +166,9 @@ class PublicKey(namedtuple("PublicKeyTuple", "pubkey")):
         raise ValueError('invalid private key')
 
     @classmethod
-    def from_WIF_privkey(cls, WIF_privkey):
-        '''Create a compressed or uncompressed public key from a private
-        key.'''
+    def from_WIF_privkey(cls, WIF_privkey) -> PublicKey:
+        """Create a compressed or uncompressed public key from a private
+        key."""
         privkey, compressed = cls.privkey_from_WIF_privkey(WIF_privkey)
         ec_key = EC_KEY(privkey)
         return cls.from_pubkey(ec_key.GetPubKey(compressed))

--- a/electroncash/keystore.py
+++ b/electroncash/keystore.py
@@ -500,7 +500,7 @@ class Old_KeyStore(Deterministic_KeyStore):
         )
 
     @classmethod
-    def get_pubkey_from_mpk(self, mpk, for_change, n):
+    def get_pubkey_from_mpk(self, mpk, for_change, n) -> str:
         z = self.get_sequence(mpk, for_change, n)
         master_public_key = ecdsa.VerifyingKey.from_string(
             bytes.fromhex(mpk), curve=SECP256k1
@@ -511,7 +511,7 @@ class Old_KeyStore(Deterministic_KeyStore):
         )
         return "04" + bh2u(public_key2.to_string())
 
-    def derive_pubkey(self, for_change, n):
+    def derive_pubkey(self, for_change, n) -> str:
         return self.get_pubkey_from_mpk(self.mpk, for_change, n)
 
     def get_private_key_from_stretched_exponent(self, for_change, n, secexp):

--- a/electroncash/tests/test_wallet_vertical.py
+++ b/electroncash/tests/test_wallet_vertical.py
@@ -2,7 +2,7 @@ import unittest
 from unittest import mock
 
 from .. import keystore, mnemo, storage, wallet
-from ..address import Address
+from ..address import Address, PublicKey
 
 
 class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
@@ -123,6 +123,21 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
             w.get_change_addresses()[0],
             Address.from_string("1GG5bVeWgAp5XW7JLCphse14QaC4qiHyWn"),
         )
+
+        expected_auxiliary_keys = [
+            "L2ETdaLkdB8ZV6k95X776wRBGJgFGMurfi35EY2DdaJHfzaVieWg",
+            "KxmCxRaEg5RvqbyiLJgpFnosfykDWzbMgz6T34HsjQSZ99BbYFiV",
+        ]
+        AUX_INDEX = 2
+        for idx, wif_key in enumerate(expected_auxiliary_keys):
+            self.assertEqual(
+                w.export_private_key_for_index((AUX_INDEX, idx), None),
+                wif_key,
+            )
+            self.assertEqual(
+                w.get_auxiliary_pubkey_index(PublicKey.from_WIF_privkey(wif_key), None),
+                idx,
+            )
 
     @mock.patch.object(storage.WalletStorage, "_write")
     def test_electrum_multisig_seed_standard(self, mock_write):

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -274,6 +274,8 @@ class AvaProofWidget(CachedWalletPasswordWidget):
         Return it in WIF format, or return an empty string on failure (pwd dialog
         cancelled).
         """
+        if not self.wallet.is_deterministic() or not self.wallet.can_export():
+            return ""
         wif_pk = ""
         if not self.wallet.has_password() or self.pwd is not None:
             wif_pk = get_privkey_suggestion(
@@ -529,6 +531,8 @@ class AvaDelegationWidget(CachedWalletPasswordWidget):
         """Open a dialog to show a private/public key pair to be used as delegated key.
         Fill the delegated public key widget with the resulting public key.
         """
+        if not self.wallet.is_deterministic() or not self.wallet.can_export():
+            return
         wif_pk = ""
         if not self.wallet.has_password() or self.pwd is not None:
             wif_pk = get_privkey_suggestion(

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -545,7 +545,9 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         self.password_menu.setEnabled(self.wallet.may_have_password())
         self.import_privkey_menu.setVisible(self.wallet.can_import_privkey())
         self.import_address_menu.setVisible(self.wallet.can_import_address())
-        self.show_aux_keys_menu.setVisible(self.wallet.is_deterministic())
+        self.show_aux_keys_menu.setVisible(
+            self.wallet.is_deterministic() and self.wallet.can_export()
+        )
         self.export_menu.setEnabled(self.wallet.can_export())
 
     def warn_if_watching_only(self):
@@ -4085,7 +4087,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
 
     @protected
     def show_auxiliary_keys(self, password):
-        if not self.wallet.is_deterministic():
+        if not self.wallet.is_deterministic() or not self.wallet.can_export():
             return
         wif0 = self.wallet.export_private_key_for_index((2, 0), password)
         wif1 = self.wallet.export_private_key_for_index((2, 1), password)


### PR DESCRIPTION
When adding a delegation level to a delegation whose delegated pubkey happens to be one of the auxiliary keys of the wallet, we can prefill the private key so the user does not have to type it.

Also add a menu to show the auxiliary public keys, because they need to be shared with the person or the machine building the original delegation.

For now this assumes that we always only use the first two keys on the `m/44'/899'/0'/2` path. 

Related to #203 and  #190