### PR TITLE
fix assertion for max_tx_size in the consolidation tool.

### DIFF
--- a/electroncash/consolidate.py
+++ b/electroncash/consolidate.py
@@ -66,7 +66,7 @@ class AddressConsolidator:
         # output address defaults to input address if unspecified
         self.output_address = output_address or address
         self.max_tx_size = max_tx_size
-        assert self.max_tx_size < MAX_TX_SIZE
+        assert self.max_tx_size <= MAX_TX_SIZE
 
         self._coins = [
             utxo


### PR DESCRIPTION
The widget allows values up to (and including) one megabyte, but the assertion only allowed values up to one megabyte **minus one**.

The widget is correct, the assertion needs to be fixed.

Closes #225