### PR TITLE
Derive address-key pairs as needed when importing coin details in offline wallet

### DIFF
--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -360,6 +360,19 @@ class AvaProofEditor(CachedWalletPasswordWidget):
                 address = Address.from_string(address)
             txid = UInt256.from_hex(utxo["prevout_hash"])
 
+            # derive addresses as needed (if this is an offline wallet, it may not
+            # have derived addresses beyond the initial gap limit at index 20)
+            addr_index = utxo.get("address_index")
+            if addr_index is not None:
+                for_change = addr_index[0] == 1
+                num_addresses = (
+                    len(self.wallet.change_addresses)
+                    if for_change
+                    else len(self.wallet.receiving_addresses)
+                )
+                for _i in range(num_addresses, addr_index[1] + 1):
+                    self.wallet.create_new_address(for_change)
+
             try:
                 wif_key = self.wallet.export_private_key(address, self.pwd)
                 key = Key.from_wif(wif_key)

--- a/electroncash_gui/qt/utxo_list.py
+++ b/electroncash_gui/qt/utxo_list.py
@@ -536,7 +536,7 @@ class UTXOList(MyTreeWidget):
         for utxo in utxos:
             utxo_for_json = utxo.copy()
             addr = utxo["address"]
-            utxo_for_json["address"] = addr.to_full_string(Address.FMT_CASHADDR_BCH)
+            utxo_for_json["address"] = addr.to_full_string(Address.FMT_CASHADDR)
             utxo_for_json["address_index"] = self.wallet.get_address_index(addr)
             utxos_for_json.append(utxo_for_json)
 

--- a/electroncash_gui/qt/utxo_list.py
+++ b/electroncash_gui/qt/utxo_list.py
@@ -531,13 +531,13 @@ class UTXOList(MyTreeWidget):
         if not len(utxos):
             return
 
-        # serialize the Address
+        # serialize the Address and add the address index
         utxos_for_json = []
         for utxo in utxos:
             utxo_for_json = utxo.copy()
-            utxo_for_json["address"] = utxo["address"].to_full_string(
-                Address.FMT_CASHADDR_BCH
-            )
+            addr = utxo["address"]
+            utxo_for_json["address"] = addr.to_full_string(Address.FMT_CASHADDR_BCH)
+            utxo_for_json["address_index"] = self.wallet.get_address_index(addr)
             utxos_for_json.append(utxo_for_json)
 
         fileName, _filter = QtWidgets.QFileDialog.getSaveFileName(


### PR DESCRIPTION
Offline wallet don't have a network connection, by definition, so when they are initially created only 20 addresses are derived (up to the default gap limit). As a result when a user wants to load coins exported from an online wallet to add them to a proof and sign them, if the coin is on an address above index 20, he gets an error message "Coin does not belong to this wallet".


This PR adds the address index information in the exported coins file. The importing wallet uses this index information to derive more addresses if needed, so that the user does not need to manually create more addresses in the console.
Note that the new addresses are automatically saved to the wallet file, so this will need to be done only the first time a new unavailable key is needed.

Test Plan:
- export coin details for coins with index > 20
- disconnect Electrum ABC from the electrum servers by selecting a bad (unavailable) server
- restore the exporting wallet from seed while offline, check that only 20 addresses are derived
- open the Proof Editor, import coins from step 1, check that there is no error message and that you can generate the proof with proper stake signatures
- close the proof editor and go the the addresses tab, check that there are new addresses