### PR TITLE
[avalanche] show block heights in orange if they don't have enough confirmations for a proof

### DIFF
--- a/electroncash/constants.py
+++ b/electroncash/constants.py
@@ -43,7 +43,7 @@ class Unit:
         return self.ticker
 
     def unit_to_satoshis(self, amount: Decimal) -> int:
-        return int((amount * 10 ** self.decimals).quantize(Decimal("1")))
+        return int((amount * 10**self.decimals).quantize(Decimal("1")))
 
 
 SAT = Unit("sats", 0)
@@ -80,3 +80,6 @@ The unit is satoshis.
 
 PROOF_DUST_THRESHOLD: int = XEC.unit_to_satoshis(Decimal("1_000_000.00"))
 """Lowest amount in satoshis that can be used as stake in a proof."""
+
+STAKE_UTXO_CONFIRMATIONS: int = 2016
+"""Minimum number of confirmations for a utxo to be used as a stake in a proof."""

--- a/electroncash/servers.json
+++ b/electroncash/servers.json
@@ -1,9 +1,4 @@
 {
-    "bchabc.fmarcosh.xyz": {
-        "pruning": "-",
-        "s": "50002",
-        "t": "50001"
-    },
     "ecash.fmarcosh.xyz": {
         "pruning": "-",
         "s": "50002",

--- a/electroncash_gui/qt/utxo_list.py
+++ b/electroncash_gui/qt/utxo_list.py
@@ -38,7 +38,6 @@ from PyQt5.QtGui import QColor, QFont
 
 from electroncash.address import Address
 from electroncash.bitcoin import COINBASE_MATURITY
-from electroncash.constants import PROOF_DUST_THRESHOLD
 from electroncash.i18n import _
 from electroncash.plugins import run_hook
 
@@ -559,12 +558,6 @@ class UTXOList(MyTreeWidget):
         """Open a dialog to generate an Avalanche proof using the coins as
         stakes.
         """
-        if any(u["value"] < PROOF_DUST_THRESHOLD for u in utxos):
-            warning_dialog = StakeDustThresholdMessageBox(self)
-            warning_dialog.exec_()
-            if warning_dialog.has_cancelled():
-                return
-
         dialog = AvaProofDialog(
             utxos,
             wallet=self.wallet,
@@ -577,28 +570,3 @@ class UTXOList(MyTreeWidget):
         # storage.
         self.update()
         self.main_window.update_fee()
-
-
-class StakeDustThresholdMessageBox(QtWidgets.QMessageBox):
-    """QMessageBox question dialog with custom buttons."""
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self.setIcon(QtWidgets.QMessageBox.Warning)
-        self.setWindowTitle(_("Coins below the stake dust threshold"))
-        self.setText(
-            _(
-                "The value of one or more coins is below the 1,000,000 XEC stake "
-                "minimum threshold. The generated proof will be invalid."
-            )
-        )
-
-        self.setStandardButtons(QtWidgets.QMessageBox.Ok | QtWidgets.QMessageBox.Cancel)
-        ok_button = self.button(QtWidgets.QMessageBox.Ok)
-        ok_button.setText(_("Continue, I'm just testing"))
-
-        self.cancel_button = self.button(QtWidgets.QMessageBox.Cancel)
-        self.setEscapeButton(self.cancel_button)
-
-    def has_cancelled(self) -> bool:
-        return self.clickedButton() == self.cancel_button


### PR DESCRIPTION
A UTXO must have 2016 confirmations to be used in a valid proof. Put the block height in orange and explain why  in the tooltip.
The reason for using orange instead of red is that the proof will eventually become valid. Users might know what they are doing when they build the proof in advance of it being usable.