### PR TITLE
Improve Proof building tool

### DIFF
--- a/electroncash/avalanche/primitives.py
+++ b/electroncash/avalanche/primitives.py
@@ -40,8 +40,12 @@ from .serialize import (
     write_compact_size,
 )
 
+# We redefine private key and public key objects because the ones used in the rest
+# of the codebase are messy.
+
 
 class PublicKey(SerializableObject):
+    # fixme: merge with address.PublicKey or us a different name for one of the classes
     def __init__(self, keydata):
         self.keydata: bytes = keydata
 

--- a/electroncash/avalanche/proof.py
+++ b/electroncash/avalanche/proof.py
@@ -152,7 +152,7 @@ class Proof(SerializableObject):
         """int64"""
         self.master_pub: PublicKey = master_pub
         """Master public key"""
-        self.stakes: List[SignedStake] = signed_stakes
+        self.signed_stakes: List[SignedStake] = signed_stakes
         """List of signed stakes sorted by their stake ID."""
         self.payout_script_pubkey: bytes = payout_script_pubkey
         self.signature: bytes = signature
@@ -169,7 +169,7 @@ class Proof(SerializableObject):
     def serialize(self) -> bytes:
         p = struct.pack("<Qq", self.sequence, self.expiration_time)
         p += self.master_pub.serialize()
-        p += serialize_sequence(self.stakes)
+        p += serialize_sequence(self.signed_stakes)
         p += serialize_blob(self.payout_script_pubkey)
         p += self.signature
         return p

--- a/electroncash/avalanche/proof.py
+++ b/electroncash/avalanche/proof.py
@@ -223,6 +223,24 @@ class ProofBuilder:
         Adding stakes through :meth:`add_utxo` takes care of the sorting.
         """
 
+    @classmethod
+    def from_proof(cls, proof: Proof, master: Key) -> ProofBuilder:
+        """Create a proof builder using the data from an existing proof.
+        This is useful for adding more stakes to it.
+
+        The provided master private key must match the proof's master public key,
+        because changing the key would invalidate previous signed stakes.
+        """
+        if master.get_pubkey() != proof.master_pub:
+            raise KeyError(
+                "The provided private key does not match the proof's master public key."
+            )
+        builder = cls(
+            proof.sequence, proof.expiration_time, master, proof.payout_script_pubkey
+        )
+        builder.signed_stakes = proof.signed_stakes
+        return builder
+
     def add_utxo(self, txid: UInt256, vout, amount, height, wif_privkey, is_coinbase):
         """
 

--- a/electroncash/tests/test_avalanche.py
+++ b/electroncash/tests/test_avalanche.py
@@ -229,6 +229,52 @@ class TestAvalancheProofBuilder(unittest.TestCase):
             expected_proofid2,
         )
 
+    def test_adding_stakes_to_proof(self):
+        key = Key.from_wif("L4J6gEE4wL9ji2EQbzS5dPMTTsw8LRvcMst1Utij4e3X5ccUSdqW")
+        proofbuilder = ProofBuilder(
+            sequence=0,
+            expiration_time=1670827913,
+            master=key,
+            payout_script_pubkey=bytes.fromhex(
+                "76a9149a9ad444d4542b572b12d9be83ac79158cc175cb88ac"
+            ),
+        )
+        proofbuilder.add_utxo(
+            txid=UInt256.from_hex(
+                "37424bda9a405b59e7d4f61a4c154cea5ee34e445f3daa6033b64c70355f1e0b"
+            ),
+            vout=0,
+            amount=3291110545,
+            height=700000,
+            wif_privkey="KydYrKDNsVnY5uhpLyC4UmazuJvUjNoKJhEEv9f1mdK1D5zcnMSM",
+            is_coinbase=False,
+        )
+        proof = proofbuilder.build()
+
+        self.assertEqual(
+            proof.to_hex(),
+            "000000000000000089cf96630000000021023beefdde700a6bc02036335b4df141c8bc67bb05a971f5ac2745fd683797dde3010b1e5f35704cb63360aa3d5f444ee35eea4c154c1af6d4e7595b409ada4b423700000000915c2ac400000000c05c15002102449fb5237efe8f647d32e8b64f06c22d1d40368eaca2a71ffc6a13ecc8bce680b8d717142339f0baf0c8099bafd6491d42e73f7224cacf1daa20a2aeb7b4b3fa68a362bfed33bf20ec1c08452e6ad5536fec3e1198d839d64c2e0e6fe25afaa61976a9149a9ad444d4542b572b12d9be83ac79158cc175cb88acc768803afa6a4662bab4199535122b4a8c7fb9889f1fe77043d8ecd43ad04c5cf07e602e47b68deaac1bbdc7c170ad57c38aa47e5a5d23cac011c15ed31bbc54",
+        )
+
+        # create a new builder from this proof, add more stakes
+        proofbuilder_add_stakes = ProofBuilder.from_proof(proof, key)
+        proofbuilder_add_stakes.add_utxo(
+            txid=UInt256.from_hex(
+                "300cbba81ef40a6d269be1e931ccb58c074ace4a9b06cc0f2a2c9bf1e176ede4"
+            ),
+            vout=1,
+            amount=2866370216,
+            height=700001,
+            is_coinbase=False,
+            wif_privkey="KydYrKDNsVnY5uhpLyC4UmazuJvUjNoKJhEEv9f1mdK1D5zcnMSM",
+        )
+        proof = proofbuilder_add_stakes.build()
+
+        self.assertEqual(
+            proof.to_hex(),
+            "000000000000000089cf96630000000021023beefdde700a6bc02036335b4df141c8bc67bb05a971f5ac2745fd683797dde302e4ed76e1f19b2c2a0fcc069b4ace4a078cb5cc31e9e19b266d0af41ea8bb0c3001000000a856d9aa00000000c25c15002102449fb5237efe8f647d32e8b64f06c22d1d40368eaca2a71ffc6a13ecc8bce68089bf7f0f956b084160d505dcd8b375499ffad816d1c76c8b13ac92d1ef3c5c3ecb6ee6c094ef790fb93f6711955c48f2cf098750427808c9e2aab77ee1b8de110b1e5f35704cb63360aa3d5f444ee35eea4c154c1af6d4e7595b409ada4b423700000000915c2ac400000000c05c15002102449fb5237efe8f647d32e8b64f06c22d1d40368eaca2a71ffc6a13ecc8bce680b8d717142339f0baf0c8099bafd6491d42e73f7224cacf1daa20a2aeb7b4b3fa68a362bfed33bf20ec1c08452e6ad5536fec3e1198d839d64c2e0e6fe25afaa61976a9149a9ad444d4542b572b12d9be83ac79158cc175cb88acec2623216b901037fb780e3d2a06f982bbe36d87be7adc82e83ebfc1f3c4eff6262577cfa9f72d18570dc5cdf9bf96676700abdb3d8f4bc989c975870ab8cbb7",
+        )
+
 
 class TestAvalancheProofFromHex(unittest.TestCase):
     def test_proofid(self):

--- a/electroncash/tests/test_avalanche.py
+++ b/electroncash/tests/test_avalanche.py
@@ -298,20 +298,20 @@ class TestAvalancheProofFromHex(unittest.TestCase):
         self.assertEqual(proof.master_pub, PublicKey.from_hex(pubkey_hex))
         self.assertEqual(proof.limitedid, LimitedProofId.from_hex(expected_limited_id1))
         self.assertEqual(proof.proofid, ProofId.from_hex(expected_proofid1))
-        self.assertEqual(proof.stakes[0].stake.utxo.txid, utxos[0]["txid"])
-        self.assertEqual(proof.stakes[0].stake.utxo.n, utxos[0]["vout"])
-        self.assertEqual(proof.stakes[0].stake.amount, utxos[0]["amount"])
-        self.assertEqual(proof.stakes[0].stake.height, utxos[0]["height"])
-        self.assertFalse(proof.stakes[0].stake.is_coinbase)
+        self.assertEqual(proof.signed_stakes[0].stake.utxo.txid, utxos[0]["txid"])
+        self.assertEqual(proof.signed_stakes[0].stake.utxo.n, utxos[0]["vout"])
+        self.assertEqual(proof.signed_stakes[0].stake.amount, utxos[0]["amount"])
+        self.assertEqual(proof.signed_stakes[0].stake.height, utxos[0]["height"])
+        self.assertFalse(proof.signed_stakes[0].stake.is_coinbase)
         self.assertEqual(
-            proof.stakes[0].stake.pubkey,
+            proof.signed_stakes[0].stake.pubkey,
             PublicKey.from_hex(
                 "04d0de0aaeaefad02b8bdc8a01a1b8b11c696bd3d66a2c5f10780d95b7df42645cd852"
                 "28a6fb29940e858e7e55842ae2bd115d1ed7cc0e82d934e929c97648cb0a"
             ),
         )
         self.assertEqual(
-            proof.stakes[0].sig,
+            proof.signed_stakes[0].sig,
             base64.b64decode(
                 "vZdAyFoFp9VDw9MBJz15/3BUdYV54wzAXN/hrKM3St/lUQS0Cf/OSi8Z2KWYHV8MebI+2s"
                 "czUqsomKyoknAoJQ==".encode("ascii")

--- a/electroncash/transaction.py
+++ b/electroncash/transaction.py
@@ -29,6 +29,8 @@ import warnings
 import ecdsa
 import hashlib
 
+from typing import Tuple, Union
+
 # Note: The deserialization code originally comes from ABE.
 
 from .util import print_error, profiler
@@ -275,7 +277,11 @@ def parse_redeemScript(s):
                                               for p in pubkeys])
     return m, n, x_pubkeys, pubkeys, redeemScript
 
-def get_address_from_output_script(_bytes):
+
+def get_address_from_output_script(
+    _bytes: bytes
+) -> Tuple[int, Union[Address, PublicKey, ScriptOutput]]:
+    """Return the type of the output and the address"""
     scriptlen = len(_bytes)
 
     if scriptlen == 23 and _bytes.startswith(P2SH_prefix) and _bytes.endswith(P2SH_suffix):

--- a/electroncash/wallet.py
+++ b/electroncash/wallet.py
@@ -94,6 +94,10 @@ from .i18n import _
 DEFAULT_CONFIRMED_ONLY = False
 
 
+class AddressNotFoundError(Exception):
+    """Exception used for Address errors."""
+
+
 def sweep_preparations(privkeys, network, imax=100):
     class InputsMaxxed(Exception):
         pass
@@ -570,7 +574,7 @@ class Abstract_Wallet(PrintError, SPVDelegate):
         except ValueError:
             pass
         assert not isinstance(address, str)
-        raise Exception("Address {} not found".format(address))
+        raise AddressNotFoundError("Address {} not found".format(address))
 
     def add_unverified_tx(self, tx_hash, tx_height):
         with self.lock:

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -210,7 +210,9 @@ class AvaProofEditor(CachedWalletPasswordWidget):
         self.master_key_edit = QtWidgets.QLineEdit()
         self.master_key_edit.setToolTip(
             "Private key that controls the proof. This is the key that signs the "
-            "delegation or signs the avalanche votes."
+            "delegation or signs the avalanche votes. The suggested key (if any) is "
+            "derived from the wallet's seed, on the (change_index, key_index) = (2, 0) "
+            "index."
         )
         layout.addWidget(self.master_key_edit)
         layout.addSpacing(10)
@@ -896,6 +898,8 @@ class AvaDelegationWidget(CachedWalletPasswordWidget):
         QtWidgets.QMessageBox.information(
             self,
             "Delegated key",
+            f"This key is derived from the change_index = 2 branch of this wallet's "
+            f"derivation path.<br><br>"
             f"Please save the following private key:<br><b>{wif_pk}</b><br><br>"
             f"You will need it to use your delegation with a Bitcoin ABC node.",
         )

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -601,13 +601,10 @@ class AvaProofDialog(QtWidgets.QDialog):
 
         buttons_layout = QtWidgets.QHBoxLayout()
         layout.addLayout(buttons_layout)
-        self.ok_button = QtWidgets.QPushButton("OK")
-        buttons_layout.addWidget(self.ok_button)
-        self.dismiss_button = QtWidgets.QPushButton("Dismiss")
-        buttons_layout.addWidget(self.dismiss_button)
+        self.close_button = QtWidgets.QPushButton("Close")
+        buttons_layout.addWidget(self.close_button)
 
-        self.ok_button.clicked.connect(self.accept)
-        self.dismiss_button.clicked.connect(self.reject)
+        self.close_button.clicked.connect(self.accept)
 
     def add_utxos(self, utxos: List[dict]) -> bool:
         if not self.check_utxos(utxos):
@@ -856,13 +853,10 @@ class AvaDelegationDialog(QtWidgets.QDialog):
 
         buttons_layout = QtWidgets.QHBoxLayout()
         layout.addLayout(buttons_layout)
-        self.ok_button = QtWidgets.QPushButton("OK")
-        buttons_layout.addWidget(self.ok_button)
-        self.dismiss_button = QtWidgets.QPushButton("Dismiss")
-        buttons_layout.addWidget(self.dismiss_button)
+        self.close_button = QtWidgets.QPushButton("Close")
+        buttons_layout.addWidget(self.close_button)
 
-        self.ok_button.clicked.connect(self.accept)
-        self.dismiss_button.clicked.connect(self.reject)
+        self.close_button.clicked.connect(self.accept)
 
     def set_proof(self, proof_hex: str):
         self.dg_widget.set_proof(proof_hex)

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -503,11 +503,19 @@ class AvaProofEditor(CachedWalletPasswordWidget):
     def _build(self) -> Optional[str]:
         master_wif = self.master_key_edit.text()
         if not is_private_key(master_wif):
-            QtWidgets.QMessageBox.critical(
-                self, "Invalid private key", "Could not parse private key."
+            reply = QtWidgets.QMessageBox.question(
+                self,
+                "Invalid private key",
+                "Could not parse private key. Do you want to generate a proof with an "
+                "invalid signature anyway?",
             )
-            return
-        master = Key.from_wif(master_wif)
+            if reply != QtWidgets.QMessageBox.Yes:
+                return
+            master = None
+            master_pub = PublicKey.from_hex(self.master_pubkey_view.text())
+        else:
+            master = Key.from_wif(master_wif)
+            master_pub = None
 
         try:
             payout_address = Address.from_string(self.payout_addr_edit.text())
@@ -530,6 +538,7 @@ class AvaProofEditor(CachedWalletPasswordWidget):
             expiration_time=expiration_time,
             payout_address=payout_address,
             master=master,
+            master_pub=master_pub,
         )
 
         for ss in self.stakes:

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -237,7 +237,7 @@ class AvaProofEditor(CachedWalletPasswordWidget):
 
         # Init widgets
         now = QtCore.QDateTime.currentDateTime()
-        self.calendar.setDateTime(now.addYears(1))
+        self.calendar.setDateTime(now.addYears(3))
         self.dg_dialog = None
         self.update_master_pubkey(self.master_key_edit.text())
 

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING, List, Optional
 
 from PyQt5 import QtCore, QtGui, QtWidgets
@@ -221,6 +222,9 @@ class AvaProofEditor(CachedWalletPasswordWidget):
         )
         layout.addWidget(self.utxos_wigdet)
 
+        self.add_coins_button = QtWidgets.QPushButton("Add coins")
+        layout.addWidget(self.add_coins_button, alignment=QtCore.Qt.AlignLeft)
+
         self.generate_button = QtWidgets.QPushButton("Generate proof")
         layout.addWidget(self.generate_button)
         self.generate_button.clicked.connect(self._on_generate_clicked)
@@ -238,6 +242,7 @@ class AvaProofEditor(CachedWalletPasswordWidget):
         self.calendar.dateTimeChanged.connect(self.on_datetime_changed)
         self.timestamp_widget.valueChanged.connect(self.on_timestamp_changed)
         self.master_key_edit.textChanged.connect(self.update_master_pubkey)
+        self.add_coins_button.clicked.connect(self.on_add_coins_clicked)
         self.generate_dg_button.clicked.connect(self.open_dg_dialog)
 
         # Init widgets
@@ -325,6 +330,21 @@ class AvaProofEditor(CachedWalletPasswordWidget):
         was_blocked = self.blockSignals(True)
         self.calendar.setDateTime(QtCore.QDateTime.fromSecsSinceEpoch(timestamp))
         self.blockSignals(was_blocked)
+
+    def on_add_coins_clicked(self):
+        fileName, __ = QtWidgets.QFileDialog.getOpenFileName(
+            self,
+            "Select the file containing the data for coins to be used as stakes",
+            filter="JSON (*.json);;All files (*)",
+        )
+
+        if not fileName:
+            return
+        with open(fileName, "r", encoding="utf-8") as f:
+            utxos = json.load(f)
+        if utxos is None:
+            return
+        self.add_utxos(utxos)
 
     def update_master_pubkey(self, master_wif: str):
         if is_private_key(master_wif):

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -346,7 +346,6 @@ class AvaProofWidget(CachedWalletPasswordWidget):
         except AddressError as e:
             QtWidgets.QMessageBox.critical(self, "Invalid payout address", str(e))
             return
-        payout_script = payout_address.to_script()
 
         if self.wallet.has_password() and self.pwd is None:
             self.proof_display.setText(
@@ -358,7 +357,7 @@ class AvaProofWidget(CachedWalletPasswordWidget):
             sequence=self.sequence_sb.value(),
             expiration_time=self.calendar.dateTime().toSecsSinceEpoch(),
             master=master,
-            payout_script_pubkey=payout_script,
+            payout_address=payout_address,
         )
 
         self.excluded_utxos = []

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -528,8 +528,8 @@ class AvaProofEditor(CachedWalletPasswordWidget):
         proofbuilder = ProofBuilder(
             sequence=self.sequence_sb.value(),
             expiration_time=expiration_time,
-            master=master,
             payout_address=payout_address,
+            master=master,
         )
 
         for ss in self.stakes:

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -547,14 +547,6 @@ class AvaProofEditor(CachedWalletPasswordWidget):
                     )
                 )
 
-        num_utxos_in_proof = len(self.utxos) - len(self.unconfirmed_utxos)
-        if num_utxos_in_proof <= 0:
-            QtWidgets.QMessageBox.critical(
-                self,
-                _("No valid stake"),
-                _("No valid stake left after excluding unconfirmed coins."),
-            )
-            return
         if len(self.unconfirmed_utxos) > 0:
             QtWidgets.QMessageBox.warning(
                 self,

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -578,10 +578,16 @@ class AvaProofEditor(CachedWalletPasswordWidget):
                 "No proof to be saved. The save button should not be enabled."
             )
         proof = Proof.from_hex(self.proof_display.toPlainText())
+
+        default_filename = f"{proof.proofid.get_hex()[:8]}"
+        if not proof.verify_master_signature():
+            default_filename += "-unsigned"
+        default_filename += ".proof"
+
         fileName, __ = QtWidgets.QFileDialog.getSaveFileName(
             self,
             "Save proof to file",
-            f"{proof.proofid.get_hex()[:8]}.proof",
+            default_filename,
             filter="Avalanche proof (*.proof);;All files (*)",
         )
         if not fileName:

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -775,7 +775,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
 
         tools_menu.addSeparator()
         avaproof_action = tools_menu.addAction(
-            "Build avalanche proof from coins file", self.build_avalanche_proof
+            "Avalanche proof editor", self.open_proof_editor
         )
         tools_menu.addAction(
             "Build avalanche delegation", self.build_avalanche_delegation
@@ -3596,41 +3596,9 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             f"{1 if invoice.exchange_rate is None else computed_rate:.10f}"
         )
 
-    def build_avalanche_proof(self):
-        """Open a dialog to build an avalanche proof from coins metadata
-        loaded from a file. The coins must belong to this wallet, and the
-        wallet must be capable of exporting private keys for the coins
-        (no hardware wallet, no watchonly wallet...)
-
-        This tools is meant to be used with an offline wallet, after exporting
-        the UTXOs from the corresponding watch-only or hardware wallet.
-
-        The typical workflow is:
-
-         - on the hot (online) wallet, go to the "Coins" tab, select one or
-           multiple coins you want to use as Avalanche stakes, then
-           right-click on a selected coin an select "Export coins details"
-         - save the file to disk, then transfer it to the offline computer
-         - restore the wallet from seed on the offline computer
-         - select "Build avalanche proof" in the tools menu, and load
-           the .json file containing the coin details
-         - in the new dialog, specify all required parameters (proof sequence
-           number, expiration timestamp, master public key), then click the
-           "Generate proof" button
-        """
-        fileName = self.getOpenFileName(
-            "Select the file containing the data for coins to be used as stakes",
-            "JSON (*.json);;All files (*)"
-        )
-        if not fileName:
-            return
-        with open(fileName, "r", encoding='utf-8') as f:
-            utxos = json.load(f)
-        if utxos is None:
-            return
+    def open_proof_editor(self):
         dialog = AvaProofDialog(self.wallet, self.receive_address, parent=self)
-        if dialog.add_utxos(utxos):
-            dialog.exec_()
+        dialog.exec_()
 
     def build_avalanche_delegation(self):
         """

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -3632,10 +3632,6 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         if dialog.add_utxos(utxos):
             dialog.exec_()
 
-        # Update the coins' frozen state.
-        self.utxo_list.update()
-        self.update_fee()
-
     def build_avalanche_delegation(self):
         """
         Open a dialog to build an avalanche delegation.

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -3628,8 +3628,9 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             utxos = json.load(f)
         if utxos is None:
             return
-        dialog = AvaProofDialog(utxos, self.wallet, self.receive_address, parent=self)
-        dialog.exec_()
+        dialog = AvaProofDialog(self.wallet, self.receive_address, parent=self)
+        if dialog.add_utxos(utxos):
+            dialog.exec_()
 
         # Update the coins' frozen state.
         self.utxo_list.update()

--- a/electroncash_gui/qt/utxo_list.py
+++ b/electroncash_gui/qt/utxo_list.py
@@ -565,8 +565,3 @@ class UTXOList(MyTreeWidget):
         )
         if dialog.add_utxos(utxos):
             dialog.exec_()
-
-        # Update the coins' frozen state in the GUI in case the proof editor updated it
-        # in storage.
-        self.update()
-        self.main_window.update_fee()

--- a/electroncash_gui/qt/utxo_list.py
+++ b/electroncash_gui/qt/utxo_list.py
@@ -559,14 +559,14 @@ class UTXOList(MyTreeWidget):
         stakes.
         """
         dialog = AvaProofDialog(
-            utxos,
             wallet=self.wallet,
             receive_address=self.main_window.receive_address,
             parent=self,
         )
-        dialog.exec_()
+        if dialog.add_utxos(utxos):
+            dialog.exec_()
 
-        # Update the coins' frozen state in the GUI in case the dialog updated it in
-        # storage.
+        # Update the coins' frozen state in the GUI in case the proof editor updated it
+        # in storage.
         self.update()
         self.main_window.update_fee()


### PR DESCRIPTION
This PR refactors the proof building tool to allow creating proof templates (with no stakes), viewing and editing existing proofs, adding stakes to an existing proof. 

Until now, we assumed that the wallet signing the proof and the wallet signing the stakes was the same. From this PR, the assumption will be that they are normally separate wallets.  What seems to make most sense is to create a dummy wallet to build the proof, separate from the wallet containing the stake. This removes the need of having to export any private key from the staking wallet (which could be an offline wallet restored from the seed from a hardware wallet).

This work also prepares the way to collaboratively build proofs, with inputs from multiple coinholders.

It introduces a file format for exchanging proofs, a `.proof` file, which contains a hexadecimal proof. This proof may have an invalid master signature during some stages of the building process, namely after the staking wallets adds signed stakes to the proof and before the proof signing wallet can update the  master signature to include the new stakes. 