### PR TITLE
Make the proof editor window non-modal

### DIFF
--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -681,7 +681,7 @@ class AvaProofDialog(QtWidgets.QDialog):
         parent: Optional[QtWidgets.QWidget] = None,
     ):
         super().__init__(parent)
-        self.setWindowTitle("Avalanche proof editor")
+        self.setWindowTitle(f"Avalanche proof editor - {wallet.basename()}")
 
         layout = QtWidgets.QVBoxLayout()
         self.setLayout(layout)

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -681,7 +681,7 @@ class AvaProofDialog(QtWidgets.QDialog):
         parent: Optional[QtWidgets.QWidget] = None,
     ):
         super().__init__(parent)
-        self.setWindowTitle(f"Avalanche proof editor - {wallet.basename()}")
+        self.setWindowTitle(f"Avalanche Proof Editor - {wallet.basename()}")
 
         layout = QtWidgets.QVBoxLayout()
         self.setLayout(layout)
@@ -1013,7 +1013,7 @@ class AvaDelegationDialog(QtWidgets.QDialog):
         parent: Optional[QtWidgets.QWidget] = None,
     ):
         super().__init__(parent)
-        self.setWindowTitle("Build avalanche delegation")
+        self.setWindowTitle("Build Avalanche Delegation")
 
         layout = QtWidgets.QVBoxLayout()
         self.setLayout(layout)

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -3598,7 +3598,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
 
     def open_proof_editor(self):
         dialog = AvaProofDialog(self.wallet, self.receive_address, parent=self)
-        dialog.exec_()
+        dialog.show()
 
     def build_avalanche_delegation(self):
         """

--- a/electroncash_gui/qt/utxo_list.py
+++ b/electroncash_gui/qt/utxo_list.py
@@ -564,4 +564,4 @@ class UTXOList(MyTreeWidget):
             parent=self,
         )
         if dialog.add_utxos(utxos):
-            dialog.exec_()
+            dialog.show()


### PR DESCRIPTION
allow interacting with wallet windows and other open proof edit windows.

Note that the proof editor is still a child window of the wallet, so if the wallet is closed it disappears.