### PR TITLE
command line: enforce specifying global options before command name

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -25,6 +25,11 @@ transactions as expected.
 
 # Release notes
 
+## Current master
+
+- Change command line usage to enforce specifying global options before command name.
+
+
 ## Release 5.1.1
 
 - Use a fallback ripemd160 implementation to compute addresses when OpenSSL does

--- a/contrib/requirements/requirements.txt
+++ b/contrib/requirements/requirements.txt
@@ -2,7 +2,7 @@ pyaes>=1.6.1
 ecdsa>=0.15
 requests
 qrcode
-protobuf>=3.7.1
+protobuf>=3.7.1,<=3.20.1
 dnspython[DNSSEC]
 jsonrpclib-pelix
 PySocks>=1.6.6

--- a/electroncash/commands.py
+++ b/electroncash/commands.py
@@ -980,19 +980,16 @@ def get_parser():
         # explicitly enabled on macOS! (see gui/qt/__init__.py)
         parser_gui.add_argument("--qt_disable_highdpi", action="store_true", dest="qt_disable_highdpi", default=None, help="(Linux & Windows only) If using Qt gui, disable high DPI scaling")
     add_network_options(parser_gui)
-    add_global_options(parser_gui)
     # daemon
     parser_daemon = subparsers.add_parser('daemon', help="Run Daemon")
     parser_daemon.add_argument("subcommand", nargs='?', help="start, stop, status, load_wallet, close_wallet. Other commands may be added by plugins.")
     parser_daemon.add_argument("subargs", nargs='*', metavar='arg', help="additional arguments (used by plugins)")
     #parser_daemon.set_defaults(func=run_daemon)
     add_network_options(parser_daemon)
-    add_global_options(parser_daemon)
     # commands
     for cmdname in sorted(known_commands.keys()):
         cmd = known_commands[cmdname]
         p = subparsers.add_parser(cmdname, help=cmd.help, description=cmd.description)
-        add_global_options(p)
         if cmdname == 'restore':
             p.add_argument("-o", "--offline", action="store_true", dest="offline", default=False, help="Run offline")
         for optname, default in zip(cmd.options, cmd.defaults):

--- a/electroncash/tests/__main__.py
+++ b/electroncash/tests/__main__.py
@@ -8,7 +8,7 @@ from .test_bitcoin import suite as test_bitcoin_suite
 from .test_blockchain import TestBlockchain
 from .test_cashacct import TestCashAccounts
 from .test_cashaddrenc import TestCashAddrAddress
-from .test_commands import TestCommands
+from .test_commands import suite as test_commands_suite
 from .test_consolidate import suite as test_consolidate_suite
 from .test_dnssec import TestDnsSec
 from .test_import_electroncash_data import TestImportECData
@@ -38,7 +38,7 @@ def suite():
     test_suite.addTest(loadTests(TestBlockchain))
     test_suite.addTest(loadTests(TestCashAccounts))
     test_suite.addTest(loadTests(TestCashAddrAddress))
-    test_suite.addTest(loadTests(TestCommands))
+    test_suite.addTest(test_commands_suite())
     test_suite.addTest(test_consolidate_suite())
     test_suite.addTest(loadTests(TestDnsSec))
     test_suite.addTest(loadTests(TestImportECData))


### PR DESCRIPTION
Initially in electrum global options such as `-w` / `--wallet` could be placed before or after commands/subparsers (`gui`, `daemon`, `history`...). This was achieved by specifying these args both for the parent parser and for the subparser. This was broken in argparse around python 2.7.9 and python 3.5 (see https://bugs.python.org/issue23058), and as a result the subparsers arguments would override the global arguments in case they used the same name, so any global option before the command would be ignored. Electrum then added a hack to make it work again.

I removed these hacks in commits 9f42a606bb7fd12b2b23b76fec2b494311ea64b5 and 8db0894d0e9c02f2774be4943558e1e1cf4d6642, without realizing that it would force adding all arguments after the command, and break global options in case no command is specified (default `gui`).

This commit sanitizes the situation, by enforcing that global options be specified before the subparser cmd. Now the subparsers don't redefine all all the global options.
It adds a test to guard against new regressions.

Test plan:

Run new unit test.

Run various commands, including global options and command specific options:
 - `./electrum-abc`
 - `./electrum-abc -v`
 - `./electrum-abc -v daemon`
 - `./electrum-abc  --wallet /home/pierre/.electrum-abc/wallets/test_wallet`
 - `./electrum-abc  --wallet /home/pierre/.electrum-abc/wallets/test_wallet getbalance`
 - `./electrum-abc  --wallet /home/pierre/.electrum-abc/wallets/test_wallet history --year 2019`