### PR TITLE
history: show value in XEC units

### DIFF
--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -44,7 +44,7 @@ from collections import defaultdict, namedtuple
 from enum import Enum, auto
 from typing import ItemsView, List, Optional, Set, Tuple, Union, ValuesView
 
-from .constants import DUST_THRESHOLD
+from .constants import DUST_THRESHOLD, XEC
 from .i18n import ngettext
 from .util import (NotEnoughFunds, ExcessiveFee, PrintError,
                    UserCancelled, InvalidPassword, multisig_type, profiler,
@@ -1503,7 +1503,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         return h2
 
     def export_history(self, domain=None, from_timestamp=None, to_timestamp=None, fx=None,
-                       show_addresses=False, decimal_point=8,
+                       show_addresses=False, decimal_point: int = XEC.decimals,
                        *, fee_calc_timeout=10.0, download_inputs=False,
                        progress_callback=None):
         ''' Export history. Used by RPC & GUI.


### PR DESCRIPTION
There was still a hardcoded `decimal_point=8` in the code. This caused the `history` command line to show values/fees/amounts  in MegaXEC instead of XEC.

Before:
```
$./ElectrumABC-5.1.2-9-gdedc670cb-x86_64.AppImage history
[
    {
        "balance": "0.175",
        "confirmations": 6,
        "date": "2022-02-02 02:02",
        "fee": "0.00000807",
        "height": 777777,
        "label": "",
        "timestamp": 1655555555,
        "txid": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
        "value": "+0.075"
    },
    {
        "balance": "0.1",
        "confirmations": 6,
        "date": "2022-02-02 02:02",
        "fee": "0.00000452",
        "height": 777777,
        "label": "",
        "timestamp": 1655555555,
        "txid": "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy",
        "value": "+0.1"
    }
]
```
