### PR TITLE
Update proof dust threshold

### DIFF
--- a/electroncash/constants.py
+++ b/electroncash/constants.py
@@ -78,7 +78,7 @@ Change < dust threshold is added to the tx fee.
 The unit is satoshis.
 """
 
-PROOF_DUST_THRESHOLD: int = XEC.unit_to_satoshis(Decimal("1_000_000.00"))
+PROOF_DUST_THRESHOLD: int = XEC.unit_to_satoshis(Decimal("100_000_000.00"))
 """Lowest amount in satoshis that can be used as stake in a proof."""
 
 STAKE_UTXO_CONFIRMATIONS: int = 2016

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -18,6 +18,7 @@ from electroncash.bitcoin import is_private_key
 from electroncash.constants import PROOF_DUST_THRESHOLD, STAKE_UTXO_CONFIRMATIONS
 from electroncash.i18n import _
 from electroncash.uint256 import UInt256
+from electroncash.util import format_satoshis
 
 from .password_dialog import PasswordDialog
 
@@ -227,8 +228,8 @@ class AvaProofWidget(CachedWalletPasswordWidget):
                 amount_item.setForeground(QtGui.QColor("red"))
                 amount_item.setToolTip(
                     _(
-                        "The minimum threshold for a coin in an avalanche proof is "
-                        "1,000,000 XEC."
+                        f"The minimum threshold for a coin in an avalanche proof is "
+                        f"{format_satoshis(PROOF_DUST_THRESHOLD)} XEC."
                     )
                 )
             self.utxos_wigdet.setItem(i, 2, amount_item)
@@ -708,8 +709,8 @@ class StakeDustThresholdMessageBox(QtWidgets.QMessageBox):
         self.setWindowTitle(_("Coins below the stake dust threshold"))
         self.setText(
             _(
-                "The value of one or more coins is below the 1,000,000 XEC stake "
-                "minimum threshold. The generated proof will be invalid."
+                f"The value of one or more coins is below the {format_satoshis(PROOF_DUST_THRESHOLD)} XEC stake "
+                f"minimum threshold. The generated proof will be invalid."
             )
         )
 


### PR DESCRIPTION
Update the PROOF_DUST_THRESHOLD to the same value as the next release of the node (https://reviews.bitcoinabc.org/D11830)

This value is used in a warning message if the user chooses coins of insufficient value. The resulting coins will be in red in the proof building dialog. We keep allowing building proofs with coins of low value for now because it  makes testing the tool easier. In the future, the warning will become an error message and the software will refuse to build the proof with such coins.