### PR TITLE
[Proof editor] update the payout address when loading a proof

### DIFF
--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -783,15 +783,19 @@ class LoadProofDialog(QtWidgets.QDialog):
             return
         with open(fileName, "r") as f:
             proof_hex = f.read().strip()
-        return proof_hex
+        if self.try_to_decode_proof(proof_hex):
+            self.accept()
 
     def on_proof_text_changed(self):
+        self.try_to_decode_proof(self.proof_edit.toPlainText())
+        self.ok_button.setEnabled(self.proof is not None)
+
+    def try_to_decode_proof(self, proof_hex) -> bool:
         try:
-            self.proof = Proof.from_hex(self.proof_edit.toPlainText())
+            self.proof = Proof.from_hex(proof_hex)
         except DeserializationError:
             self.proof = None
-
-        self.ok_button.setEnabled(self.proof is not None)
+        return self.proof is not None
 
 
 class AvaDelegationWidget(CachedWalletPasswordWidget):

--- a/electroncash_gui/qt/avalanche_dialogs.py
+++ b/electroncash_gui/qt/avalanche_dialogs.py
@@ -30,6 +30,7 @@ from electroncash.avalanche.serialize import (
 from electroncash.bitcoin import is_private_key
 from electroncash.constants import PROOF_DUST_THRESHOLD, STAKE_UTXO_CONFIRMATIONS
 from electroncash.i18n import _
+from electroncash.transaction import get_address_from_output_script
 from electroncash.uint256 import UInt256
 from electroncash.util import format_satoshis
 from electroncash.wallet import AddressNotFoundError
@@ -581,6 +582,11 @@ class AvaProofEditor(CachedWalletPasswordWidget):
                 "just want to sign your stakes, ",
             )
         self.master_pubkey_view.setText(proof.master_pub.to_hex())
+
+        _txout_type, addr = get_address_from_output_script(proof.payout_script_pubkey)
+        # note: this will work even if the "addr" is not an address (PublicKey or
+        # ScriptOutput), but the proof generation currently only supports addresses
+        self.payout_addr_edit.setText(addr.to_ui_string())
         self.add_stakes(proof.signed_stakes)
 
         self.displayProof(proof)

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -775,10 +775,10 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
 
         tools_menu.addSeparator()
         avaproof_action = tools_menu.addAction(
-            "Avalanche proof editor", self.open_proof_editor
+            "Avalanche Proof Editor", self.open_proof_editor
         )
         tools_menu.addAction(
-            "Build avalanche delegation", self.build_avalanche_delegation
+            "Build Avalanche Delegation", self.build_avalanche_delegation
         )
         if self.wallet.is_watching_only() or not self.wallet.is_schnorr_possible():
             avaproof_action.setEnabled(False)


### PR DESCRIPTION
This fixes a bug when the user loaded a proof to decode its content: the payout address was not updated accordingly and was set to this wallet's next available address.

Also make the load proof dialog more convenient when loading a proof from file (close the dialog automatically)