### PR TITLE
fix ColorScheme for dark style

### DIFF
--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -211,8 +211,6 @@ class ElectrumGui(QtCore.QObject, PrintError):
         self.nd = None
         self._last_active_window = None  # we remember the last activated ElectrumWindow as a Weak.ref
         Address.set_address_format(self.get_config_addr_format())
-        # Dark Theme -- ideally set this before any widgets are created.
-        self.set_dark_theme_if_needed()
         # /
         # Wallet Password Cache
         # wallet -> (password, QTimer) map for some plugins (like CashShuffle)
@@ -239,10 +237,9 @@ class ElectrumGui(QtCore.QObject, PrintError):
             self._start_auto_update_timer(first_run=True)
         self.app.focusChanged.connect(self.on_focus_change)  # track last window the user interacted with
         self.shutdown_signal.connect(self.close, QtCore.Qt.QueuedConnection)
+
+        self.set_dark_theme_if_needed()
         run_hook('init_qt', self)
-        # We did this once already in the set_dark_theme call, but we do this
-        # again here just in case some plugin modified the color scheme.
-        ColorScheme.update_from_widget(QtWidgets.QWidget())
 
         self._check_and_warn_qt_version()
 


### PR DESCRIPTION
The second call to `ColorScheme.update_from_widget` did not take the user setting  (`force_dark`) into consideration, so it overwrote the ColorScheme setting. This is strange because I would expect the first call to change the stylesheet, and so make the second call autodetect that the dark theme is in use via `ColorScheme.has_dark_background`, but it somehow does not work. Maybe Qt change something in the way the stylesheet is applied, and it is not taken into account by the time the second call occurs.

This changes the behavior to the one used by electrum. Hopefully there aren't too many Electrum ABC plugins messing with the color theme.


Before:
----------

![Screenshot from 2022-05-27 09-54-17](https://user-images.githubusercontent.com/419570/170658921-f5a183a9-45fb-41f6-8d5a-3e21f4fcafa1.png)
![Screenshot from 2022-05-27 09-54-23](https://user-images.githubusercontent.com/419570/170658924-a8157d38-d6d6-449f-aeac-79421cc85542.png)
![Screenshot from 2022-05-27 09-54-32](https://user-images.githubusercontent.com/419570/170658925-4aed3d0f-fc66-4595-9d93-59f39b161fa3.png)

After:
-------
![Screenshot from 2022-05-27 09-53-17](https://user-images.githubusercontent.com/419570/170658969-b5682e80-e30b-46ca-8ff8-6d210d355681.png)
![Screenshot from 2022-05-27 09-53-43](https://user-images.githubusercontent.com/419570/170658974-567d952f-72ab-4049-96e7-524fcc191c60.png)
![Screenshot from 2022-05-27 09-53-52](https://user-images.githubusercontent.com/419570/170658977-049319cd-b1de-4fef-9764-8620f1bceb4c.png)
