### PR TITLE
Fix opening of encrypted hardware wallets and creation of new wallets

### DIFF
--- a/electroncash/plugins.py
+++ b/electroncash/plugins.py
@@ -1003,8 +1003,10 @@ class DeviceMgr(ThreadJob):
         handler: HardwareHandlerBase,
         keystore: Hardware_KeyStore,
         devices: List['Device'] = None) -> DeviceInfo:
-        '''Ask the user to select a device to use if there is more than one,
-        and return the DeviceInfo for the device.'''
+        """Ask the user to select a device to use if there is more than one,
+        and return the DeviceInfo for the device."""
+        # ideally this should not be called from the GUI thread...
+        # assert handler.get_gui_thread() != threading.current_thread(), 'must not be called from GUI thread'
         while True:
             infos = self.unpaired_device_infos(handler, plugin, devices)
             if infos:

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -657,7 +657,7 @@ class ElectrumGui(QtCore.QObject, PrintError):
         return window
 
     def _start_wizard_to_select_or_create_wallet(self, path) -> Optional[Abstract_Wallet]:
-        wizard = InstallWizard(self.config, self.app, self.plugins)
+        wizard = InstallWizard(self.config, self.app, self.plugins, gui_object=self)
         try:
             path, storage = wizard.select_storage(path, self.daemon.get_wallet)
             # storage is None if file does not exist
@@ -722,7 +722,9 @@ class ElectrumGui(QtCore.QObject, PrintError):
         # Show network dialog if config does not exist
         if self.daemon.network:
             if self.config.get('auto_connect') is None:
-                wizard = InstallWizard(self.config, self.app, self.plugins)
+                wizard = InstallWizard(
+                    self.config, self.app, self.plugins, gui_object=self
+                )
                 wizard.init_network(self.daemon.network)
                 wizard.terminate()
 

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -606,10 +606,8 @@ class ElectrumGui(QtCore.QObject, PrintError):
             wallet = self.daemon.load_wallet(path, None)
         except BaseException as e:
             traceback.print_exc(file=sys.stdout)
-            d = QtWidgets.QMessageBox(
-                QtWidgets.QMessageBox.Warning, _('Error'),
-                _('Cannot load wallet') + ' (1):\n' + str(e))
-            d.exec_()
+            QtWidgets.QMessageBox.warning(
+                None, _('Error'), _('Cannot load wallet') + ' (1):\n' + str(e))
             # if app is starting, still let wizard to appear
             if not app_is_starting:
                 return
@@ -632,28 +630,25 @@ class ElectrumGui(QtCore.QObject, PrintError):
             if not self.windows:
                 self.warn_if_no_secp()
 
-            for w in self.windows:
-                if w.wallet.storage.path == wallet.storage.path:
-                    w.bring_to_top()
+            for window in self.windows:
+                if window.wallet.storage.path == wallet.storage.path:
+                    window.bring_to_top()
                     return
-            w = self._create_window_for_wallet(wallet)
+            window = self._create_window_for_wallet(wallet)
         except BaseException as e:
             traceback.print_exc(file=sys.stdout)
-            d = QtWidgets.QMessageBox(
-                QtWidgets.QMessageBox.Warning, _('Error'),
-                _('Cannot create window for wallet:') + '\n' + str(e)
+            QtWidgets.QMessageBox.warning(
+                None, _('Error'), _('Cannot create window for wallet:') + '\n' + str(e)
             )
-            d.exec_()
             return
 
         if uri:
-            w.pay_to_URI(uri)
-        w.bring_to_top()
-        w.setWindowState(w.windowState() & ~QtCore.Qt.WindowMinimized | QtCore.Qt.WindowActive)
+            window.pay_to_URI(uri)
+        window.bring_to_top()
+        window.setWindowState(window.windowState() & ~QtCore.Qt.WindowMinimized | QtCore.Qt.WindowActive)
 
-        # this will activate the window
-        w.activateWindow()
-        return w
+        window.activateWindow()
+        return window
 
     def _start_wizard_to_select_or_create_wallet(self, path) -> Optional[Abstract_Wallet]:
         wizard = InstallWizard(self.config, self.app, self.plugins)

--- a/electroncash_gui/qt/__init__.py
+++ b/electroncash_gui/qt/__init__.py
@@ -24,6 +24,7 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
 
 import gc
 import os
@@ -32,7 +33,7 @@ import signal
 import sys
 import threading
 import traceback
-from typing import Callable, Optional
+from typing import Callable, Optional, TYPE_CHECKING
 
 try:
     import PyQt5
@@ -93,6 +94,11 @@ from .util import (
     finalization_print_error,
     print_error,
 )
+
+if TYPE_CHECKING:
+    from electroncash.daemon import Daemon
+    from electroncash.plugins import Plugins
+    from electroncash.simple_config import SimpleConfig
 
 
 def _pre_and_post_app_setup(config) -> Callable[[], None]:
@@ -176,7 +182,7 @@ class ElectrumGui(QtCore.QObject, PrintError):
 
     instance = None
 
-    def __init__(self, config, daemon, plugins):
+    def __init__(self, config: SimpleConfig, daemon: Daemon, plugins: Plugins):
         super(__class__, self).__init__() # QtCore.QObject init
         assert __class__.instance is None, "ElectrumGui is a singleton, yet an instance appears to already exist! FIXME!"
         __class__.instance = self

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -90,19 +90,20 @@ class CosignWidget(QtWidgets.QWidget):
 def wizard_dialog(func):
     def func_wrapper(*args, **kwargs):
         run_next = kwargs['run_next']
-        wizard = args[0]
+        wizard: InstallWizard = args[0]
         wizard.back_button.setText(_('Back') if wizard.can_go_back() else _('Cancel'))
         try:
             out = func(*args, **kwargs)
+            if type(out) is not tuple:
+                out = (out, )
+            run_next(*out)
         except GoBack:
-            wizard.go_back() if wizard.can_go_back() else wizard.close()
-            return
-        except UserCancelled:
-            return
-
-        if type(out) is not tuple:
-            out = (out,)
-        run_next(*out)
+            if wizard.can_go_back():
+                wizard.go_back()
+                return
+            else:
+                wizard.close()
+                raise
     return func_wrapper
 
 

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -49,6 +49,8 @@ if TYPE_CHECKING:
     from electroncash.plugins import Plugins
     from electroncash.simple_config import SimpleConfig
 
+    from . import ElectrumGui
+
 
 MSG_ENTER_PASSWORD = _("Choose a password to encrypt your wallet keys.") + '\n'\
                      + _("Leave this field empty if you want to disable encryption.")
@@ -125,12 +127,20 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
 
     accept_signal = pyqtSignal()
 
-    def __init__(self, config: SimpleConfig, app: QtWidgets.QApplication, plugins: Plugins):
+    def __init__(
+        self,
+        config: SimpleConfig,
+        app: QtWidgets.QApplication,
+        plugins: Plugins,
+        *,
+        gui_object: ElectrumGui
+    ):
         BaseWizard.__init__(self, config)
         QtWidgets.QDialog.__init__(self, None)
         self.setWindowTitle(f'{PROJECT_NAME}  -  ' + _('Install Wizard'))
         self.app = app
         self.config = config
+        self.gui_thread = gui_object.gui_thread
         # Set for base base class
         self.plugins = plugins
         self.setMinimumSize(600, 400)

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -1,4 +1,6 @@
 # -*- mode: python3 -*-
+from __future__ import annotations
+
 import os
 import random
 import sys
@@ -6,7 +8,7 @@ import tempfile
 import time
 import threading
 import traceback
-from typing import Tuple, Optional
+from typing import Tuple, Optional, TYPE_CHECKING
 
 from PyQt5.QtCore import QEventLoop, QRect, Qt, QThread, pyqtSignal
 from PyQt5.QtGui import QIcon, QPainter, QPalette, QPen
@@ -42,6 +44,11 @@ from .util import (
     char_width_in_lineedit,
     destroyed_print_error,
 )
+
+if TYPE_CHECKING:
+    from electroncash.plugins import Plugins
+    from electroncash.simple_config import SimpleConfig
+
 
 MSG_ENTER_PASSWORD = _("Choose a password to encrypt your wallet keys.") + '\n'\
                      + _("Leave this field empty if you want to disable encryption.")
@@ -118,7 +125,7 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
 
     accept_signal = pyqtSignal()
 
-    def __init__(self, config, app, plugins):
+    def __init__(self, config: SimpleConfig, app: QtWidgets.QApplication, plugins: Plugins):
         BaseWizard.__init__(self, config)
         QtWidgets.QDialog.__init__(self, None)
         self.setWindowTitle(f'{PROJECT_NAME}  -  ' + _('Install Wizard'))

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -301,6 +301,8 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
                             _('If you use a passphrase, make sure it is correct.'))
                         self.reset_stack()
                         return self.select_storage(path, get_wallet_from_daemon)
+                    except (UserCancelled, GoBack):
+                        raise
                     except BaseException as e:
                         traceback.print_exc(file=sys.stdout)
                         QtWidgets.QMessageBox.information(None, _('Error'), str(e))

--- a/electroncash_gui/qt/installwizard.py
+++ b/electroncash_gui/qt/installwizard.py
@@ -226,32 +226,28 @@ class InstallWizard(QtWidgets.QDialog, MessageBoxMixin, BaseWizard):
             except IOError:
                 self.temp_storage = None
                 self.next_button.setEnabled(False)
+            user_needs_to_enter_password = False
             if self.temp_storage:
                 if not self.temp_storage.file_exists():
                     msg =_("This file does not exist.") + '\n' \
                           + _("Press 'Next' to create this wallet, or choose another file.")
-                    pw = False
                 elif not wallet_from_memory:
                     if self.temp_storage.is_encrypted_with_user_pw():
                         msg = _("This file is encrypted with a password.") + '\n' \
                               + _('Enter your password or choose another file.')
-                        pw = True
+                        user_needs_to_enter_password = True
                     elif self.temp_storage.is_encrypted_with_hw_device():
                         msg = _("This file is encrypted using a hardware device.") + '\n' \
                               + _("Press 'Next' to choose device to decrypt.")
-                        pw = False
                     else:
                         msg = _("Press 'Next' to open this wallet.")
-                        pw = False
                 else:
                     msg = _("This file is already open in memory.") + "\n" \
                         + _("Press 'Next' to create/focus window.")
-                    pw = False
             else:
                 msg = _('Cannot read file')
-                pw = False
             self.msg_label.setText(msg)
-            if pw:
+            if user_needs_to_enter_password:
                 self.pw_label.show()
                 self.pw_e.show()
                 self.pw_e.setFocus()

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -23,6 +23,7 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
 
 import copy
 import csv
@@ -50,7 +51,7 @@ from PyQt5 import QtWidgets
 from collections import OrderedDict
 from decimal import Decimal as PyDecimal  # Qt 5.12 also exports Decimal
 from functools import partial
-from typing import List, Optional
+from typing import List, Optional, TYPE_CHECKING
 
 import electroncash.constants
 import electroncash.web as web
@@ -134,6 +135,9 @@ try:
 except ImportError as e:
     pass  # we tried to pre-load it, failure is ok; camera just won't be available
 
+if TYPE_CHECKING:
+    from . import ElectrumGui
+
 
 class StatusBarButton(QtWidgets.QPushButton):
     def __init__(self, icon, tooltip, func):
@@ -201,7 +205,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
 
     status_icon_dict = dict()  # app-globel cache of "status_*" -> QIcon instances (for update_status() speedup)
 
-    def __init__(self, gui_object, wallet: Abstract_Wallet):
+    def __init__(self, gui_object: ElectrumGui, wallet: Abstract_Wallet):
         QtWidgets.QMainWindow.__init__(self)
 
         self.gui_object = gui_object

--- a/electroncash_plugins/hw_wallet/plugin.py
+++ b/electroncash_plugins/hw_wallet/plugin.py
@@ -35,6 +35,7 @@ from electroncash.util import finalization_print_error
 from electroncash.address import OpCodes, Script
 
 if TYPE_CHECKING:
+    import threading
     from electroncash.base_wizard import BaseWizard
     from electroncash.keystore import Hardware_KeyStore
     from electroncash.wallet import Abstract_Wallet
@@ -211,6 +212,11 @@ class HardwareHandlerBase:
         if self.win is not None:
             if hasattr(self.win, 'wallet'):
                 return self.win.wallet
+
+    def get_gui_thread(self) -> Optional[threading.Thread]:
+        if self.win is not None:
+            if hasattr(self.win, 'gui_thread'):
+                return self.win.gui_thread
 
     def update_status(self, paired: bool) -> None:
         pass

--- a/electroncash_plugins/hw_wallet/qt.py
+++ b/electroncash_plugins/hw_wallet/qt.py
@@ -28,7 +28,7 @@ from __future__ import annotations
 
 from functools import partial
 import threading
-from typing import TYPE_CHECKING, Union, Optional, Callable, Any
+from typing import TYPE_CHECKING, Union, Optional
 
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5.QtGui import QIcon
@@ -314,10 +314,9 @@ class QtPluginBase(object):
         return device_id
 
     def show_settings_dialog(self, window: ElectrumWindow, keystore: Hardware_KeyStore):
-        try:
+        def connect():
             device_id = self.choose_device(window, keystore)
-        except:
-            window.on_error(sys.exc_info())
+        keystore.thread.add(connect)
 
     def create_handler(
         self, window:  Union[ElectrumWindow, InstallWizard]

--- a/electroncash_plugins/keepkey/qt.py
+++ b/electroncash_plugins/keepkey/qt.py
@@ -42,6 +42,7 @@ CHARACTER_RECOVERY = (
     "Press ENTER or the Seed Entered button once the last word in your "
     "seed is auto-completed.")
 
+
 class CharacterButton(QtWidgets.QPushButton):
     def __init__(self, text=None):
         QtWidgets.QPushButton.__init__(self, text)
@@ -206,9 +207,15 @@ class QtPlugin(QtPluginBase):
                 menu.addAction(_("Show on {}").format(device_name), show_address)
 
     def show_settings_dialog(self, window, keystore):
-        device_id = self.choose_device(window, keystore)
-        if device_id:
-            SettingsDialog(window, self, keystore, device_id).exec_()
+        def connect():
+            device_id = self.choose_device(window, keystore)
+            return device_id
+
+        def show_dialog(device_id):
+            if device_id:
+                SettingsDialog(window, self, keystore, device_id).exec_()
+
+        keystore.thread.add(connect, on_success=show_dialog)
 
     def request_trezor_init_settings(self, wizard, method, device):
         vbox = QtWidgets.QVBoxLayout()

--- a/electroncash_plugins/trezor/qt.py
+++ b/electroncash_plugins/trezor/qt.py
@@ -248,9 +248,15 @@ class QtPlugin(QtPluginBase):
                 break
 
     def show_settings_dialog(self, window, keystore):
-        device_id = self.choose_device(window, keystore)
-        if device_id:
-            SettingsDialog(window, self, keystore, device_id).exec_()
+        def connect():
+            device_id = self.choose_device(window, keystore)
+            return device_id
+
+        def show_dialog(device_id):
+            if device_id:
+                SettingsDialog(window, self, keystore, device_id).exec_()
+
+        keystore.thread.add(connect, on_success=show_dialog)
 
     def request_trezor_init_settings(self, wizard, method, model):
         vbox = QtWidgets.QVBoxLayout()


### PR DESCRIPTION
The issue was a missing commit in the backport stack of #201 which caused an `AttributeError: InstallWizard has no 'gui_thread' attribute` error, hidden by a `catch BaseException:` clause.

Unfortunately the install wizard hw wallet code is still messy to this day in Electrum. It would be difficult to remove the `catch BaseExecption:...` statements without having an advanced understanding of all the errors that can happen when a user tries to connect to his device.


Test plan:
- Open existing hardware wallets, both encrypted and unencrypted (tried with Ledger Nano X and Trezor One)
- Create wallets from HW device, both encrypted and unencrypted.