### PR TITLE
[Refactoring] remove dependency on ElectrumWindow in base tree widget

### DIFF
--- a/electroncash_gui/qt/address_list.py
+++ b/electroncash_gui/qt/address_list.py
@@ -74,7 +74,6 @@ class AddressList(MyTreeWidget):
     def __init__(self, main_window: ElectrumWindow, *, picker=False):
         super().__init__(
             main_window,
-            self.create_menu,
             [],
             config=main_window.config,
             wallet=main_window.wallet,
@@ -82,6 +81,7 @@ class AddressList(MyTreeWidget):
             deferred_updates=True,
         )
         self.main_window = main_window
+        self.customContextMenuRequested.connect(self.create_menu)
         self.refresh_headers()
         self.picker = picker
         if self.picker:

--- a/electroncash_gui/qt/address_list.py
+++ b/electroncash_gui/qt/address_list.py
@@ -23,11 +23,13 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
 
 from collections import defaultdict
 from contextlib import suppress
 from enum import IntEnum
 from functools import partial
+from typing import TYPE_CHECKING
 
 from PyQt5 import QtWidgets
 from PyQt5.QtCore import Qt, pyqtSignal
@@ -53,6 +55,9 @@ from .util import (
     webopen,
 )
 
+if TYPE_CHECKING:
+    from .main_window import ElectrumWindow
+
 
 class AddressList(MyTreeWidget):
     # Address, Label, Balance
@@ -66,15 +71,17 @@ class AddressList(MyTreeWidget):
         can_edit_label = Qt.UserRole + 1
         cash_accounts = Qt.UserRole + 2
 
-    def __init__(self, parent, *, picker=False):
+    def __init__(self, parent: ElectrumWindow, *, picker=False):
         super().__init__(
             parent,
             self.create_menu,
             [],
             config=parent.config,
+            wallet=parent.wallet,
             stretch_column=2,
             deferred_updates=True,
         )
+        self.parent = parent
         self.refresh_headers()
         self.picker = picker
         if self.picker:

--- a/electroncash_gui/qt/address_list.py
+++ b/electroncash_gui/qt/address_list.py
@@ -67,7 +67,14 @@ class AddressList(MyTreeWidget):
         cash_accounts = Qt.UserRole + 2
 
     def __init__(self, parent, *, picker=False):
-        super().__init__(parent, self.create_menu, [], 2, deferred_updates=True)
+        super().__init__(
+            parent,
+            self.create_menu,
+            [],
+            config=parent.config,
+            stretch_column=2,
+            deferred_updates=True,
+        )
         self.refresh_headers()
         self.picker = picker
         if self.picker:

--- a/electroncash_gui/qt/contact_list.py
+++ b/electroncash_gui/qt/contact_list.py
@@ -55,9 +55,17 @@ class ContactList(PrintError, MyTreeWidget):
         Contact     = Qt.UserRole + 0
 
     def __init__(self, parent):
-        MyTreeWidget.__init__(self, parent, self.create_menu,
-                              ["", _('Name'), _('Label'), _('Address'), _('Type') ], 2, [1,2],  # headers, stretch_column, editable_columns
-                              deferred_updates=True, save_sort_settings=True)
+        MyTreeWidget.__init__(
+            self,
+            parent,
+            self.create_menu,
+            headers=["", _('Name'), _('Label'), _('Address'), _('Type')],
+            config=parent.config,
+            stretch_column=2,
+            editable_columns=[1, 2],
+            deferred_updates=True,
+            save_sort_settings=True
+        )
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         self.setSortingEnabled(True)
         self.wallet = parent.wallet

--- a/electroncash_gui/qt/contact_list.py
+++ b/electroncash_gui/qt/contact_list.py
@@ -63,7 +63,6 @@ class ContactList(PrintError, MyTreeWidget):
         MyTreeWidget.__init__(
             self,
             main_window,
-            self.create_menu,
             headers=["", _('Name'), _('Label'), _('Address'), _('Type')],
             config=main_window.config,
             wallet=main_window.wallet,
@@ -73,6 +72,7 @@ class ContactList(PrintError, MyTreeWidget):
             save_sort_settings=True
         )
         self.main_window = main_window
+        self.customContextMenuRequested.connect(self.create_menu)
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         self.setSortingEnabled(True)
         self.setIndentation(0)

--- a/electroncash_gui/qt/contact_list.py
+++ b/electroncash_gui/qt/contact_list.py
@@ -23,6 +23,7 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
 
 from electroncash.i18n import _, ngettext
 import electroncash.web as web
@@ -40,12 +41,16 @@ from .util import (MyTreeWidget, webopen, ColorScheme, MONOSPACE_FONT,
                    rate_limited)
 from enum import IntEnum
 from collections import defaultdict
-from typing import List, Set, Dict, Tuple
+from typing import List, Set, Dict, Tuple, TYPE_CHECKING
 from . import cashacctqt
+
+if TYPE_CHECKING:
+    from .main_window import ElectrumWindow
 
 
 class ContactList(PrintError, MyTreeWidget):
-    filter_columns = [1, 2, 3]  # Name, Label, Address
+    # Name, Label, Address
+    filter_columns = [1, 2, 3]
     default_sort = MyTreeWidget.SortSpec(1, Qt.AscendingOrder)
 
     do_update_signal = pyqtSignal()
@@ -54,21 +59,22 @@ class ContactList(PrintError, MyTreeWidget):
     class DataRoles(IntEnum):
         Contact     = Qt.UserRole + 0
 
-    def __init__(self, parent):
+    def __init__(self, parent: ElectrumWindow):
         MyTreeWidget.__init__(
             self,
             parent,
             self.create_menu,
             headers=["", _('Name'), _('Label'), _('Address'), _('Type')],
             config=parent.config,
+            wallet=parent.wallet,
             stretch_column=2,
             editable_columns=[1, 2],
             deferred_updates=True,
             save_sort_settings=True
         )
+        self.parent = parent
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         self.setSortingEnabled(True)
-        self.wallet = parent.wallet
         self.setIndentation(0)
         self._edited_item_cur_sel = (None,) * 3
         self.monospace_font = QFont(MONOSPACE_FONT)

--- a/electroncash_gui/qt/external_plugins_window.py
+++ b/electroncash_gui/qt/external_plugins_window.py
@@ -35,7 +35,7 @@ from PyQt5 import QtWidgets
 from electroncash.i18n import _
 from electroncash.plugins import ExternalPluginCodes, run_hook
 from electroncash.constants import PROJECT_NAME
-from .util import MyTreeWidget, MessageBoxMixin, WindowModalDialog, Buttons, CloseButton
+from .util import MessageBoxMixin, WindowModalDialog, Buttons, CloseButton
 
 
 INSTALL_ERROR_MESSAGES = {

--- a/electroncash_gui/qt/history_list.py
+++ b/electroncash_gui/qt/history_list.py
@@ -23,7 +23,10 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
+
 import time
+from typing import TYPE_CHECKING
 
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QBrush, QColor, QIcon, QFont
@@ -41,6 +44,9 @@ import electroncash.web as web
 from electroncash.i18n import _
 from electroncash.util import timestamp_to_datetime, profiler, Weak
 from electroncash.plugins import run_hook
+
+if TYPE_CHECKING:
+    from .main_window import ElectrumWindow
 
 
 TX_ICONS = [
@@ -63,19 +69,19 @@ class HistoryList(MyTreeWidget):
     statusIcons = {}
     default_sort = MyTreeWidget.SortSpec(0, Qt.AscendingOrder)
 
-    def __init__(self, parent):
+    def __init__(self, parent: ElectrumWindow):
         super().__init__(
             parent,
             self.create_menu,
             [],
             config=parent.config,
+            wallet=parent.wallet,
             stretch_column=3,
             deferred_updates=True
         )
+        self.parent = parent
         self.refresh_headers()
         self.setColumnHidden(1, True)
-        # force attributes to always be defined, even if None, at construction.
-        self.wallet = self.parent.wallet
         self.cleaned_up = False
 
         self.monospaceFont = QFont(MONOSPACE_FONT)
@@ -132,7 +138,6 @@ class HistoryList(MyTreeWidget):
 
     @profiler
     def on_update(self):
-        self.wallet = self.parent.wallet
         h = self.wallet.get_history(self.get_domain(), reverse=True)
         sels = self.selectedItems()
         current_tx = sels[0].data(0, Qt.UserRole) if sels else None

--- a/electroncash_gui/qt/history_list.py
+++ b/electroncash_gui/qt/history_list.py
@@ -56,6 +56,7 @@ TX_ICONS = [
     "confirmed.svg",
 ]
 
+
 class HistoryList(MyTreeWidget):
     filter_columns = [2, 3, 4]  # Date, Description, Amount
     filter_data_columns = [0]  # Allow search on tx_hash (string)
@@ -63,7 +64,14 @@ class HistoryList(MyTreeWidget):
     default_sort = MyTreeWidget.SortSpec(0, Qt.AscendingOrder)
 
     def __init__(self, parent):
-        super().__init__(parent, self.create_menu, [], 3, deferred_updates=True)
+        super().__init__(
+            parent,
+            self.create_menu,
+            [],
+            config=parent.config,
+            stretch_column=3,
+            deferred_updates=True
+        )
         self.refresh_headers()
         self.setColumnHidden(1, True)
         # force attributes to always be defined, even if None, at construction.

--- a/electroncash_gui/qt/history_list.py
+++ b/electroncash_gui/qt/history_list.py
@@ -72,7 +72,6 @@ class HistoryList(MyTreeWidget):
     def __init__(self, main_window: ElectrumWindow):
         super().__init__(
             main_window,
-            self.create_menu,
             [],
             config=main_window.config,
             wallet=main_window.wallet,
@@ -80,6 +79,7 @@ class HistoryList(MyTreeWidget):
             deferred_updates=True
         )
         self.main_window = main_window
+        self.customContextMenuRequested.connect(self.create_menu)
         self.refresh_headers()
         self.setColumnHidden(1, True)
         self.cleaned_up = False

--- a/electroncash_gui/qt/invoice_list.py
+++ b/electroncash_gui/qt/invoice_list.py
@@ -54,13 +54,13 @@ class InvoiceList(MyTreeWidget):
         MyTreeWidget.__init__(
             self,
             main_window,
-            self.create_menu,
             [_('Expires'), _('Requestor'), _('Description'), _('Amount'), _('Status')],
             config=main_window.config,
             wallet=main_window.wallet,
             stretch_column=2,
         )
         self.main_window = main_window
+        self.customContextMenuRequested.connect(self.create_menu)
         self.setSortingEnabled(True)
         self.header().setSectionResizeMode(1, QtWidgets.QHeaderView.Interactive)
         self.setColumnWidth(1, 200)

--- a/electroncash_gui/qt/invoice_list.py
+++ b/electroncash_gui/qt/invoice_list.py
@@ -23,6 +23,11 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
 from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QIcon, QFont
 from PyQt5 import QtWidgets
@@ -38,19 +43,24 @@ from electroncash.i18n import _
 from electroncash.util import format_time, FileImportFailed
 from electroncash.paymentrequest import pr_tooltips
 
+if TYPE_CHECKING:
+    from .main_window import ElectrumWindow
+
 
 class InvoiceList(MyTreeWidget):
     filter_columns = [0, 1, 2, 3]  # Date, Requestor, Description, Amount
 
-    def __init__(self, parent):
+    def __init__(self, parent: ElectrumWindow):
         MyTreeWidget.__init__(
             self,
             parent,
             self.create_menu,
             [_('Expires'), _('Requestor'), _('Description'), _('Amount'), _('Status')],
             config=parent.config,
+            wallet=parent.wallet,
             stretch_column=2,
         )
+        self.parent = parent
         self.setSortingEnabled(True)
         self.header().setSectionResizeMode(1, QtWidgets.QHeaderView.Interactive)
         self.setColumnWidth(1, 200)
@@ -83,7 +93,7 @@ class InvoiceList(MyTreeWidget):
 
 
     def import_invoices(self):
-        wallet_folder = self.parent.get_wallet_folder()
+        wallet_folder = os.path.dirname(os.path.abspath(self.config.get_wallet_path()))
         filename, __ = QtWidgets.QFileDialog.getOpenFileName(self.parent, "Select your wallet file", wallet_folder)
         if not filename:
             return

--- a/electroncash_gui/qt/invoice_list.py
+++ b/electroncash_gui/qt/invoice_list.py
@@ -43,7 +43,14 @@ class InvoiceList(MyTreeWidget):
     filter_columns = [0, 1, 2, 3]  # Date, Requestor, Description, Amount
 
     def __init__(self, parent):
-        MyTreeWidget.__init__(self, parent, self.create_menu, [_('Expires'), _('Requestor'), _('Description'), _('Amount'), _('Status')], 2)
+        MyTreeWidget.__init__(
+            self,
+            parent,
+            self.create_menu,
+            [_('Expires'), _('Requestor'), _('Description'), _('Amount'), _('Status')],
+            config=parent.config,
+            stretch_column=2,
+        )
         self.setSortingEnabled(True)
         self.header().setSectionResizeMode(1, QtWidgets.QHeaderView.Interactive)
         self.setColumnWidth(1, 200)

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -1156,9 +1156,10 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
 
     def create_history_tab(self):
         from .history_list import HistoryList
-        self.history_list = l = HistoryList(self)
-        l.searchable_list = l
-        return l
+        self.history_list = HistoryList(self)
+        self.history_list.edited.connect(self.update_labels)
+        self.history_list.searchable_list = self.history_list
+        return self.history_list
 
     def show_address(self, addr, *, parent=None):
         parent = parent or self.top_level_window()
@@ -1715,7 +1716,13 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
 
         self.from_label = QtWidgets.QLabel(_('&From'))
         grid.addWidget(self.from_label, 4, 0)
-        self.from_list = MyTreeWidget(self, self.from_list_menu, ['', ''], self.config)
+        self.from_list = MyTreeWidget(
+            self,
+            self.from_list_menu,
+            ['', ''],
+            self.config,
+            self.wallet
+        )
         self.from_label.setBuddy(self.from_list)
         self.from_list.setHeaderHidden(True)
         self.from_list.setMaximumHeight(80)
@@ -2720,13 +2727,15 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
 
     def create_addresses_tab(self):
         from .address_list import AddressList
-        self.address_list = l = AddressList(self)
-        return self.create_list_tab(l)
+        self.address_list = AddressList(self)
+        self.address_list.edited.connect(self.update_labels)
+        return self.create_list_tab(self.address_list)
 
     def create_utxo_tab(self):
         from .utxo_list import UTXOList
-        self.utxo_list = l = UTXOList(self)
-        return self.create_list_tab(l)
+        self.utxo_list = UTXOList(self)
+        self.utxo_list.edited.connect(self.update_labels)
+        return self.create_list_tab(self.utxo_list)
 
     def create_contacts_tab(self):
         from .contact_list import ContactList

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -25,6 +25,7 @@
 # SOFTWARE.
 from __future__ import annotations
 
+import contextlib
 import copy
 import csv
 import json
@@ -2734,6 +2735,10 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
     def create_utxo_tab(self):
         from .utxo_list import UTXOList
         self.utxo_list = UTXOList(self)
+        self.ca_address_default_changed_signal.connect(
+            self.utxo_list.ca_on_address_default_change
+        )
+        self.gui_object.addr_fmt_changed.connect(self.utxo_list.update)
         self.utxo_list.edited.connect(self.update_labels)
         return self.create_list_tab(self.utxo_list)
 
@@ -4976,6 +4981,13 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         for w in [self.address_list, self.history_list, self.utxo_list, self.cash_account_e, self.contact_list,
                   self.tx_update_mgr]:
             if w: w.clean_up()  # tell relevant object to clean itself up, unregister callbacks, disconnect signals, etc
+
+        with contextlib.suppress(TypeError):
+            self.ca_address_default_changed_signal.disconnect(
+                self.utxo_list.ca_on_address_default_change
+            )
+        with contextlib.suppress(TypeError):
+            self.gui_object.addr_fmt_changed.disconnect(self.utxo_list.update)
 
         # We catch these errors with the understanding that there is no recovery at
         # this point, given user has likely performed an action we cannot recover

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -1719,11 +1719,11 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         grid.addWidget(self.from_label, 4, 0)
         self.from_list = MyTreeWidget(
             self,
-            self.from_list_menu,
             ['', ''],
             self.config,
             self.wallet
         )
+        self.from_list.customContextMenuRequested.connect(self.from_list_menu)
         self.from_label.setBuddy(self.from_list)
         self.from_list.setHeaderHidden(True)
         self.from_list.setMaximumHeight(80)

--- a/electroncash_gui/qt/main_window.py
+++ b/electroncash_gui/qt/main_window.py
@@ -1715,7 +1715,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
 
         self.from_label = QtWidgets.QLabel(_('&From'))
         grid.addWidget(self.from_label, 4, 0)
-        self.from_list = MyTreeWidget(self, self.from_list_menu, ['',''])
+        self.from_list = MyTreeWidget(self, self.from_list_menu, ['', ''], self.config)
         self.from_label.setBuddy(self.from_list)
         self.from_list.setHeaderHidden(True)
         self.from_list.setMaximumHeight(80)

--- a/electroncash_gui/qt/request_list.py
+++ b/electroncash_gui/qt/request_list.py
@@ -49,7 +49,6 @@ class RequestList(MyTreeWidget):
         MyTreeWidget.__init__(
             self,
             main_window,
-            self.create_menu,
             [_('Date'), _('Address'), '', _('Description'), _('Amount'), _('Status')],
             config=main_window.config,
             wallet=main_window.wallet,
@@ -57,6 +56,7 @@ class RequestList(MyTreeWidget):
             deferred_updates=False,
         )
         self.main_window = main_window
+        self.customContextMenuRequested.connect(self.create_menu)
         self.currentItemChanged.connect(self.item_changed)
         self.itemClicked.connect(self.item_changed)
         self.setSortingEnabled(True)

--- a/electroncash_gui/qt/request_list.py
+++ b/electroncash_gui/qt/request_list.py
@@ -23,6 +23,9 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 
 from electroncash.address import Address
 from electroncash.i18n import _
@@ -34,27 +37,31 @@ from PyQt5.QtGui import QIcon
 from PyQt5 import QtWidgets
 from .util import MyTreeWidget, pr_icons
 
+if TYPE_CHECKING:
+    from .main_window import ElectrumWindow
+
 
 class RequestList(MyTreeWidget):
     # Date, Account, Address, Description, Amount
     filter_columns = [0, 1, 2, 3, 4]
 
-    def __init__(self, parent):
+    def __init__(self, parent: ElectrumWindow):
         MyTreeWidget.__init__(
             self,
             parent,
             self.create_menu,
             [_('Date'), _('Address'), '', _('Description'), _('Amount'), _('Status')],
             config=parent.config,
+            wallet=parent.wallet,
             stretch_column=3,
             deferred_updates=False,
         )
+        self.parent = parent
         self.currentItemChanged.connect(self.item_changed)
         self.itemClicked.connect(self.item_changed)
         self.setSortingEnabled(True)
         self.setColumnWidth(0, 180)
         self.hideColumn(1)
-        self.wallet = parent.wallet
 
     def item_changed(self, item):
         if item is None:

--- a/electroncash_gui/qt/request_list.py
+++ b/electroncash_gui/qt/request_list.py
@@ -36,11 +36,19 @@ from .util import MyTreeWidget, pr_icons
 
 
 class RequestList(MyTreeWidget):
-    filter_columns = [0, 1, 2, 3, 4]  # Date, Account, Address, Description, Amount
-
+    # Date, Account, Address, Description, Amount
+    filter_columns = [0, 1, 2, 3, 4]
 
     def __init__(self, parent):
-        MyTreeWidget.__init__(self, parent, self.create_menu, [_('Date'), _('Address'), '', _('Description'), _('Amount'), _('Status')], 3, deferred_updates=False)
+        MyTreeWidget.__init__(
+            self,
+            parent,
+            self.create_menu,
+            [_('Date'), _('Address'), '', _('Description'), _('Amount'), _('Status')],
+            config=parent.config,
+            stretch_column=3,
+            deferred_updates=False,
+        )
         self.currentItemChanged.connect(self.item_changed)
         self.itemClicked.connect(self.item_changed)
         self.setSortingEnabled(True)

--- a/electroncash_gui/qt/util.py
+++ b/electroncash_gui/qt/util.py
@@ -613,7 +613,6 @@ class MyTreeWidget(QtWidgets.QTreeWidget):
     def __init__(
         self,
         parent: QtWidgets.QWidget,
-        create_menu,
         headers,
         config: SimpleConfig,
         wallet: Abstract_Wallet,
@@ -628,7 +627,6 @@ class MyTreeWidget(QtWidgets.QTreeWidget):
         self.wallet = wallet
         self.stretch_column = stretch_column
         self.setContextMenuPolicy(Qt.CustomContextMenu)
-        self.customContextMenuRequested.connect(create_menu)
         self.setUniformRowHeights(True)
         # extend the syntax for consistency
         self.addChild = self.addTopLevelItem

--- a/electroncash_gui/qt/util.py
+++ b/electroncash_gui/qt/util.py
@@ -10,6 +10,7 @@ from collections import namedtuple
 from functools import partial, wraps
 from locale import atof
 
+from electroncash.simple_config import SimpleConfig
 from electroncash.util import print_error, PrintError, Weak, finalization_print_error
 from electroncash.wallet import Abstract_Wallet
 
@@ -605,12 +606,13 @@ class MyTreeWidget(QtWidgets.QTreeWidget):
     # the QTreeWidgetItem data role to use when searching data columns
     filter_data_role : int = Qt.UserRole
 
-    def __init__(self, parent, create_menu, headers, stretch_column=None,
+    def __init__(self, parent, create_menu, headers, config: SimpleConfig,
+                 stretch_column=None,
                  editable_columns=None,
                  *, deferred_updates=False, save_sort_settings=False):
         QtWidgets.QTreeWidget.__init__(self, parent)
         self.parent = parent
-        self.config = self.parent.config
+        self.config = config
         self.stretch_column = stretch_column
         self.setContextMenuPolicy(Qt.CustomContextMenu)
         self.customContextMenuRequested.connect(create_menu)

--- a/electroncash_gui/qt/utxo_list.py
+++ b/electroncash_gui/qt/utxo_list.py
@@ -97,6 +97,7 @@ class UTXOList(MyTreeWidget):
             self.create_menu,
             columns,
             config=main_window.config,
+            wallet=main_window.wallet,
             stretch_column=UTXOList.Col.label,
             deferred_updates=True,
             save_sort_settings=True,
@@ -104,7 +105,6 @@ class UTXOList(MyTreeWidget):
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         self.setSortingEnabled(True)
         self.main_window = main_window
-        self.wallet = main_window.wallet
         main_window.ca_address_default_changed_signal.connect(
             self._ca_on_address_default_change
         )
@@ -137,7 +137,7 @@ class UTXOList(MyTreeWidget):
 
         @wraps(func)
         def wrapper(self, *args, **kwargs):
-            if self.cleaned_up or not self.wallet or not self.parent:
+            if self.cleaned_up or not self.wallet or not self.main_window:
                 return
             else:
                 func(self, *args, **kwargs)

--- a/electroncash_gui/qt/utxo_list.py
+++ b/electroncash_gui/qt/utxo_list.py
@@ -94,7 +94,6 @@ class UTXOList(MyTreeWidget):
         MyTreeWidget.__init__(
             self,
             main_window,
-            self.create_menu,
             columns,
             config=main_window.config,
             wallet=main_window.wallet,
@@ -105,6 +104,7 @@ class UTXOList(MyTreeWidget):
         self.setSelectionMode(QtWidgets.QAbstractItemView.ExtendedSelection)
         self.setSortingEnabled(True)
         self.main_window = main_window
+        self.customContextMenuRequested.connect(self.create_menu)
         self.utxos = []
         # cache some values to avoid constructing Qt objects for every pass through self.on_update (this is important for large wallets)
         self.monospaceFont = QFont(MONOSPACE_FONT)

--- a/electroncash_gui/qt/utxo_list.py
+++ b/electroncash_gui/qt/utxo_list.py
@@ -96,6 +96,7 @@ class UTXOList(MyTreeWidget):
             main_window,
             self.create_menu,
             columns,
+            config=main_window.config,
             stretch_column=UTXOList.Col.label,
             deferred_updates=True,
             save_sort_settings=True,

--- a/electroncash_plugins/email_requests/qt.py
+++ b/electroncash_plugins/email_requests/qt.py
@@ -23,8 +23,6 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
-
-import time
 import threading
 import queue
 import base64
@@ -37,6 +35,8 @@ from email.mime.multipart import MIMEMultipart
 from email.mime.base import MIMEBase
 from email.encoders import encode_base64
 
+from typing import TYPE_CHECKING
+
 from PyQt5.QtCore import QObject, pyqtSignal
 from PyQt5 import QtWidgets
 
@@ -46,6 +46,9 @@ from electroncash.i18n import _
 from electroncash_gui.qt.util import EnterButton, Buttons, CloseButton
 from electroncash_gui.qt.util import OkButton, WindowModalDialog
 from electroncash.util import Weak, PrintError
+
+if TYPE_CHECKING:
+    from electroncash_gui.qt.request_list import RequestList
 
 
 class Processor(threading.Thread, PrintError):
@@ -180,7 +183,8 @@ class Plugin(BasePlugin):
 
     @hook
     def receive_list_menu(self, menu, addr):
-        window = menu.parentWidget().parent  # Grr. Electrum programmers overwrote parent() method.
+        request_list: RequestList = menu.parentWidget()
+        window = request_list.main_window
         menu.addAction(_("Send via e-mail"), lambda: self.send(window, addr))
 
     def send(self, window, addr):

--- a/electroncash_plugins/fusion/qt.py
+++ b/electroncash_plugins/fusion/qt.py
@@ -24,11 +24,13 @@
 # ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
+from __future__ import annotations
+
 import threading
 import weakref
 
 from functools import partial
-from typing import Optional
+from typing import Optional, TYPE_CHECKING
 
 from PyQt5.QtCore import QMargins, QObject, QPoint, QSize, Qt, QTimer, pyqtSignal
 from PyQt5.QtGui import QCursor, QIcon, QImage, QPainter
@@ -62,6 +64,9 @@ from .fusion import can_fuse_from, can_fuse_to
 from .server import Params
 from .plugin import FusionPlugin, TOR_PORTS, COIN_FRACTION_FUDGE_FACTOR, select_coins, MAX_LIMIT_FUSE_DEPTH
 from .util import get_coin_name
+
+if TYPE_CHECKING:
+    from electroncash_gui.qt.address_list import AddressList
 
 from pathlib import Path
 heredir = Path(__file__).parent
@@ -153,11 +158,11 @@ class Plugin(FusionPlugin, QObject):
             self.on_new_window(window)
 
     @hook
-    def address_list_context_menu_setup(self, address_list, menu, addrs):
+    def address_list_context_menu_setup(self, address_list: AddressList, menu, addrs):
         if not self.active:
             return
         wallet = address_list.wallet
-        window = address_list.parent
+        window = address_list.main_window
         network = wallet.network
         if not (can_fuse_from(wallet) and can_fuse_to(wallet) and network):
             return


### PR DESCRIPTION
The tree widgets used in Electrum all derive from a BaseTreeWidget which knows way too much about its parent main_window. Clean up the base widget so that it does not need a reference to the main_window.

Note that for now the child classes still need to access the internals of the main window, so this is just pushing the dirt downstream. But at least after that it will be possible to clean up each inheritor individually.

Reduce also the interconnections between the widget and the wallet, for the same reasons.