### PR TITLE
Add an invoice tool

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,8 @@ files: |
         electroncash_gui/qt/exception_window.py|
         electroncash_gui/qt/invoice_dialog.py|
         electroncash_gui/qt/multi_transactions_dialog.py|
-        electroncash_gui/qt/sign_verify_dialog.py
+        electroncash_gui/qt/sign_verify_dialog.py|
+        electroncash_gui/qt/utxo_list.py
     )$
 repos:
 -   repo: https://github.com/pycqa/isort
@@ -40,7 +41,7 @@ repos:
     -   id: flake8
         args:
         -   --max-line-length=88
-        -   --ignore=E203,E501,E731,E741,W503,SIM106,SIM119
+        -   --ignore=E203,E501,E731,E741,W503,SIM106,SIM119,FS002
         additional_dependencies:
         -   flake8-comprehensions
         -   flake8-mutable

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,7 @@ files: |
         electroncash_gui/qt/avalanche_dialogs.py|
         electroncash_gui/qt/consolidate_coins_dialog.py|
         electroncash_gui/qt/exception_window.py|
+        electroncash_gui/qt/invoice_dialog.py|
         electroncash_gui/qt/multi_transactions_dialog.py|
         electroncash_gui/qt/sign_verify_dialog.py
     )$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,6 +4,7 @@ files: |
         electroncash/avalanche/.*py|
         electroncash/consolidate.py|
         electroncash/constants.py|
+        electroncash/invoice.py|
         electroncash/keystore.py|
         electroncash/uint256.py|
         electroncash_gui/qt/address_list.py|

--- a/electroncash/invoice.py
+++ b/electroncash/invoice.py
@@ -37,10 +37,6 @@ class InvoiceDataError(Exception):
     pass
 
 
-class InvoiceLoadFromFileError(Exception):
-    pass
-
-
 class Invoice:
     def __init__(
         self,

--- a/electroncash/invoice.py
+++ b/electroncash/invoice.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+#
+# Electrum ABC - lightweight eCash client
+# Copyright (C) 2022 The Electrum ABC developers
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Dict, List, Optional, Union
+
+from .address import Address, AddressError
+
+
+class InvoiceDataError(Exception):
+    pass
+
+
+class Invoice:
+    def __init__(
+        self,
+        address: Address,
+        amount: Decimal,
+        label: str = "",
+        currency: str = "XEC",
+        exchange_rate: Optional[Union[FixedExchangeRate, APIExchangeRate]] = None,
+    ):
+        self.address = address
+        self.amount = amount
+        self.currency = currency
+        self.label = label
+        if currency.lower() != "xec":
+            assert exchange_rate is not None
+        self.exchange_rate = exchange_rate
+
+    def to_dict(self) -> dict:
+        out = {
+            "invoice": {
+                "address": self.address.to_ui_string(),
+                "label": self.label,
+                "amount": str(self.amount),
+                "currency": self.currency,
+            }
+        }
+
+        if self.exchange_rate is None:
+            return out
+
+        if isinstance(self.exchange_rate, FixedExchangeRate):
+            out["exchangeRate"] = self.exchange_rate.to_string()
+            return out
+
+        out["exchangeRateAPI"] = self.exchange_rate.to_dict()
+        return out
+
+    @classmethod
+    def from_dict(cls, data: dict) -> Invoice:
+        """Build an invoice from a dict."""
+        if "invoice" not in data:
+            raise InvoiceDataError("Missing top-level invoice node.")
+        invoice = data["invoice"]
+        currency = invoice.get("currency") or "XEC"
+        try:
+            address = Address.from_string(invoice["address"])
+        except (KeyError, AddressError):
+            raise InvoiceDataError("Missing or invalid payment address.")
+
+        if "exchangeRate" in invoice and "exchangeRateAPI" in invoice:
+            raise InvoiceDataError(
+                "Ambiguous exchange rate data (both fixed and API rates are present)"
+            )
+        if currency.lower() == "xec" and (
+            "exchangeRate" in invoice or "exchangeRateAPI" in invoice
+        ):
+            raise InvoiceDataError(
+                "Exchange rate must not be specified for XEC amounts"
+            )
+
+        rate = None
+        if "exchangeRate" in invoice:
+            rate = FixedExchangeRate(Decimal(invoice["exchangeRate"]))
+        elif "exchangeRateAPI" in invoice:
+            rate = APIExchangeRate(
+                url=invoice["exchangeRateAPI"].get("url") or "",
+                keys=invoice["exchangeRateAPI"].get("keys") or [],
+            )
+
+        return Invoice(
+            address=address,
+            amount=Decimal(invoice.get("amount", "0.")),
+            label=invoice.get("label", ""),
+            currency=currency,
+            exchange_rate=rate,
+        )
+
+
+@dataclass
+class FixedExchangeRate:
+    rate: Decimal
+
+    def to_string(self) -> str:
+        return str(self.rate)
+
+
+@dataclass
+class APIExchangeRate:
+    url: str
+    keys: List[str]
+
+    def to_dict(self) -> Dict[str, Union[str, List[str]]]:
+        return {"url": self.url, "keys": self.keys}

--- a/electroncash/tests/__main__.py
+++ b/electroncash/tests/__main__.py
@@ -13,6 +13,7 @@ from .test_consolidate import suite as test_consolidate_suite
 from .test_dnssec import TestDnsSec
 from .test_import_electroncash_data import TestImportECData
 from .test_interface import TestInterface
+from .test_invoice import TestInvoice
 from .test_mnemonic import suite as test_mnemonic_suite
 from .test_paymentrequests import Test_PaymentRequests
 from .test_schnorr import suite as test_schnorr_suite
@@ -42,6 +43,7 @@ def suite():
     test_suite.addTest(loadTests(TestDnsSec))
     test_suite.addTest(loadTests(TestImportECData))
     test_suite.addTest(loadTests(TestInterface))
+    test_suite.addTest(loadTests(TestInvoice))
     test_suite.addTest(test_mnemonic_suite())
     test_suite.addTest(loadTests(Test_PaymentRequests))
     test_suite.addTest(test_schnorr_suite())

--- a/electroncash/tests/test_invoice.py
+++ b/electroncash/tests/test_invoice.py
@@ -1,0 +1,158 @@
+import unittest
+from decimal import Decimal
+
+from ..invoice import (
+    ExchangeRateApi,
+    FixedExchangeRate,
+    Invoice,
+    InvoiceDataError,
+    MultiCurrencyExchangeRateApi,
+)
+
+
+class TestInvoice(unittest.TestCase):
+    def test_xec_amount(self):
+        invoice = Invoice.from_dict(
+            {
+                "invoice": {
+                    "address": "ecash:qzdf44zy632zk4etztvmaqav0y2cest4evtph9jyf4",
+                    "currency": "XEC",
+                    "amount": "1337.42",
+                    "label": "spam",
+                }
+            }
+        )
+        self.assertEqual(invoice.label, "spam")
+        self.assertEqual(invoice.currency, "XEC")
+        self.assertEqual(invoice.amount, Decimal("1337.42"))
+        self.assertEqual(
+            invoice.address.to_ui_string(),
+            "ecash:qzdf44zy632zk4etztvmaqav0y2cest4evtph9jyf4",
+        )
+        self.assertEqual(invoice.get_xec_amount(), Decimal("1337.42"))
+        self.assertIsNone(invoice.exchange_rate)
+
+    def test_fixed_exchange_rate(self):
+        invoice = Invoice.from_dict(
+            {
+                "invoice": {
+                    "address": "ecash:qzdf44zy632zk4etztvmaqav0y2cest4evtph9jyf4",
+                    "currency": "CHF",
+                    "amount": "42.1",
+                    "label": "spam",
+                    "exchangeRate": "0.5",
+                }
+            }
+        )
+        self.assertEqual(invoice.label, "spam")
+        self.assertEqual(invoice.currency, "CHF")
+        self.assertEqual(invoice.amount, Decimal("42.1"))
+        self.assertEqual(
+            invoice.address.to_ui_string(),
+            "ecash:qzdf44zy632zk4etztvmaqav0y2cest4evtph9jyf4",
+        )
+        self.assertEqual(invoice.exchange_rate.get_exchange_rate(), Decimal("0.5"))
+        self.assertEqual(invoice.exchange_rate.to_string(), "0.5")
+        self.assertEqual(invoice.get_xec_amount(), Decimal("84.2"))
+        self.assertIsInstance(invoice.exchange_rate, FixedExchangeRate)
+
+    def test_api_exchange_rate(self):
+        invoice = Invoice.from_dict(
+            {
+                "invoice": {
+                    "address": "ecash:qzdf44zy632zk4etztvmaqav0y2cest4evtph9jyf4",
+                    "currency": "NOK",
+                    "amount": "42.1",
+                    "label": "spam",
+                    "exchangeRateAPI": {
+                        "url": "foo",
+                        "keys": ["bar"],
+                    },
+                }
+            }
+        )
+        self.assertEqual(invoice.label, "spam")
+        self.assertEqual(invoice.currency, "NOK")
+        self.assertEqual(invoice.amount, Decimal("42.1"))
+        self.assertEqual(
+            invoice.address.to_ui_string(),
+            "ecash:qzdf44zy632zk4etztvmaqav0y2cest4evtph9jyf4",
+        )
+        self.assertEqual(invoice.exchange_rate.url, "foo")
+        self.assertEqual(invoice.exchange_rate.keys, ["bar"])
+        self.assertIsInstance(invoice.exchange_rate, ExchangeRateApi)
+
+    def test_invoice_data_errors(self):
+        vector = [
+            # Missing top-level "invoice" node
+            {
+                "address": "ecash:qzdf44zy632zk4etztvmaqav0y2cest4evtph9jyf4",
+                "currency": "XEC",
+                "amount": "1337.42",
+                "label": "spam",
+            },
+            # bad address
+            {
+                "invoice": {
+                    "address": "icash:qzdf44zy632zk4etztvmaqav0y2cest4evtph9jyf4",
+                    "currency": "XEC",
+                    "amount": "1337.42",
+                    "label": "spam",
+                }
+            },
+            # XEC amount with exchange rate
+            {
+                "invoice": {
+                    "address": "ecash:qzdf44zy632zk4etztvmaqav0y2cest4evtph9jyf4",
+                    "currency": "XEC",
+                    "amount": "1337.42",
+                    "label": "spam",
+                    "exchangeRate": "1.5",
+                }
+            },
+            # XEC amount with exchange rate API
+            {
+                "invoice": {
+                    "address": "ecash:qzdf44zy632zk4etztvmaqav0y2cest4evtph9jyf4",
+                    "currency": "XEC",
+                    "amount": "1337.42",
+                    "label": "spam",
+                    "exchangeRateAPI": {
+                        "url": "foo",
+                        "keys": ["bar"],
+                    },
+                }
+            },
+            # Both exchangeRate and exchangeRateAPI are specified (ambiguous)
+            {
+                "invoice": {
+                    "address": "icash:qzdf44zy632zk4etztvmaqav0y2cest4evtph9jyf4",
+                    "currency": "USD",
+                    "amount": "1337.42",
+                    "label": "spam",
+                    "exchangeRate": "1.5",
+                    "exchangeRateAPI": {
+                        "url": "foo",
+                        "keys": ["bar"],
+                    },
+                }
+            },
+        ]
+        for data in vector:
+            # Missing top-level "invoice" node
+            with self.assertRaises(InvoiceDataError):
+                Invoice.from_dict(data)
+
+    def test_multicurrency_exchange_rate_api(self):
+        api = MultiCurrencyExchangeRateApi(
+            url="spam-%cur%_foo%CUR%",
+            keys=["foo%cur%", "%CUR%spam", "bar"],
+        )
+        self.assertEqual(api.get_url(currency="eur"), "spam-eur_fooEUR")
+        self.assertEqual(api.get_url(currency="EUR"), "spam-eur_fooEUR")
+        self.assertEqual(api.get_keys(currency="usd"), ["foousd", "USDspam", "bar"])
+        self.assertEqual(api.get_keys(currency="USD"), ["foousd", "USDspam", "bar"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/electroncash_gui/qt/address_list.py
+++ b/electroncash_gui/qt/address_list.py
@@ -43,6 +43,7 @@ from electroncash.wallet import Multisig_Wallet
 
 from . import cashacctqt
 from .consolidate_coins_dialog import ConsolidateCoinsWizard
+from .invoice_dialog import InvoiceDialog
 from .util import (
     MONOSPACE_FONT,
     ColorScheme,
@@ -170,7 +171,7 @@ class AddressList(MyTreeWidget):
                     # recurse, do leaves first
                     restore_expanded_items(it, expanded_item_names)
                     old = bool(it.isExpanded())
-                    new = bool(item_path(it) in expanded_item_names)
+                    new = item_path(it) in expanded_item_names
                     if old != new:
                         it.setExpanded(new)
 
@@ -395,6 +396,10 @@ class AddressList(MyTreeWidget):
                 # self.parent.receive_at(addr). This is because the recieve tab
                 # now strongly enforces no-address-reuse. See #1552.
                 a.setDisabled(True)
+            a = menu.addAction(
+                _("Request payment (via invoice file)"),
+                lambda: self.create_invoice(addr),
+            )
             if self.wallet.can_export():
                 menu.addAction(
                     _("Private key"), lambda: self.parent.show_private_key(addr)
@@ -629,4 +634,9 @@ class AddressList(MyTreeWidget):
 
     def _open_consolidate_coins_dialog(self, addr):
         d = ConsolidateCoinsWizard(addr, self.parent.wallet, self.parent, parent=self)
+        d.exec_()
+
+    def create_invoice(self, address: Address):
+        d = InvoiceDialog(self)
+        d.set_address(address)
         d.exec_()

--- a/electroncash_gui/qt/amountedit.py
+++ b/electroncash_gui/qt/amountedit.py
@@ -79,6 +79,10 @@ class AmountEdit(MyLineEdit):
         except (ValueError, ArithmeticError):
             return None
 
+    def set_base_unit(self, base_unit: str):
+        self.base_unit = base_unit
+        self.update()
+
 
 class XECAmountEdit(AmountEdit):
     def __init__(self, decimal_point: int, is_int=False, parent=None):

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -49,6 +49,7 @@ class InvoiceDialog(QtWidgets.QDialog):
         super().__init__(parent)
         self.setMinimumWidth(650)
         self.setMinimumHeight(520)
+        self.setWindowTitle(_("Create or modify an invoice"))
 
         layout = QtWidgets.QVBoxLayout()
         self.setLayout(layout)

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -45,6 +45,11 @@ class InvoiceDialog(QtWidgets.QDialog):
         layout.addWidget(self.address_edit)
         layout.addSpacing(10)
 
+        layout.addWidget(QtWidgets.QLabel(_("Label")))
+        self.label_edit = QtWidgets.QLineEdit()
+        layout.addWidget(self.label_edit)
+        layout.addSpacing(10)
+
         self.amount_currency_edit = AmountCurrencyEdit()
         layout.addWidget(self.amount_currency_edit)
         layout.addSpacing(10)
@@ -114,6 +119,7 @@ class InvoiceDialog(QtWidgets.QDialog):
         out = {
             "invoice": {
                 "address": payment_address,
+                "label": self.label_edit.text(),
                 "amount": self.amount_currency_edit.get_amount_as_string(),
                 "currency": currency,
             }
@@ -157,6 +163,7 @@ class InvoiceDialog(QtWidgets.QDialog):
             return
         invoice = data["invoice"]
         self.address_edit.setText(invoice.get("address") or "")
+        self.label_edit.setText(invoice.get("label") or "")
         self.amount_currency_edit.set_amount(invoice.get("amount") or "0")
         self.amount_currency_edit.set_currency(invoice.get("currency") or "XEC")
         if "exchangeRate" in invoice:

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -36,11 +36,11 @@ from electroncash.address import Address, AddressError
 from electroncash.i18n import _
 from electroncash.invoice import (
     APIS,
-    APIExchangeRate,
-    ExchangeRateAPI,
+    ExchangeRateApi,
     FixedExchangeRate,
     Invoice,
     InvoiceDataError,
+    MultiCurrencyExchangeRateApi,
 )
 
 
@@ -278,16 +278,16 @@ class ExchangeRateWidget(QtWidgets.QWidget):
     def is_fixed_rate(self) -> bool:
         return self.fixed_rate_rb.isChecked()
 
-    def get_rate(self) -> Union[FixedExchangeRate, APIExchangeRate]:
+    def get_rate(self) -> Union[FixedExchangeRate, ExchangeRateApi]:
         if self.is_fixed_rate():
             return FixedExchangeRate(Decimal(f"{self.rate_edit.value():.10f}"))
-        return APIExchangeRate(self.api_widget.get_url(), self.api_widget.get_keys())
+        return ExchangeRateApi(self.api_widget.get_url(), self.api_widget.get_keys())
 
-    def set_rate(self, exchange_rate: Union[FixedExchangeRate, APIExchangeRate]):
+    def set_rate(self, exchange_rate: Union[FixedExchangeRate, ExchangeRateApi]):
         if isinstance(exchange_rate, FixedExchangeRate):
             self.fixed_rate_rb.setChecked(True)
             self.rate_edit.setValue(float(exchange_rate.rate))
-        elif isinstance(exchange_rate, APIExchangeRate):
+        elif isinstance(exchange_rate, ExchangeRateApi):
             self.api_rate_rb.setChecked(True)
             self.api_widget.set_url(exchange_rate.url)
             self.api_widget.set_keys(exchange_rate.keys)
@@ -360,7 +360,7 @@ class ExchangeRateAPIWidget(QtWidgets.QWidget):
         return self.keys_edit.setText(", ".join(keys))
 
     def _on_test_api_clicked(self):
-        api = ExchangeRateAPI(self.get_url(), self.get_keys())
+        api = MultiCurrencyExchangeRateApi(self.get_url(), self.get_keys())
         try:
             rate = api.get_exchange_rate(self._currency)
         except (

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -30,6 +30,7 @@ from typing import List, Optional, Type
 from PyQt5 import QtCore, QtWidgets
 
 from electroncash.address import Address, AddressError
+from electroncash.i18n import _
 
 
 class InvoiceDialog(QtWidgets.QDialog):
@@ -39,7 +40,7 @@ class InvoiceDialog(QtWidgets.QDialog):
         layout = QtWidgets.QVBoxLayout()
         self.setLayout(layout)
 
-        layout.addWidget(QtWidgets.QLabel("Payment address"))
+        layout.addWidget(QtWidgets.QLabel(_("Payment address")))
         self.address_edit = QtWidgets.QLineEdit()
         layout.addWidget(self.address_edit)
         layout.addSpacing(10)
@@ -56,9 +57,9 @@ class InvoiceDialog(QtWidgets.QDialog):
         buttons_layout = QtWidgets.QHBoxLayout()
         layout.addLayout(buttons_layout)
 
-        self.save_button = QtWidgets.QPushButton("Save invoice")
+        self.save_button = QtWidgets.QPushButton(_("Save invoice"))
         buttons_layout.addWidget(self.save_button)
-        self.load_button = QtWidgets.QPushButton("Load invoice")
+        self.load_button = QtWidgets.QPushButton(_("Load invoice"))
         buttons_layout.addWidget(self.load_button)
 
         # Trigger callback to init widgets
@@ -76,7 +77,7 @@ class InvoiceDialog(QtWidgets.QDialog):
     def _on_save_clicked(self):
         filename, _selected_filter = QtWidgets.QFileDialog.getSaveFileName(
             self,
-            "Save invoice to file",
+            _("Save invoice to file"),
             filter="JSON file (*.json);;All files (*)",
         )
 
@@ -96,7 +97,9 @@ class InvoiceDialog(QtWidgets.QDialog):
             Address.from_string(address_string)
         except AddressError:
             QtWidgets.QMessageBox.critical(
-                self, "Invalid payment address", "Unable to decode payement address"
+                self,
+                _("Invalid payment address"),
+                _("Unable to decode payement address"),
             )
             return ""
         return address_string
@@ -143,7 +146,7 @@ class AmountCurrencyEdit(QtWidgets.QWidget):
         self.setLayout(layout)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        layout.addWidget(QtWidgets.QLabel("Amount"))
+        layout.addWidget(QtWidgets.QLabel(_("Amount")))
         amount_layout = QtWidgets.QHBoxLayout()
         self.amount_edit = QtWidgets.QDoubleSpinBox()
         self.amount_edit.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
@@ -174,10 +177,10 @@ class ExchangeRateWidget(QtWidgets.QWidget):
         self.setLayout(layout)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        layout.addWidget(QtWidgets.QLabel("Exchange rate"))
+        layout.addWidget(QtWidgets.QLabel(_("Exchange rate")))
         fixed_rate_layout = QtWidgets.QHBoxLayout()
         layout.addLayout(fixed_rate_layout)
-        self.fixed_rate_rb = QtWidgets.QRadioButton("Fixed rate")
+        self.fixed_rate_rb = QtWidgets.QRadioButton(_("Fixed rate"))
         fixed_rate_layout.addWidget(self.fixed_rate_rb)
         self.rate_edit = QtWidgets.QDoubleSpinBox()
         self.rate_edit.setDecimals(8)
@@ -187,7 +190,7 @@ class ExchangeRateWidget(QtWidgets.QWidget):
 
         api_rate_layout = QtWidgets.QVBoxLayout()
         layout.addLayout(api_rate_layout)
-        self.api_rate_rb = QtWidgets.QRadioButton("Fetch the rate at payment time")
+        self.api_rate_rb = QtWidgets.QRadioButton(_("Fetch the rate at payment time"))
         api_rate_layout.addWidget(self.api_rate_rb)
 
         self.api_widget = ExchangeRateAPIWidget()
@@ -212,7 +215,7 @@ class ExchangeRateWidget(QtWidgets.QWidget):
         self.rate_edit.setValue(1.0)
 
     def set_currency(self, currency: str):
-        self.fixed_rate_rb.setText(f"Fixed rate ({currency}/XEC)")
+        self.fixed_rate_rb.setText(_("Fixed rate ") + f"({currency}/XEC)")
         self.api_widget.set_currency(currency)
 
     def _on_api_rate_clicked(self, is_checked: bool):
@@ -275,12 +278,12 @@ class ExchangeRateAPIWidget(QtWidgets.QWidget):
         layout = QtWidgets.QVBoxLayout()
         self.setLayout(layout)
 
-        layout.addWidget(QtWidgets.QLabel("Request URL"))
+        layout.addWidget(QtWidgets.QLabel(_("Request URL")))
         self.request_url_edit = QtWidgets.QComboBox()
         self.request_url_edit.setEditable(True)
         layout.addWidget(self.request_url_edit)
 
-        layout.addWidget(QtWidgets.QLabel("Keys"))
+        layout.addWidget(QtWidgets.QLabel(_("Keys")))
         self.keys_edit = QtWidgets.QLineEdit()
         layout.addWidget(self.keys_edit)
 

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -24,7 +24,8 @@
 # SOFTWARE.
 from __future__ import annotations
 
-from typing import Optional
+import enum
+from typing import List, Optional, Type
 
 from PyQt5 import QtCore, QtWidgets
 
@@ -49,6 +50,8 @@ class InvoiceDialog(QtWidgets.QDialog):
         layout.addWidget(self.exchange_rate_widget)
         layout.addSpacing(10)
 
+        layout.addStretch(1)
+
         # Trigger callback to init widgets
         self._on_currency_changed(self.amount_currency_edit.get_currency())
 
@@ -57,7 +60,7 @@ class InvoiceDialog(QtWidgets.QDialog):
 
     def _on_currency_changed(self, currency: str):
         self.exchange_rate_widget.setVisible(currency.lower() != "xec")
-        self.exchange_rate_widget.setCurrency(currency)
+        self.exchange_rate_widget.set_currency(currency)
 
 
 class AmountCurrencyEdit(QtWidgets.QWidget):
@@ -67,6 +70,7 @@ class AmountCurrencyEdit(QtWidgets.QWidget):
         super().__init__(parent)
         layout = QtWidgets.QVBoxLayout()
         self.setLayout(layout)
+        layout.setContentsMargins(0, 0, 0, 0)
 
         layout.addWidget(QtWidgets.QLabel("Amount"))
         amount_layout = QtWidgets.QHBoxLayout()
@@ -94,7 +98,9 @@ class ExchangeRateWidget(QtWidgets.QWidget):
         super().__init__(parent)
         layout = QtWidgets.QVBoxLayout()
         self.setLayout(layout)
+        layout.setContentsMargins(0, 0, 0, 0)
 
+        layout.addWidget(QtWidgets.QLabel("Exchange rate"))
         fixed_rate_layout = QtWidgets.QHBoxLayout()
         layout.addLayout(fixed_rate_layout)
         self.fixed_rate_rb = QtWidgets.QRadioButton("Fixed rate")
@@ -103,11 +109,129 @@ class ExchangeRateWidget(QtWidgets.QWidget):
         self.rate_edit.setDecimals(8)
         self.rate_edit.setRange(10**-8, 10**100)
         self.rate_edit.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
-        self.rate_edit.setValue(1.0)
         fixed_rate_layout.addWidget(self.rate_edit)
 
-    def setCurrency(self, currency: str):
+        api_rate_layout = QtWidgets.QVBoxLayout()
+        layout.addLayout(api_rate_layout)
+        self.api_rate_rb = QtWidgets.QRadioButton("Fetch the rate at payment time")
+        api_rate_layout.addWidget(self.api_rate_rb)
+
+        self.api_widget = ExchangeRateAPIWidget()
+        margins = self.api_widget.contentsMargins()
+        margins.setLeft(margins.left() + 10)
+        self.api_widget.setContentsMargins(margins)
+
+        api_rate_layout.addWidget(self.api_widget)
+
+        # Signals
+        self.api_rate_rb.toggled.connect(self._on_api_rate_clicked)
+
+        # Default state
+        # Use an exclusive button group to disallow unckecking the check radio button
+        self._button_group = QtWidgets.QButtonGroup()
+        self._button_group.setExclusive(True)
+        self._button_group.addButton(self.fixed_rate_rb)
+        self._button_group.addButton(self.api_rate_rb)
+
+        self.api_widget.setVisible(False)
+        self.fixed_rate_rb.setChecked(True)
+        self.rate_edit.setValue(1.0)
+
+    def set_currency(self, currency: str):
         self.fixed_rate_rb.setText(f"Fixed rate ({currency}/XEC)")
+        self.api_widget.set_currency(currency)
+
+    def _on_api_rate_clicked(self, is_checked: bool):
+        self.api_widget.setVisible(is_checked)
+
+
+class APIDataFormat(enum.Enum):
+    JSON = 1
+    YAML = 2
+
+
+class ExchangeRateAPI:
+    def __init__(self, currency: str):
+        self._currency = currency
+        self.url: str = ""
+        self.format: APIDataFormat = APIDataFormat.JSON
+        self.keys: List[str] = []
+
+
+class CoingeckoAPI1(ExchangeRateAPI):
+    def __init__(self, currency: str):
+        super().__init__(currency)
+        self.url = f"https://api.coingecko.com/api/v3/simple/price?ids=ecash&vs_currencies={currency.lower()}"
+        self.format = APIDataFormat.JSON
+        self.keys = ["ecash", f"{currency.lower()}"]
+
+
+class CoingeckoAPI2(ExchangeRateAPI):
+    def __init__(self, currency: str):
+        super().__init__(currency)
+        self.url = "https://api.coingecko.com/api/v3/coins/ecash?localization=False&sparkline=false"
+        self.format = APIDataFormat.JSON
+        self.keys = ["market_data", "current_price", f"{currency.lower()}"]
+
+
+APIS: List[Type[ExchangeRateAPI]] = [CoingeckoAPI1, CoingeckoAPI2]
+
+
+class ExchangeRateAPIWidget(QtWidgets.QWidget):
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
+        super().__init__(parent)
+
+        layout = QtWidgets.QVBoxLayout()
+        self.setLayout(layout)
+
+        layout.addWidget(QtWidgets.QLabel("Request URL"))
+        self.request_url_edit = QtWidgets.QComboBox()
+        self.request_url_edit.setEditable(True)
+        layout.addWidget(self.request_url_edit)
+
+        layout.addWidget(QtWidgets.QLabel("Data format"))
+        data_format_layout = QtWidgets.QHBoxLayout()
+        layout.addLayout(data_format_layout)
+
+        self.json_rb = QtWidgets.QRadioButton("JSON")
+        data_format_layout.addWidget(self.json_rb)
+        self.yaml_rb = QtWidgets.QRadioButton("YAML")
+        data_format_layout.addWidget(self.yaml_rb)
+
+        layout.addWidget(QtWidgets.QLabel("Keys"))
+        self.keys_edit = QtWidgets.QLineEdit()
+        layout.addWidget(self.keys_edit)
+
+        # Default state
+        self._currency: str = ""
+        self.set_currency("USD")
+        self.json_rb.setChecked(True)
+
+        # signals
+        self.request_url_edit.currentIndexChanged.connect(self._on_api_url_selected)
+
+    def set_currency(self, currency: str):
+        self._currency = currency
+        # Update currency part of preset URLs while remembering selection
+        index = self.request_url_edit.currentIndex()
+        self.request_url_edit.clear()
+        apis: List[ExchangeRateAPI] = []
+        for api_class in APIS:
+            api = api_class(currency)
+            self.request_url_edit.addItem(api.url)
+            apis.append(api)
+        self.request_url_edit.setCurrentIndex(index)
+
+    def _on_api_url_selected(self, index: int):
+        if index < 0:
+            self.keys_edit.clear()
+            return
+        api = APIS[index](self._currency)
+        self.keys_edit.setText(", ".join(api.keys))
+        if api.format == APIDataFormat.JSON:
+            self.json_rb.setChecked(True)
+        else:
+            self.yaml_rb.setChecked(True)
 
 
 if __name__ == "__main__":

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -88,7 +88,7 @@ class InvoiceDialog(QtWidgets.QDialog):
             return
 
         with open(filename, "w") as f:
-            json.dump(self.get_params_dict(), f)
+            json.dump(self.get_params_dict(), f, indent=4)
 
     def get_payment_address(self) -> str:
         address_string = self.address_edit.text().strip()
@@ -279,10 +279,6 @@ class ExchangeRateAPIWidget(QtWidgets.QWidget):
         self.request_url_edit = QtWidgets.QComboBox()
         self.request_url_edit.setEditable(True)
         layout.addWidget(self.request_url_edit)
-
-        layout.addWidget(QtWidgets.QLabel("Data format"))
-        data_format_layout = QtWidgets.QHBoxLayout()
-        layout.addLayout(data_format_layout)
 
         layout.addWidget(QtWidgets.QLabel("Keys"))
         self.keys_edit = QtWidgets.QLineEdit()

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -36,6 +36,8 @@ from electroncash.i18n import _
 class InvoiceDialog(QtWidgets.QDialog):
     def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
         super().__init__(parent)
+        self.setMinimumWidth(650)
+        self.setMinimumHeight(520)
 
         layout = QtWidgets.QVBoxLayout()
         self.setLayout(layout)
@@ -402,10 +404,3 @@ class ExchangeRateAPIWidget(QtWidgets.QWidget):
 
     def set_keys(self, keys: List[str]):
         return self.keys_edit.setText(", ".join(keys))
-
-
-if __name__ == "__main__":
-    app = QtWidgets.QApplication([])
-    w = InvoiceDialog()
-    w.show()
-    app.exec_()

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -24,7 +24,6 @@
 # SOFTWARE.
 from __future__ import annotations
 
-import enum
 from typing import List, Optional, Type
 
 from PyQt5 import QtCore, QtWidgets
@@ -145,16 +144,10 @@ class ExchangeRateWidget(QtWidgets.QWidget):
         self.api_widget.setVisible(is_checked)
 
 
-class APIDataFormat(enum.Enum):
-    JSON = 1
-    YAML = 2
-
-
 class ExchangeRateAPI:
     def __init__(self, currency: str):
         self._currency = currency
         self.url: str = ""
-        self.format: APIDataFormat = APIDataFormat.JSON
         self.keys: List[str] = []
 
 
@@ -162,7 +155,6 @@ class CoingeckoAPI1(ExchangeRateAPI):
     def __init__(self, currency: str):
         super().__init__(currency)
         self.url = f"https://api.coingecko.com/api/v3/simple/price?ids=ecash&vs_currencies={currency.lower()}"
-        self.format = APIDataFormat.JSON
         self.keys = ["ecash", f"{currency.lower()}"]
 
 
@@ -170,7 +162,6 @@ class CoingeckoAPI2(ExchangeRateAPI):
     def __init__(self, currency: str):
         super().__init__(currency)
         self.url = "https://api.coingecko.com/api/v3/coins/ecash?localization=False&sparkline=false"
-        self.format = APIDataFormat.JSON
         self.keys = ["market_data", "current_price", f"{currency.lower()}"]
 
 
@@ -178,7 +169,6 @@ class BinanceUSDT(ExchangeRateAPI):
     def __init__(self, currency: str):
         super().__init__(currency)
         self.url = "https://api.binance.com/api/v3/avgPrice?symbol=XECUSDT"
-        self.format = APIDataFormat.JSON
         self.keys = ["price"]
 
 
@@ -186,7 +176,6 @@ class BinanceBUSD(ExchangeRateAPI):
     def __init__(self, currency: str):
         super().__init__(currency)
         self.url = "https://api.binance.com/api/v3/avgPrice?symbol=XECBUSD"
-        self.format = APIDataFormat.JSON
         self.keys = ["price"]
 
 
@@ -214,11 +203,6 @@ class ExchangeRateAPIWidget(QtWidgets.QWidget):
         data_format_layout = QtWidgets.QHBoxLayout()
         layout.addLayout(data_format_layout)
 
-        self.json_rb = QtWidgets.QRadioButton("JSON")
-        data_format_layout.addWidget(self.json_rb)
-        self.yaml_rb = QtWidgets.QRadioButton("YAML")
-        data_format_layout.addWidget(self.yaml_rb)
-
         layout.addWidget(QtWidgets.QLabel("Keys"))
         self.keys_edit = QtWidgets.QLineEdit()
         layout.addWidget(self.keys_edit)
@@ -226,7 +210,6 @@ class ExchangeRateAPIWidget(QtWidgets.QWidget):
         # Default state
         self._currency: str = ""
         self.set_currency("USD")
-        self.json_rb.setChecked(True)
 
         # signals
         self.request_url_edit.currentIndexChanged.connect(self._on_api_url_selected)
@@ -249,10 +232,6 @@ class ExchangeRateAPIWidget(QtWidgets.QWidget):
             return
         api = APIS[index](self._currency)
         self.keys_edit.setText(", ".join(api.keys))
-        if api.format == APIDataFormat.JSON:
-            self.json_rb.setChecked(True)
-        else:
-            self.yaml_rb.setChecked(True)
 
 
 if __name__ == "__main__":

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -287,12 +287,13 @@ class ExchangeRateAPIWidget(QtWidgets.QWidget):
         self.keys_edit = QtWidgets.QLineEdit()
         layout.addWidget(self.keys_edit)
 
+        # signals
+        self.request_url_edit.currentIndexChanged.connect(self._on_api_url_selected)
+
         # Default state
         self._currency: str = ""
         self.set_currency("USD")
-
-        # signals
-        self.request_url_edit.currentIndexChanged.connect(self._on_api_url_selected)
+        self.request_url_edit.setCurrentIndex(0)
 
     def set_currency(self, currency: str):
         self._currency = currency

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -174,7 +174,28 @@ class CoingeckoAPI2(ExchangeRateAPI):
         self.keys = ["market_data", "current_price", f"{currency.lower()}"]
 
 
-APIS: List[Type[ExchangeRateAPI]] = [CoingeckoAPI1, CoingeckoAPI2]
+class BinanceUSDT(ExchangeRateAPI):
+    def __init__(self, currency: str):
+        super().__init__(currency)
+        self.url = "https://api.binance.com/api/v3/avgPrice?symbol=XECUSDT"
+        self.format = APIDataFormat.JSON
+        self.keys = ["price"]
+
+
+class BinanceBUSD(ExchangeRateAPI):
+    def __init__(self, currency: str):
+        super().__init__(currency)
+        self.url = "https://api.binance.com/api/v3/avgPrice?symbol=XECBUSD"
+        self.format = APIDataFormat.JSON
+        self.keys = ["price"]
+
+
+APIS: List[Type[ExchangeRateAPI]] = [
+    CoingeckoAPI1,
+    CoingeckoAPI2,
+    BinanceUSDT,
+    BinanceBUSD,
+]
 
 
 class ExchangeRateAPIWidget(QtWidgets.QWidget):

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -190,7 +190,7 @@ class ExchangeRateWidget(QtWidgets.QWidget):
 
         api_rate_layout = QtWidgets.QVBoxLayout()
         layout.addLayout(api_rate_layout)
-        self.api_rate_rb = QtWidgets.QRadioButton(_("Fetch the rate at payment time"))
+        self.api_rate_rb = QtWidgets.QRadioButton(_("Fetch rate at payment time"))
         api_rate_layout.addWidget(self.api_rate_rb)
 
         self.api_widget = ExchangeRateAPIWidget()
@@ -285,6 +285,12 @@ class ExchangeRateAPIWidget(QtWidgets.QWidget):
 
         layout.addWidget(QtWidgets.QLabel(_("Keys")))
         self.keys_edit = QtWidgets.QLineEdit()
+        self.keys_edit.setToolTip(
+            _(
+                "Comma separated list of JSON keys used to find the exchange rate in the "
+                "data sent by the API."
+            )
+        )
         layout.addWidget(self.keys_edit)
 
         # signals

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+# Electrum ABC - lightweight eCash client
+# Copyright (C) 2022 The Electrum ABC developers
+#
+# Permission is hereby granted, free of charge, to any person
+# obtaining a copy of this software and associated documentation files
+# (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge,
+# publish, distribute, sublicense, and/or sell copies of the Software,
+# and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+# BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+# ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+# CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from __future__ import annotations
+
+from typing import Optional
+
+from PyQt5 import QtWidgets
+
+
+class InvoiceDialog(QtWidgets.QDialog):
+    def __init__(self, parent: Optional[QtWidgets.QWidget] = None):
+        super().__init__(parent)
+
+        layout = QtWidgets.QVBoxLayout()
+        self.setLayout(layout)
+
+        layout.addWidget(QtWidgets.QLabel("Payment address"))
+        self.address_edit = QtWidgets.QLineEdit()
+        layout.addWidget(self.address_edit)
+        layout.addSpacing(10)
+
+        layout.addWidget(QtWidgets.QLabel("Amount"))
+        amount_layout = QtWidgets.QHBoxLayout()
+        self.amount_edit = QtWidgets.QDoubleSpinBox()
+        self.amount_edit.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
+        self.amount_edit.setDecimals(2)
+        self.amount_edit.setRange(0, 10**100)
+        amount_layout.addWidget(self.amount_edit)
+
+        self.currency_edit = QtWidgets.QComboBox()
+        self.currency_edit.addItems(["XEC", "USD", "EUR"])
+        self.currency_edit.setCurrentText("XEC")
+        self.currency_edit.setEditable(True)
+        amount_layout.addWidget(self.currency_edit)
+
+        layout.addLayout(amount_layout)
+        layout.addSpacing(10)
+
+        self.exchange_rate_widget = QtWidgets.QWidget()
+        self.exchange_rate_widget.setVisible(
+            self.currency_edit.currentText().lower() != "xec"
+        )
+        rate_layout = QtWidgets.QVBoxLayout()
+        self.exchange_rate_widget.setLayout(rate_layout)
+        fixed_rate_layout = QtWidgets.QHBoxLayout()
+        rate_layout.addLayout(fixed_rate_layout)
+        self.fixed_rate_rb = QtWidgets.QRadioButton("Fixed rate")
+        fixed_rate_layout.addWidget(self.fixed_rate_rb)
+        self.rate_edit = QtWidgets.QDoubleSpinBox()
+        self.rate_edit.setDecimals(8)
+        self.rate_edit.setRange(10**-8, 10**100)
+        self.rate_edit.setStepType(QtWidgets.QAbstractSpinBox.AdaptiveDecimalStepType)
+        self.rate_edit.setValue(1.0)
+        fixed_rate_layout.addWidget(self.rate_edit)
+
+        layout.addWidget(self.exchange_rate_widget)
+
+        self._on_currency_changed(self.currency_edit.currentText())
+
+        # signals
+        self.currency_edit.currentTextChanged.connect(self._on_currency_changed)
+
+    def _on_currency_changed(self, currency: str):
+        self.exchange_rate_widget.setVisible(currency.lower() != "xec")
+        self.fixed_rate_rb.setText(f"Fixed rate ({currency}/XEC)")
+
+
+if __name__ == "__main__":
+    app = QtWidgets.QApplication([])
+    w = InvoiceDialog()
+    w.show()
+    app.exec_()

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -147,6 +147,9 @@ class InvoiceDialog(QtWidgets.QDialog):
         if not filename:
             return
 
+        self.load_from_file(filename)
+
+    def load_from_file(self, filename: str):
         failed_decoding = False
         with open(filename, "r") as f:
             try:
@@ -182,6 +185,9 @@ class InvoiceDialog(QtWidgets.QDialog):
             url = invoice["exchangeRateAPI"].get("url") or ""
             keys = invoice["exchangeRateAPI"].get("keys") or []
             self.exchange_rate_widget.set_api_rate_params(url, keys)
+
+    def set_address(self, address: Address):
+        self.address_edit.setText(address.to_ui_string())
 
 
 class AmountCurrencyEdit(QtWidgets.QWidget):

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -155,29 +155,22 @@ class InvoiceDialog(QtWidgets.QDialog):
         self.load_from_file(filename)
 
     def load_from_file(self, filename: str):
+        error = None
         with open(filename, "r") as f:
             try:
                 data = json.load(f)
-            except json.JSONDecodeError as e:
-                QtWidgets.QMessageBox.critical(
-                    self,
-                    _("Failed to load invoice"),
-                    _("Unable to decode JSON data for invoice")
-                    + f" {filename}.\n\n"
-                    + _("The following error was raised:")
-                    + f"{type(e).__name__}: {e}",
-                )
-                return
-        try:
-            invoice = Invoice.from_dict(data)
-        except InvoiceDataError as e:
+                invoice = Invoice.from_dict(data)
+            except (json.JSONDecodeError, InvoiceDataError) as e:
+                error = e
+
+        if error is not None:
             QtWidgets.QMessageBox.critical(
                 self,
                 _("Failed to load invoice"),
                 _("Unable to decode JSON data for invoice")
                 + f" {filename}.\n\n"
                 + _("The following error was raised:\n\n")
-                + f"{type(e).__name__}: {e}",
+                + f"{type(error).__name__}: {error}",
             )
             return
 

--- a/electroncash_gui/qt/invoice_dialog.py
+++ b/electroncash_gui/qt/invoice_dialog.py
@@ -73,7 +73,7 @@ class InvoiceDialog(QtWidgets.QDialog):
         # signals
         self.amount_currency_edit.currencyChanged.connect(self._on_currency_changed)
         self.save_button.clicked.connect(self._on_save_clicked)
-        self.load_button.clicked.connect(self._on_load_clicked)
+        self.load_button.clicked.connect(self.open_file_and_load_invoice)
 
     def _on_currency_changed(self, currency: str):
         self.exchange_rate_widget.setVisible(currency.lower() != "xec")
@@ -137,7 +137,7 @@ class InvoiceDialog(QtWidgets.QDialog):
         out["invoice"]["exchangeRateAPI"] = {"url": url, "keys": keys}
         return out
 
-    def _on_load_clicked(self):
+    def open_file_and_load_invoice(self):
         filename, _selected_filter = QtWidgets.QFileDialog.getOpenFileName(
             self,
             _("Load invoice from file"),

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -3567,21 +3567,28 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             return
 
         invoice = load_invoice_from_file_and_show_error_message(filename, self)
+        xec_amount = invoice.get_xec_amount()
+        computed_rate = invoice.amount / xec_amount
         if invoice is None:
             return
+        self.show_send_tab()
+        self.payto_e.setText(invoice.address.to_ui_string())
+        self.amount_e.setText(str(xec_amount))
+        self.message_e.setText(invoice.label)
+        # signal to set fee
+        self.amount_e.textEdited.emit("")
+
         QtWidgets.QMessageBox.warning(
             self,
             _("Paying invoice"),
             _("You are about to use the experimental 'Pay Invoice' feature. Please "
-              "review the XEC amount carefully and make sure the applied exchange rate "
-              "was sensible before sending.")
+              "review the XEC amount carefully before sending the transaction.") +
+            f"\n\nAddress: {invoice.address.to_ui_string()}"
+            f"\n\nAmount: {xec_amount}"
+            f"\n\nLabel: {invoice.label}"
+            f"\n\nInvoice currency: {invoice.currency}"
+            f"\n\nExchange rate ({invoice.currency}/XEC): {1 if invoice.exchange_rate is None else computed_rate}"
         )
-        self.show_send_tab()
-        self.payto_e.setText(invoice.address.to_ui_string())
-        self.amount_e.setText(str(invoice.get_xec_amount()))
-        self.message_e.setText(invoice.label)
-        # signal to set fee
-        self.amount_e.textEdited.emit("")
 
     def build_avalanche_proof(self):
         """Open a dialog to build an avalanche proof from coins metadata

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -3568,12 +3568,13 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
 
         invoice = load_invoice_from_file_and_show_error_message(filename, self)
         xec_amount = invoice.get_xec_amount()
+        amount_str = format_satoshis_plain(int(xec_amount * 100), self.decimal_point)
         computed_rate = invoice.amount / xec_amount
         if invoice is None:
             return
         self.show_send_tab()
         self.payto_e.setText(invoice.address.to_ui_string())
-        self.amount_e.setText(str(xec_amount))
+        self.amount_e.setText(amount_str)
         self.message_e.setText(invoice.label)
         # signal to set fee
         self.amount_e.textEdited.emit("")
@@ -3584,10 +3585,11 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             _("You are about to use the experimental 'Pay Invoice' feature. Please "
               "review the XEC amount carefully before sending the transaction.") +
             f"\n\nAddress: {invoice.address.to_ui_string()}"
-            f"\n\nAmount: {xec_amount}"
+            f"\n\nAmount ({self.base_unit()}): {amount_str}"
             f"\n\nLabel: {invoice.label}"
             f"\n\nInvoice currency: {invoice.currency}"
-            f"\n\nExchange rate ({invoice.currency}/XEC): {1 if invoice.exchange_rate is None else computed_rate}"
+            f"\n\nExchange rate ({invoice.currency}/XEC): "
+            f"{1 if invoice.exchange_rate is None else computed_rate:.10f}"
         )
 
     def build_avalanche_proof(self):


### PR DESCRIPTION
In its most basic form, an invoice is like a payment URI. But payment URI only support amounts in XEC, and there is a need to have a more flexible payment request system that can handle other currencies, either by specifying an exchange rate fixed by the producer of the invoice, or by defining an API to fetch the exchange rate from at payment time.

This implements such an invoice file format  (JSON for human readability), a dialog to produce the invoice, and a menu action to load an invoice and automatically prepare a transaction.

In the future, it would be useful to add also a way to export the invoice  in a display format (PDF).