### PR TITLE
Rename classes to PEP8 style

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: 'pb2.py'
 repos:
 -   repo: https://github.com/pycqa/isort
-    rev: 5.9.3
+    rev: 5.11.2
     hooks:
     -   id: isort
         name: isort (python)
@@ -15,11 +15,11 @@ repos:
         types: [pyi]
         args: [--profile=black]
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.12.0
     hooks:
     -   id: black
 -   repo: https://github.com/pycqa/flake8
-    rev: 4.0.1
+    rev: 6.0.0
     hooks:
     # Syntax errors checked on all files
     -   id: flake8

--- a/electrum-abc
+++ b/electrum-abc
@@ -56,7 +56,7 @@ from electrumabc.simple_config import SimpleConfig
 from electrumabc.storage import WalletStorage
 from electrumabc.util import InvalidPassword, json_decode, json_encode
 from electrumabc.wallet import (
-    Abstract_Wallet,
+    AbstractWallet,
     ImportedAddressWallet,
     ImportedPrivkeyWallet,
     Wallet,
@@ -178,7 +178,7 @@ def run_non_rpc(simple_config: SimpleConfig):
 
 def restore_wallet(
     simple_config: SimpleConfig, storage: WalletStorage
-) -> Abstract_Wallet:
+) -> AbstractWallet:
     """Restore an existing wallet"""
     text = simple_config.get("text").strip()
     passphrase = simple_config.get("passphrase", "")
@@ -230,7 +230,7 @@ def restore_wallet(
     return wallet
 
 
-def create_wallet(simple_config: SimpleConfig) -> Abstract_Wallet:
+def create_wallet(simple_config: SimpleConfig) -> AbstractWallet:
     """Create a new wallet"""
     password = prompt_create_wallet_password()
     seed_type = simple_config.get("seed_type", "bip39")

--- a/electrumabc/address.py
+++ b/electrumabc/address.py
@@ -32,8 +32,8 @@ from typing import Optional, Tuple, Union
 
 from . import cashaddr, networks
 from .bitcoin import (
-    EC_KEY,
     SCRIPT_TYPES,
+    ECKey,
     OpCodes,
     hash_160,
     is_minikey,
@@ -172,7 +172,7 @@ class PublicKey(namedtuple("PublicKeyTuple", "pubkey")):
         """Create a compressed or uncompressed public key from a private
         key."""
         privkey, compressed = cls.privkey_from_WIF_privkey(WIF_privkey)
-        ec_key = EC_KEY(privkey)
+        ec_key = ECKey(privkey)
         return cls.from_pubkey(ec_key.GetPubKey(compressed))
 
     @classmethod

--- a/electrumabc/base_wizard.py
+++ b/electrumabc/base_wizard.py
@@ -31,13 +31,13 @@ import sys
 import traceback
 from typing import Any, Callable, Dict, List, NamedTuple, Optional
 
-from electrumabc_plugins.hw_wallet import HW_PluginBase
+from electrumabc_plugins.hw_wallet import HWPluginBase
 
 from . import bitcoin, keystore, mnemo, util
 from .address import Address
 from .constants import CURRENCY, PROJECT_NAME, REPOSITORY_URL
 from .i18n import _
-from .keystore import Hardware_KeyStore
+from .keystore import HardwareKeyStore
 from .plugins import BasePlugin, DeviceInfo
 from .printerror import PrintError
 from .simple_config import SimpleConfig
@@ -511,7 +511,7 @@ class BaseWizard(PrintError):
         from .keystore import hardware_keystore
 
         devmgr = self.plugins.device_manager
-        assert isinstance(self.plugin, HW_PluginBase)
+        assert isinstance(self.plugin, HWPluginBase)
         xtype = "standard"
         try:
             xpub = self.plugin.get_xpub(device_info.device.id_, derivation, xtype, self)
@@ -651,11 +651,11 @@ class BaseWizard(PrintError):
         # note: the following condition ("if") is duplicated logic from
         # wallet.get_available_storage_encryption_version()
         if self.wallet_type == "standard" and isinstance(
-            self.keystores[0], Hardware_KeyStore
+            self.keystores[0], HardwareKeyStore
         ):
             # offer encrypting with a pw derived from the hw device
-            k: Hardware_KeyStore = self.keystores[0]
-            assert isinstance(self.plugin, HW_PluginBase)
+            k: HardwareKeyStore = self.keystores[0]
+            assert isinstance(self.plugin, HWPluginBase)
             try:
                 k.handler = self.plugin.create_handler(self)
                 password = k.get_password_for_storage_encryption()
@@ -750,7 +750,7 @@ class BaseWizard(PrintError):
     def create_seed(self, seed_type):
         self.seed_type = seed_type
         if seed_type in ["standard", "electrum"]:
-            seed = mnemo.Mnemonic_Electrum("en").make_seed()
+            seed = mnemo.MnemonicElectrum("en").make_seed()
         elif seed_type == "bip39":
             seed = mnemo.make_bip39_words("english")
         else:

--- a/electrumabc/bitcoin.py
+++ b/electrumabc/bitcoin.py
@@ -717,7 +717,7 @@ def deserialize_privkey(key, *, net=None):
 
 def regenerate_key(pk):
     assert len(pk) == 32
-    return EC_KEY(pk)
+    return ECKey(pk)
 
 
 def GetPubKey(pubkey, compressed=False):
@@ -832,7 +832,7 @@ def verify_message(
 
 
 def encrypt_message(message, pubkey, magic=b"BIE1"):
-    return EC_KEY.encrypt_message(message, bfh(pubkey), magic)
+    return ECKey.encrypt_message(message, bfh(pubkey), magic)
 
 
 def ECC_YfromX(x, curved=curve_secp256k1, odd=True):
@@ -932,7 +932,7 @@ class MySigningKey(ecdsa.SigningKey):
         return r, s
 
 
-class EC_KEY(object):
+class ECKey(object):
     def __init__(self, k):
         secret = string_to_number(k)
         self.pubkey = ecdsa.ecdsa.Public_key(
@@ -996,7 +996,7 @@ class EC_KEY(object):
         ephemeral_exponent = number_to_string(
             ecdsa.util.randrange(pow(2, 256)), generator_secp256k1.order()
         )
-        ephemeral = EC_KEY(ephemeral_exponent)
+        ephemeral = ECKey(ephemeral_exponent)
         ecdh_key = point_to_ser(pk * ephemeral.privkey.secret_multiplier)
         key = hashlib.sha512(ecdh_key).digest()
         iv, key_e, key_m = key[0:16], key[16:32], key[32:]
@@ -1061,7 +1061,7 @@ def CKD_priv(k, c, n):
 
 def _CKD_priv(k, c, s, is_prime):
     order = generator_secp256k1.order()
-    keypair = EC_KEY(k)
+    keypair = ECKey(k)
     cK = GetPubKey(keypair.pubkey, True)
     data = bytes([0]) + k + s if is_prime else cK + s
     I_ = hmac.new(c, data, hashlib.sha512).digest()

--- a/electrumabc/commands.py
+++ b/electrumabc/commands.py
@@ -40,7 +40,7 @@ from . import bitcoin, util
 from .address import Address, AddressError
 from .bitcoin import CASH, TYPE_ADDRESS, hash_160
 from .constants import PROJECT_NAME, SCRIPT_NAME, XEC
-from .mnemo import Mnemonic_Electrum, make_bip39_words
+from .mnemo import MnemonicElectrum, make_bip39_words
 from .paymentrequest import PR_EXPIRED, PR_PAID, PR_UNCONFIRMED, PR_UNKNOWN, PR_UNPAID
 from .plugins import run_hook
 from .printerror import print_error
@@ -353,7 +353,7 @@ class Commands:
     def make_electrum_seed(self, nbits=132, entropy=1, language=None):
         """Create an Electrum seed"""
         t = "electrum"
-        s = Mnemonic_Electrum(language).make_seed(t, nbits, custom_entropy=entropy)
+        s = MnemonicElectrum(language).make_seed(t, nbits, custom_entropy=entropy)
         return s
 
     @command("")
@@ -365,7 +365,7 @@ class Commands:
     @command("")
     def check_electrum_seed(self, seed, entropy=1, language=None):
         """Check that an Electrum seed was generated with given entropy"""
-        return Mnemonic_Electrum(language).check_seed(seed, entropy)
+        return MnemonicElectrum(language).check_seed(seed, entropy)
 
     @command("")
     def check_seed(self, seed, entropy=1, language=None):

--- a/electrumabc/consolidate.py
+++ b/electrumabc/consolidate.py
@@ -51,7 +51,7 @@ class AddressConsolidator:
     def __init__(
         self,
         address: Address,
-        wallet_instance: wallet.Abstract_Wallet,
+        wallet_instance: wallet.AbstractWallet,
         include_coinbase: bool = True,
         include_non_coinbase: bool = True,
         include_frozen: bool = False,
@@ -104,7 +104,7 @@ class AddressConsolidator:
                 "signatures": [None],
                 "num_sig": 1,
             }
-        elif isinstance(self.wallet, wallet.Multisig_Wallet):
+        elif isinstance(self.wallet, wallet.MultisigWallet):
             derivation = self.wallet.get_address_index(address)
             sig_info = {
                 "x_pubkeys": [

--- a/electrumabc/daemon.py
+++ b/electrumabc/daemon.py
@@ -46,7 +46,7 @@ from .wallet import Wallet
 
 if TYPE_CHECKING:
     from .plugins import Plugins
-    from .wallet import Abstract_Wallet
+    from .wallet import AbstractWallet
 
 
 def get_lockfile(config):
@@ -187,7 +187,7 @@ class Daemon(DaemonThread):
             self.network.add_jobs([self.fx])
         self.gui = None
         self.server = None
-        self.wallets: Dict[str, Abstract_Wallet] = {}
+        self.wallets: Dict[str, AbstractWallet] = {}
         if listen_jsonrpc:
             # Setup JSONRPC server
             self.init_server(config, fd)

--- a/electrumabc/mnemo.py
+++ b/electrumabc/mnemo.py
@@ -200,7 +200,7 @@ def is_electrum_seed(seed: str, prefix: str = version.SEED_PREFIX) -> bool:
     Returns True if the text in question matches the checksum for Electrum
     seeds. Does not depend on any particular word list, just checks unicode
     data.  Very fast."""
-    return Mnemonic_Electrum.verify_checksum_only(seed, prefix)
+    return MnemonicElectrum.verify_checksum_only(seed, prefix)
 
 
 def is_old_seed(seed: str) -> bool:
@@ -389,7 +389,7 @@ class MnemonicBase(PrintError):
         return self.is_checksum_valid(mnemonic)[0]
 
 
-class Mnemonic_Electrum(MnemonicBase):
+class MnemonicElectrum(MnemonicBase):
     """This implements the "Electrum" mnemonic seed phrase format, which was
     used for many years, but starting in 2020, Electron Cash switched back to
     BIP39 since it has wider support.

--- a/electrumabc/paymentrequest.py
+++ b/electrumabc/paymentrequest.py
@@ -553,7 +553,7 @@ class InvoiceStore(object):
                 raw = bfh(v.get("hex"))
                 try:
                     # First try BitPay 2.0 style PR -- this contains compressed raw bytes of the headers & json associated with the request; will raise if wrong format
-                    pr = PaymentRequest_BitPay20.deserialize(raw)
+                    pr = PaymentRequestBitPay20.deserialize(raw)
                 except Exception:
                     pass
                 if not pr:
@@ -644,7 +644,7 @@ class ResponseError(Exception):
     """Contains the exact text of the bad response error message from BitPay"""
 
 
-class PaymentRequest_BitPay20(PaymentRequest, PrintError):
+class PaymentRequestBitPay20(PaymentRequest, PrintError):
     """Work-alike to the existing BIP70 PaymentRequest class.
     Wraps payment requests based on the new BitPay 2.0 JSON API."""
 
@@ -1016,14 +1016,14 @@ def get_payment_request_bitpay20(url, timeout=10.0):
     """Synchronously contacts BitPay and gets the payment request.
     Returns the PaymentRequest object. Returned PaymentRequest
     has .error != None on error."""
-    headers = PaymentRequest_BitPay20.HEADERS.copy()
+    headers = PaymentRequestBitPay20.HEADERS.copy()
     headers.update({"accept": "application/payment-request"})
     try:
         r = requests.get(url, headers=headers, timeout=timeout, verify=True)
         if r.status_code == 400:
             raise ResponseError(r.text)
         r.raise_for_status()
-        return PaymentRequest_BitPay20(PaymentRequest_BitPay20.Raw(response=r))
+        return PaymentRequestBitPay20(PaymentRequestBitPay20.Raw(response=r))
     except Exception as e:
         print_error("[BitPay2.0] get_payment_request:", repr(e))
         return PaymentRequest(None, error=str(e))

--- a/electrumabc/pem.py
+++ b/electrumabc/pem.py
@@ -31,7 +31,7 @@
 
 import binascii
 
-from .x509 import ASN1_Node, bytestr_to_int, decode_OID
+from .x509 import ASN1Node, bytestr_to_int, decode_OID
 
 
 def a2b_base64(s):
@@ -156,7 +156,7 @@ def parse_private_key(s):
 
 
 def _parsePKCS8(_bytes):
-    s = ASN1_Node(_bytes)
+    s = ASN1Node(_bytes)
     root = s.root()
     version_node = s.first_child(root)
     version = bytestr_to_int(s.get_value_of_type(version_node, "INTEGER"))
@@ -173,7 +173,7 @@ def _parsePKCS8(_bytes):
 
 
 def _parseSSLeay(bytes):
-    return _parseASN1PrivateKey(ASN1_Node(bytes))
+    return _parseASN1PrivateKey(ASN1Node(bytes))
 
 
 def bytesToNumber(s):
@@ -181,7 +181,7 @@ def bytesToNumber(s):
 
 
 def _parseASN1PrivateKey(s):
-    s = ASN1_Node(s)
+    s = ASN1Node(s)
     root = s.root()
     version_node = s.first_child(root)
     version = bytestr_to_int(s.get_value_of_type(version_node, "INTEGER"))

--- a/electrumabc/plugins.py
+++ b/electrumabc/plugins.py
@@ -67,10 +67,10 @@ if TYPE_CHECKING:
     from electrumabc_plugins.hw_wallet import (
         HardwareClientBase,
         HardwareHandlerBase,
-        HW_PluginBase,
+        HWPluginBase,
     )
 
-    from .keystore import Hardware_KeyStore
+    from .keystore import HardwareKeyStore
 
 plugin_loaders = {}
 hooks = defaultdict(list)
@@ -883,8 +883,8 @@ class DeviceMgr(ThreadJob):
         # a (path, id_) pair. Needs self.lock.
         self.clients: Dict[HardwareClientBase, Tuple[Union[str, bytes], str]] = {}
         # What we recognise.  (vendor_id, product_id) -> Plugin
-        self._recognised_hardware: Dict[Tuple[int, int], HW_PluginBase] = {}
-        self._recognised_vendor: Dict[int, HW_PluginBase] = {}
+        self._recognised_hardware: Dict[Tuple[int, int], HWPluginBase] = {}
+        self._recognised_vendor: Dict[int, HWPluginBase] = {}
         """vendor_id -> Plugin"""
         # Custom enumerate functions for devices we don't know about.
         self.enumerate_func = set()
@@ -925,11 +925,11 @@ class DeviceMgr(ThreadJob):
         for client in clients:
             client.timeout(cutoff)
 
-    def register_devices(self, device_pairs, *, plugin: HW_PluginBase):
+    def register_devices(self, device_pairs, *, plugin: HWPluginBase):
         for pair in device_pairs:
             self._recognised_hardware[pair] = plugin
 
-    def register_vendor_ids(self, vendor_ids: Iterable[int], *, plugin: HW_PluginBase):
+    def register_vendor_ids(self, vendor_ids: Iterable[int], *, plugin: HWPluginBase):
         for vendor_id in vendor_ids:
             self._recognised_vendor[vendor_id] = plugin
 
@@ -937,7 +937,7 @@ class DeviceMgr(ThreadJob):
         self.enumerate_func.add(func)
 
     def create_client(
-        self, device: Device, handler: HardwareHandlerBase, plugin: HW_PluginBase
+        self, device: Device, handler: HardwareHandlerBase, plugin: HWPluginBase
     ) -> Optional[HardwareClientBase]:
         # Get from cache first
         client = self._client_by_id(device.id_)
@@ -1005,9 +1005,9 @@ class DeviceMgr(ThreadJob):
     @with_scan_lock
     def client_for_keystore(
         self,
-        plugin: HW_PluginBase,
+        plugin: HWPluginBase,
         handler: Optional[HardwareHandlerBase],
-        keystore: Hardware_KeyStore,
+        keystore: HardwareKeyStore,
         force_pair: bool,
     ) -> Optional[HardwareClientBase]:
         self.print_error("getting client for keystore")
@@ -1034,7 +1034,7 @@ class DeviceMgr(ThreadJob):
 
     def client_by_xpub(
         self,
-        plugin: HW_PluginBase,
+        plugin: HWPluginBase,
         xpub,
         handler: HardwareHandlerBase,
         devices: Iterable[Device],
@@ -1053,7 +1053,7 @@ class DeviceMgr(ThreadJob):
 
     def force_pair_xpub(
         self,
-        plugin: HW_PluginBase,
+        plugin: HWPluginBase,
         handler: HardwareHandlerBase,
         info: DeviceInfo,
         xpub,
@@ -1091,7 +1091,7 @@ class DeviceMgr(ThreadJob):
     def unpaired_device_infos(
         self,
         handler: Optional[HardwareHandlerBase],
-        plugin: HW_PluginBase,
+        plugin: HWPluginBase,
         devices: Optional[List[Device]] = None,
     ) -> List["DeviceInfo"]:
         """Returns a list of DeviceInfo objects: one for each connected,
@@ -1119,9 +1119,9 @@ class DeviceMgr(ThreadJob):
 
     def select_device(
         self,
-        plugin: HW_PluginBase,
+        plugin: HWPluginBase,
         handler: HardwareHandlerBase,
-        keystore: Hardware_KeyStore,
+        keystore: HardwareKeyStore,
         devices: Optional[List["Device"]] = None,
     ) -> DeviceInfo:
         """Ask the user to select a device to use if there is more than one,

--- a/electrumabc/storage.py
+++ b/electrumabc/storage.py
@@ -167,7 +167,7 @@ class WalletStorage(PrintError):
         secret = hashlib.pbkdf2_hmac(
             "sha512", password.encode("utf-8"), b"", iterations=1024
         )
-        ec_key = bitcoin.EC_KEY(secret)
+        ec_key = bitcoin.ECKey(secret)
         return ec_key
 
     def _get_encryption_magic(self):

--- a/electrumabc/synchronizer.py
+++ b/electrumabc/synchronizer.py
@@ -40,7 +40,7 @@ from .transaction import Transaction
 from .util import ThreadJob, bh2u
 
 if TYPE_CHECKING:
-    from .wallet import Abstract_Wallet
+    from .wallet import AbstractWallet
 
 
 class Synchronizer(ThreadJob):
@@ -54,7 +54,7 @@ class Synchronizer(ThreadJob):
     External interface: __init__() and add() member functions.
     """
 
-    def __init__(self, wallet: Abstract_Wallet, network):
+    def __init__(self, wallet: AbstractWallet, network):
         self.wallet = wallet
         self.network = network
         assert self.wallet and self.wallet.storage and self.network

--- a/electrumabc/tests/__main__.py
+++ b/electrumabc/tests/__main__.py
@@ -1,7 +1,7 @@
 import unittest
 
 from .test_address import TestAddressFromString
-from .test_asert import Test_ASERTDaa
+from .test_asert import TestASERTDaa
 from .test_avalanche import suite as test_avalanche_suite
 from .test_bip44_derivation_path import TestBip44Derivations
 from .test_bitcoin import suite as test_bitcoin_suite
@@ -13,7 +13,7 @@ from .test_dnssec import TestDnsSec
 from .test_interface import TestInterface
 from .test_invoice import TestInvoice
 from .test_mnemonic import suite as test_mnemonic_suite
-from .test_paymentrequests import Test_PaymentRequests
+from .test_paymentrequests import TestPaymentRequests
 from .test_schnorr import suite as test_schnorr_suite
 from .test_simple_config import suite as test_simple_config_suite
 from .test_slp import SLPTests
@@ -29,7 +29,7 @@ def suite():
     test_suite = unittest.TestSuite()
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
     test_suite.addTest(loadTests(TestAddressFromString))
-    test_suite.addTest(loadTests(Test_ASERTDaa))
+    test_suite.addTest(loadTests(TestASERTDaa))
     test_suite.addTest(test_avalanche_suite())
     test_suite.addTest(loadTests(TestBip44Derivations))
     test_suite.addTest(test_bitcoin_suite())
@@ -41,7 +41,7 @@ def suite():
     test_suite.addTest(loadTests(TestInterface))
     test_suite.addTest(loadTests(TestInvoice))
     test_suite.addTest(test_mnemonic_suite())
-    test_suite.addTest(loadTests(Test_PaymentRequests))
+    test_suite.addTest(loadTests(TestPaymentRequests))
     test_suite.addTest(test_schnorr_suite())
     test_suite.addTest(test_simple_config_suite())
     test_suite.addTest(loadTests(SLPTests))

--- a/electrumabc/tests/test_asert.py
+++ b/electrumabc/tests/test_asert.py
@@ -3,7 +3,7 @@ import unittest
 from ..asert_daa import ASERTDaa
 
 
-class Test_ASERTDaa(unittest.TestCase):
+class TestASERTDaa(unittest.TestCase):
     def validate_blocksequence(self, anchor_height, ref_time, ref_bits, blocks):
         asert = ASERTDaa()
         for block in blocks:

--- a/electrumabc/tests/test_bitcoin.py
+++ b/electrumabc/tests/test_bitcoin.py
@@ -6,8 +6,8 @@ from ecdsa.util import number_to_string
 
 from ..address import Address
 from ..bitcoin import (
-    EC_KEY,
     Bip38Key,
+    ECKey,
     Hash,
     OpCodes,
     SignatureType,
@@ -48,7 +48,7 @@ except ImportError:
     )
 
 
-class Test_bitcoin(unittest.TestCase):
+class TestBitcoin(unittest.TestCase):
     def test_crypto(self):
         for message in [
             b"Chancellor on brink of second bailout for banks",
@@ -66,9 +66,9 @@ class Test_bitcoin(unittest.TestCase):
         # pubkey_u = point_to_ser(Pub,False)
         public_key_to_p2pkh(pubkey_c)
 
-        eck = EC_KEY(number_to_string(pvk, _r))
+        eck = ECKey(number_to_string(pvk, _r))
 
-        enc = EC_KEY.encrypt_message(message, pubkey_c)
+        enc = ECKey.encrypt_message(message, pubkey_c)
         dec = eck.decrypt_message(enc)
         self.assertEqual(message, dec)
 
@@ -78,7 +78,7 @@ class Test_bitcoin(unittest.TestCase):
 
         signature = eck.sign_message(message, True)
         # print signature
-        EC_KEY.verify_message(eck, signature, message)
+        ECKey.verify_message(eck, signature, message)
 
     def test_msg_signing(self):
         msg1 = b"Chancellor on brink of second bailout for banks"
@@ -300,7 +300,7 @@ class Test_bitcoin(unittest.TestCase):
         )
 
 
-class Test_bitcoin_testnet(unittest.TestCase):
+class TestBitcoinTestnet(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
@@ -312,7 +312,7 @@ class Test_bitcoin_testnet(unittest.TestCase):
         set_mainnet()
 
 
-class Test_xprv_xpub(unittest.TestCase):
+class TestXprvXpub(unittest.TestCase):
 
     xprv_xpub = (
         # Taken from test vectors in https://en.bitcoin.it/wiki/BIP_0032_TestVectors
@@ -410,7 +410,7 @@ class Test_xprv_xpub(unittest.TestCase):
         self.assertFalse(is_bip32_derivation("m/q8462"))
 
 
-class Test_keyImport(unittest.TestCase):
+class TestKeyImport(unittest.TestCase):
 
     priv_pub_addr = (
         {
@@ -492,7 +492,7 @@ class Test_keyImport(unittest.TestCase):
             )
 
 
-class Test_Bip38(unittest.TestCase):
+class TestBip38(unittest.TestCase):
     """Test Bip38 encryption/decryption. Test cases taken from:
 
     https://github.com/bitcoin/bips/blob/master/bip-0038.mediawiki"""
@@ -653,11 +653,11 @@ class Test_Bip38(unittest.TestCase):
 def suite():
     test_suite = unittest.TestSuite()
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
-    test_suite.addTest(loadTests(Test_bitcoin))
-    test_suite.addTest(loadTests(Test_bitcoin_testnet))
-    test_suite.addTest(loadTests(Test_xprv_xpub))
-    test_suite.addTest(loadTests(Test_keyImport))
-    test_suite.addTest(loadTests(Test_Bip38))
+    test_suite.addTest(loadTests(TestBitcoin))
+    test_suite.addTest(loadTests(TestBitcoinTestnet))
+    test_suite.addTest(loadTests(TestXprvXpub))
+    test_suite.addTest(loadTests(TestKeyImport))
+    test_suite.addTest(loadTests(TestBip38))
     return test_suite
 
 

--- a/electrumabc/tests/test_mnemonic.py
+++ b/electrumabc/tests/test_mnemonic.py
@@ -6,9 +6,9 @@ from .. import mnemo, old_mnemonic
 from ..util import bh2u
 
 
-class Test_NewMnemonic(unittest.TestCase):
+class TestNewMnemonic(unittest.TestCase):
     def test_to_seed(self):
-        seed = mnemo.Mnemonic_Electrum.mnemonic_to_seed(
+        seed = mnemo.MnemonicElectrum.mnemonic_to_seed(
             mnemonic="foobar", passphrase="none"
         )
         self.assertEqual(
@@ -19,14 +19,14 @@ class Test_NewMnemonic(unittest.TestCase):
 
     def test_random_seeds(self):
         iters = 10
-        m = mnemo.Mnemonic_Electrum(lang="en")
+        m = mnemo.MnemonicElectrum(lang="en")
         for _ in range(iters):
             seed = m.make_seed()
             i = m.mnemonic_decode(seed)
             self.assertEqual(m.mnemonic_encode(i), seed)
 
 
-class Test_OldMnemonic(unittest.TestCase):
+class TestOldMnemonic(unittest.TestCase):
     def test(self):
         seed = "8edad31a95e7d59f8837667510d75a4d"
         result = old_mnemonic.mn_encode(seed)
@@ -35,7 +35,7 @@ class Test_OldMnemonic(unittest.TestCase):
         self.assertEqual(old_mnemonic.mn_decode(result), seed)
 
 
-class Test_BIP39Checksum(unittest.TestCase):
+class TestBIP39Checksum(unittest.TestCase):
     def test(self):
         words = (
             "gravity machine north sort system female "
@@ -46,7 +46,7 @@ class Test_BIP39Checksum(unittest.TestCase):
         self.assertTrue(mnemon.check(words))
 
 
-class Test_Seeds(unittest.TestCase):
+class TestSeeds(unittest.TestCase):
     """Test old and new seeds."""
 
     mnemonics = {
@@ -124,10 +124,10 @@ class Test_Seeds(unittest.TestCase):
 def suite():
     test_suite = unittest.TestSuite()
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
-    test_suite.addTest(loadTests(Test_NewMnemonic))
-    test_suite.addTest(loadTests(Test_OldMnemonic))
-    test_suite.addTest(loadTests(Test_BIP39Checksum))
-    test_suite.addTest(loadTests(Test_Seeds))
+    test_suite.addTest(loadTests(TestNewMnemonic))
+    test_suite.addTest(loadTests(TestOldMnemonic))
+    test_suite.addTest(loadTests(TestBIP39Checksum))
+    test_suite.addTest(loadTests(TestSeeds))
     return test_suite
 
 

--- a/electrumabc/tests/test_paymentrequests.py
+++ b/electrumabc/tests/test_paymentrequests.py
@@ -7,7 +7,7 @@ from ..address import Address
 from ..paymentrequest import get_payment_request
 
 
-class Test_PaymentRequests(unittest.TestCase):
+class TestPaymentRequests(unittest.TestCase):
     def setUp(self):
         self.serv = None
         self.th = None

--- a/electrumabc/tests/test_simple_config.py
+++ b/electrumabc/tests/test_simple_config.py
@@ -9,9 +9,9 @@ from io import StringIO
 from ..simple_config import SimpleConfig, read_user_config
 
 
-class Test_SimpleConfig(unittest.TestCase):
+class TestSimpleConfig(unittest.TestCase):
     def setUp(self):
-        super(Test_SimpleConfig, self).setUp()
+        super(TestSimpleConfig, self).setUp()
         # make sure "read_user_config" and "user_dir" return a temporary directory.
         self.electrum_dir = tempfile.mkdtemp()
         # Do the same for the user dir to avoid overwriting the real configuration
@@ -24,7 +24,7 @@ class Test_SimpleConfig(unittest.TestCase):
         sys.stdout = self._stdout_buffer
 
     def tearDown(self):
-        super(Test_SimpleConfig, self).tearDown()
+        super(TestSimpleConfig, self).tearDown()
         # Remove the temporary directory after each test (to make sure we don't
         # pollute /tmp for nothing.
         shutil.rmtree(self.electrum_dir)
@@ -190,7 +190,7 @@ class TestUserConfig(unittest.TestCase):
 def suite():
     test_suite = unittest.TestSuite()
     loadTests = unittest.defaultTestLoader.loadTestsFromTestCase
-    test_suite.addTest(loadTests(Test_SimpleConfig))
+    test_suite.addTest(loadTests(TestSimpleConfig))
     test_suite.addTest(loadTests(TestUserConfig))
     return test_suite
 

--- a/electrumabc/tests/test_wallet.py
+++ b/electrumabc/tests/test_wallet.py
@@ -84,7 +84,7 @@ class TestCreateRestoreWallet(WalletTestCase):
             password=password,
             encrypt_file=encrypt_file,
         )
-        wallet = d["wallet"]  # type: Standard_Wallet
+        wallet: Standard_Wallet = d["wallet"]
         wallet.check_password(password)
         self.assertEqual(passphrase, wallet.keystore.get_passphrase(password))
         self.assertEqual(d["seed"], wallet.keystore.get_seed(password))
@@ -103,7 +103,7 @@ class TestCreateRestoreWallet(WalletTestCase):
             encrypt_file=encrypt_file,
             config=self.config,
         )
-        wallet = d["wallet"]  # type: Standard_Wallet
+        wallet: Standard_Wallet = d["wallet"]
         self.assertEqual(passphrase, wallet.keystore.get_passphrase(password))
         self.assertEqual(text, wallet.keystore.get_seed(password))
         self.assertEqual(encrypt_file, wallet.storage.is_encrypted())
@@ -115,7 +115,7 @@ class TestCreateRestoreWallet(WalletTestCase):
     def test_restore_wallet_from_text_xpub(self):
         text = "xpub6CUzEfgtza7ZNtfDGYwHPnbPMPiQh93mAbP6v7C3ozUgkZq4tXSgYb9qqZ62oh8RCeexdSF7ZJmTzCm5bdWLB3zSMF8rNfuY8kccNAsdF4d"
         d = restore_wallet_from_text(text, path=self.wallet_path, config=self.config)
-        wallet = d["wallet"]  # type: Standard_Wallet
+        wallet: Standard_Wallet = d["wallet"]
         self.assertEqual(text, wallet.keystore.get_master_public_key())
         self.assertEqual(
             Address.from_string("qzrseeup3rhehuaf9e6nr3sgm6t5eegufu96l404mu"),
@@ -125,7 +125,7 @@ class TestCreateRestoreWallet(WalletTestCase):
     def test_restore_wallet_from_text_xprv(self):
         text = "xprv9y4nb6Akxru8R68sYGrihutfqUgMNxmiF83ViTf65MobJrRRyHWc1M8mSZJSmZ1nQCJntxmF99sKGkkcQQGziECvdkwA4kqxsH5srNAzRin"
         d = restore_wallet_from_text(text, path=self.wallet_path, config=self.config)
-        wallet = d["wallet"]  # type: Standard_Wallet
+        wallet: Standard_Wallet = d["wallet"]
         self.assertEqual(text, wallet.keystore.get_master_private_key(password=None))
         self.assertEqual(
             Address.from_string("qr2q6aadv6nxmqwjt8qmax76yqp09mlqzq5jsz5fe9"),
@@ -135,7 +135,7 @@ class TestCreateRestoreWallet(WalletTestCase):
     def test_restore_wallet_from_text_addresses(self):
         text = "qr2q6aadv6nxmqwjt8qmax76yqp09mlqzq5jsz5fe9"
         d = restore_wallet_from_text(text, path=self.wallet_path, config=self.config)
-        wallet = d["wallet"]  # type: Abstract_Wallet
+        wallet: Abstract_Wallet = d["wallet"]
         self.assertEqual(
             Address.from_string("qr2q6aadv6nxmqwjt8qmax76yqp09mlqzq5jsz5fe9"),
             wallet.get_receiving_addresses()[0],
@@ -145,7 +145,7 @@ class TestCreateRestoreWallet(WalletTestCase):
     def test_restore_wallet_from_text_privkeys(self):
         text = "Kz7FS9Adyj6RgSVGx5YLjZPanUhuze4yvcziZ1qLA24a3GJJZvBr"
         d = restore_wallet_from_text(text, path=self.wallet_path, config=self.config)
-        wallet = d["wallet"]  # type: Abstract_Wallet
+        wallet: Abstract_Wallet = d["wallet"]
         addr0 = wallet.get_receiving_addresses()[0]
         self.assertEqual(
             Address.from_string("qzrseeup3rhehuaf9e6nr3sgm6t5eegufu96l404mu"), addr0

--- a/electrumabc/tests/test_wallet.py
+++ b/electrumabc/tests/test_wallet.py
@@ -11,8 +11,8 @@ from ..json_db import FINAL_SEED_VERSION
 from ..simple_config import SimpleConfig
 from ..storage import WalletStorage
 from ..wallet import (
-    Abstract_Wallet,
-    Standard_Wallet,
+    AbstractWallet,
+    StandardWallet,
     create_new_wallet,
     restore_wallet_from_text,
 )
@@ -84,7 +84,7 @@ class TestCreateRestoreWallet(WalletTestCase):
             password=password,
             encrypt_file=encrypt_file,
         )
-        wallet: Standard_Wallet = d["wallet"]
+        wallet: StandardWallet = d["wallet"]
         wallet.check_password(password)
         self.assertEqual(passphrase, wallet.keystore.get_passphrase(password))
         self.assertEqual(d["seed"], wallet.keystore.get_seed(password))
@@ -103,7 +103,7 @@ class TestCreateRestoreWallet(WalletTestCase):
             encrypt_file=encrypt_file,
             config=self.config,
         )
-        wallet: Standard_Wallet = d["wallet"]
+        wallet: StandardWallet = d["wallet"]
         self.assertEqual(passphrase, wallet.keystore.get_passphrase(password))
         self.assertEqual(text, wallet.keystore.get_seed(password))
         self.assertEqual(encrypt_file, wallet.storage.is_encrypted())
@@ -115,7 +115,7 @@ class TestCreateRestoreWallet(WalletTestCase):
     def test_restore_wallet_from_text_xpub(self):
         text = "xpub6CUzEfgtza7ZNtfDGYwHPnbPMPiQh93mAbP6v7C3ozUgkZq4tXSgYb9qqZ62oh8RCeexdSF7ZJmTzCm5bdWLB3zSMF8rNfuY8kccNAsdF4d"
         d = restore_wallet_from_text(text, path=self.wallet_path, config=self.config)
-        wallet: Standard_Wallet = d["wallet"]
+        wallet: StandardWallet = d["wallet"]
         self.assertEqual(text, wallet.keystore.get_master_public_key())
         self.assertEqual(
             Address.from_string("qzrseeup3rhehuaf9e6nr3sgm6t5eegufu96l404mu"),
@@ -125,7 +125,7 @@ class TestCreateRestoreWallet(WalletTestCase):
     def test_restore_wallet_from_text_xprv(self):
         text = "xprv9y4nb6Akxru8R68sYGrihutfqUgMNxmiF83ViTf65MobJrRRyHWc1M8mSZJSmZ1nQCJntxmF99sKGkkcQQGziECvdkwA4kqxsH5srNAzRin"
         d = restore_wallet_from_text(text, path=self.wallet_path, config=self.config)
-        wallet: Standard_Wallet = d["wallet"]
+        wallet: StandardWallet = d["wallet"]
         self.assertEqual(text, wallet.keystore.get_master_private_key(password=None))
         self.assertEqual(
             Address.from_string("qr2q6aadv6nxmqwjt8qmax76yqp09mlqzq5jsz5fe9"),
@@ -135,7 +135,7 @@ class TestCreateRestoreWallet(WalletTestCase):
     def test_restore_wallet_from_text_addresses(self):
         text = "qr2q6aadv6nxmqwjt8qmax76yqp09mlqzq5jsz5fe9"
         d = restore_wallet_from_text(text, path=self.wallet_path, config=self.config)
-        wallet: Abstract_Wallet = d["wallet"]
+        wallet: AbstractWallet = d["wallet"]
         self.assertEqual(
             Address.from_string("qr2q6aadv6nxmqwjt8qmax76yqp09mlqzq5jsz5fe9"),
             wallet.get_receiving_addresses()[0],
@@ -145,7 +145,7 @@ class TestCreateRestoreWallet(WalletTestCase):
     def test_restore_wallet_from_text_privkeys(self):
         text = "Kz7FS9Adyj6RgSVGx5YLjZPanUhuze4yvcziZ1qLA24a3GJJZvBr"
         d = restore_wallet_from_text(text, path=self.wallet_path, config=self.config)
-        wallet: Abstract_Wallet = d["wallet"]
+        wallet: AbstractWallet = d["wallet"]
         addr0 = wallet.get_receiving_addresses()[0]
         self.assertEqual(
             Address.from_string("qzrseeup3rhehuaf9e6nr3sgm6t5eegufu96l404mu"), addr0

--- a/electrumabc/tests/test_wallet_vertical.py
+++ b/electrumabc/tests/test_wallet_vertical.py
@@ -14,7 +14,7 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
         self.assertFalse(ks.is_watching_only())
         self.assertFalse(ks.can_import())
         self.assertTrue(ks.has_seed())
-        if isinstance(ks, keystore.BIP32_KeyStore):
+        if isinstance(ks, keystore.BIP32KeyStore):
             self.assertTrue(ks.has_derivation())
 
     def _check_xpub_keystore_sanity(self, ks):
@@ -27,7 +27,7 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
         store = storage.WalletStorage("if_this_exists_mocking_failed_648151893")
         store.put("keystore", ks.dump())
         store.put("gap_limit", self.gap_limit)
-        w = wallet.Standard_Wallet(store)
+        w = wallet.StandardWallet(store)
         w.synchronize()
         return w
 
@@ -38,7 +38,7 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
         store.put("x1/", ks1.dump())
         store.put("x2/", ks2.dump())
         store.put("gap_limit", self.gap_limit)
-        w = wallet.Multisig_Wallet(store)
+        w = wallet.MultisigWallet(store)
         w.synchronize()
         return w
 
@@ -50,7 +50,7 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
         ks = keystore.from_seed(seed_words, "")
 
         self._check_seeded_keystore_sanity(ks)
-        self.assertTrue(isinstance(ks, keystore.BIP32_KeyStore))
+        self.assertTrue(isinstance(ks, keystore.BIP32KeyStore))
 
         self.assertEqual(
             ks.xpub,
@@ -76,7 +76,7 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
         ks = keystore.from_seed(seed_words, "")
 
         self._check_seeded_keystore_sanity(ks)
-        self.assertTrue(isinstance(ks, keystore.Old_KeyStore))
+        self.assertTrue(isinstance(ks, keystore.OldKeyStore))
 
         self.assertEqual(
             ks.mpk,
@@ -106,7 +106,7 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
             seed_words, "", seed_type="bip39", derivation="m/44'/0'/0'"
         )
 
-        self.assertTrue(isinstance(ks, keystore.BIP32_KeyStore))
+        self.assertTrue(isinstance(ks, keystore.BIP32KeyStore))
 
         self.assertEqual(
             ks.xpub,
@@ -146,7 +146,7 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
 
         ks1 = keystore.from_seed(seed_words, "")
         self._check_seeded_keystore_sanity(ks1)
-        self.assertTrue(isinstance(ks1, keystore.BIP32_KeyStore))
+        self.assertTrue(isinstance(ks1, keystore.BIP32KeyStore))
         self.assertEqual(
             ks1.xpub,
             "xpub661MyMwAqRbcGNEPu3aJQqXTydqR9t49Tkwb4Esrj112kw8xLthv8uybxvaki4Ygt9xiwZUQGeFTG7T2TUzR3eA4Zp3aq5RXsABHFBUrq4c",
@@ -156,7 +156,7 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
             "xpub661MyMwAqRbcGfCPEkkyo5WmcrhTq8mi3xuBS7VEZ3LYvsgY1cCFDbenT33bdD12axvrmXhuX3xkAbKci3yZY9ZEk8vhLic7KNhLjqdh5ec"
         )
         self._check_xpub_keystore_sanity(ks2)
-        self.assertTrue(isinstance(ks2, keystore.BIP32_KeyStore))
+        self.assertTrue(isinstance(ks2, keystore.BIP32KeyStore))
 
         w = self._create_multisig_wallet(ks1, ks2)
 
@@ -179,7 +179,7 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
         ks1 = keystore.from_seed(
             seed_words, "", seed_type="bip39", derivation="m/45'/0"
         )
-        self.assertTrue(isinstance(ks1, keystore.BIP32_KeyStore))
+        self.assertTrue(isinstance(ks1, keystore.BIP32KeyStore))
         self.assertEqual(ks1.derivation, "m/45'/0")
         self.assertEqual(ks1.seed_type, "bip39")
         self.assertEqual(
@@ -191,7 +191,7 @@ class TestWalletKeystoreAddressIntegrity(unittest.TestCase):
             "xpub6Bco9vrgo8rNUSi8Bjomn8xLA41DwPXeuPcgJamNRhTTyGVHsp8fZXaGzp9ypHoei16J6X3pumMAP1u3Dy4jTSWjm4GZowL7Dcn9u4uZC9W"
         )
         self._check_xpub_keystore_sanity(ks2)
-        self.assertTrue(isinstance(ks2, keystore.BIP32_KeyStore))
+        self.assertTrue(isinstance(ks2, keystore.BIP32KeyStore))
 
         w = self._create_multisig_wallet(ks1, ks2)
 

--- a/electrumabc/x509.py
+++ b/electrumabc/x509.py
@@ -172,7 +172,7 @@ def encode_OID(oid):
     return s
 
 
-class ASN1_Node(bytes):
+class ASN1Node(bytes):
     def get_node(self, ix):
         # return index of first byte, first content byte and last byte.
         first = self[ix + 1]
@@ -250,7 +250,7 @@ class X509(object):
 
         self.bytes = bytearray(b)
 
-        der = ASN1_Node(b)
+        der = ASN1Node(b)
         root = der.root()
         cert = der.first_child(root)
         # data for signature
@@ -306,7 +306,7 @@ class X509(object):
             # pubkey modulus and exponent
             subject_public_key = der.next_node(public_key_algo)
             spk = der.get_value_of_type(subject_public_key, "BIT STRING")
-            spk = ASN1_Node(bitstr_to_bytestr(spk))
+            spk = ASN1Node(bitstr_to_bytestr(spk))
             r = spk.root()
             modulus = spk.first_child(r)
             exponent = spk.next_node(modulus)
@@ -328,7 +328,7 @@ class X509(object):
             i = der.next_node(i)
             d = der.get_dict(i)
             for oid, value in d.items():
-                value = ASN1_Node(value)
+                value = ASN1Node(value)
                 if oid == "2.5.29.19":
                     # Basic Constraints
                     self.CA = bool(value)

--- a/electrumabc_gui/qt/__init__.py
+++ b/electrumabc_gui/qt/__init__.py
@@ -80,7 +80,7 @@ from electrumabc.util import (
     get_new_wallet_name,
     standardize_path,
 )
-from electrumabc.wallet import Abstract_Wallet, Wallet
+from electrumabc.wallet import AbstractWallet, Wallet
 
 # This needs to be imported once app-wide then the :icons/ namespace becomes available
 # for Qt icon filenames.
@@ -629,7 +629,7 @@ class ElectrumGui(QtCore.QObject, PrintError):
         if jumpto:
             self.nd.jumpto(jumpto)
 
-    def _create_window_for_wallet(self, wallet: Abstract_Wallet):
+    def _create_window_for_wallet(self, wallet: AbstractWallet):
         w = ElectrumWindow(self, wallet)
         self.windows.append(w)
         finalization_print_error(w, "[{}] finalized".format(w.diagnostic_name()))
@@ -746,7 +746,7 @@ class ElectrumGui(QtCore.QObject, PrintError):
 
     def _start_wizard_to_select_or_create_wallet(
         self, path
-    ) -> Optional[Abstract_Wallet]:
+    ) -> Optional[AbstractWallet]:
         wizard = InstallWizard(self.config, self.app, self.plugins, gui_object=self)
         try:
             path, storage = wizard.select_storage(path, self.daemon.get_wallet)

--- a/electrumabc_gui/qt/address_list.py
+++ b/electrumabc_gui/qt/address_list.py
@@ -40,7 +40,7 @@ from electrumabc.address import Address
 from electrumabc.i18n import _
 from electrumabc.plugins import run_hook
 from electrumabc.util import profiler
-from electrumabc.wallet import Multisig_Wallet
+from electrumabc.wallet import MultisigWallet
 
 from .consolidate_coins_dialog import ConsolidateCoinsWizard
 from .invoice_dialog import InvoiceDialog
@@ -285,7 +285,7 @@ class AddressList(MyTreeWidget):
             # picker mode has no menu
             return
 
-        is_multisig = isinstance(self.wallet, Multisig_Wallet)
+        is_multisig = isinstance(self.wallet, MultisigWallet)
         can_delete = self.wallet.can_delete_address()
         addrs = self.get_selected_addresses()
         multi_select = len(addrs) > 1

--- a/electrumabc_gui/qt/avalanche/delegation_editor.py
+++ b/electrumabc_gui/qt/avalanche/delegation_editor.py
@@ -14,7 +14,7 @@ from electrumabc.avalanche.primitives import Key, PublicKey
 from electrumabc.avalanche.proof import LimitedProofId, Proof
 from electrumabc.avalanche.serialize import DeserializationError
 from electrumabc.bitcoin import is_private_key
-from electrumabc.wallet import Deterministic_Wallet
+from electrumabc.wallet import DeterministicWallet
 
 from .util import AuxiliaryKeysDialog, CachedWalletPasswordWidget
 
@@ -22,7 +22,7 @@ from .util import AuxiliaryKeysDialog, CachedWalletPasswordWidget
 class AvaDelegationWidget(CachedWalletPasswordWidget):
     def __init__(
         self,
-        wallet: Deterministic_Wallet,
+        wallet: DeterministicWallet,
         pwd: Optional[str] = None,
         parent: Optional[QtWidgets.QWidget] = None,
     ):
@@ -241,7 +241,7 @@ class AvaDelegationWidget(CachedWalletPasswordWidget):
 class AvaDelegationDialog(QtWidgets.QDialog):
     def __init__(
         self,
-        wallet: Deterministic_Wallet,
+        wallet: DeterministicWallet,
         pwd: Optional[str] = None,
         parent: Optional[QtWidgets.QWidget] = None,
     ):

--- a/electrumabc_gui/qt/avalanche/proof_editor.py
+++ b/electrumabc_gui/qt/avalanche/proof_editor.py
@@ -21,7 +21,7 @@ from electrumabc.i18n import _
 from electrumabc.transaction import get_address_from_output_script
 from electrumabc.uint256 import UInt256
 from electrumabc.util import format_satoshis
-from electrumabc.wallet import AddressNotFoundError, Deterministic_Wallet
+from electrumabc.wallet import AddressNotFoundError, DeterministicWallet
 
 from .delegation_editor import AvaDelegationDialog
 from .util import CachedWalletPasswordWidget, get_auxiliary_privkey
@@ -77,7 +77,7 @@ def proof_to_rich_text(proof: Proof) -> str:
 class AvaProofEditor(CachedWalletPasswordWidget):
     def __init__(
         self,
-        wallet: Deterministic_Wallet,
+        wallet: DeterministicWallet,
         receive_address: Optional[Address] = None,
         parent: Optional[QtWidgets.QWidget] = None,
     ):
@@ -652,7 +652,7 @@ class AvaProofEditor(CachedWalletPasswordWidget):
 class AvaProofDialog(QtWidgets.QDialog):
     def __init__(
         self,
-        wallet: Deterministic_Wallet,
+        wallet: DeterministicWallet,
         receive_address: Optional[Address] = None,
         parent: Optional[QtWidgets.QWidget] = None,
     ):
@@ -784,7 +784,7 @@ def check_utxos(utxos: List[dict], parent: Optional[QtWidgets.QWidget] = None) -
 class UtxosDialog(QtWidgets.QDialog):
     """A widget listing all coins in a wallet and allowing to load multiple coins"""
 
-    def __init__(self, wallet: Deterministic_Wallet):
+    def __init__(self, wallet: DeterministicWallet):
         super().__init__()
         self.setMinimumWidth(750)
 

--- a/electrumabc_gui/qt/avalanche/util.py
+++ b/electrumabc_gui/qt/avalanche/util.py
@@ -6,14 +6,14 @@ from PyQt5 import QtWidgets
 
 from electrumabc.address import PublicKey
 from electrumabc.bitcoin import is_private_key
-from electrumabc.wallet import Deterministic_Wallet
+from electrumabc.wallet import DeterministicWallet
 
 from ..password_dialog import PasswordDialog
 from ..util import ButtonsLineEdit
 
 
 def get_auxiliary_privkey(
-    wallet: Deterministic_Wallet,
+    wallet: DeterministicWallet,
     key_index: int = 0,
     pwd: Optional[str] = None,
 ) -> str:
@@ -40,7 +40,7 @@ class CachedWalletPasswordWidget(QtWidgets.QWidget):
 
     def __init__(
         self,
-        wallet: Deterministic_Wallet,
+        wallet: DeterministicWallet,
         pwd: Optional[str] = None,
         parent: Optional[QtWidgets.QWidget] = None,
     ):
@@ -109,7 +109,7 @@ class AuxiliaryKeysWidget(CachedWalletPasswordWidget):
 
     def __init__(
         self,
-        wallet: Deterministic_Wallet,
+        wallet: DeterministicWallet,
         pwd: Optional[str] = None,
         parent: Optional[QtWidgets.QWidget] = None,
         additional_info: Optional[str] = None,
@@ -166,7 +166,7 @@ class AuxiliaryKeysWidget(CachedWalletPasswordWidget):
 class AuxiliaryKeysDialog(QtWidgets.QDialog):
     def __init__(
         self,
-        wallet: Deterministic_Wallet,
+        wallet: DeterministicWallet,
         pwd: Optional[str] = None,
         parent: Optional[QtWidgets.QWidget] = None,
         additional_info: Optional[str] = None,

--- a/electrumabc_gui/qt/consolidate_coins_dialog.py
+++ b/electrumabc_gui/qt/consolidate_coins_dialog.py
@@ -11,7 +11,7 @@ from electrumabc.consolidate import (
 )
 from electrumabc.constants import PROJECT_NAME, XEC
 from electrumabc.transaction import Transaction
-from electrumabc.wallet import Abstract_Wallet
+from electrumabc.wallet import AbstractWallet
 
 from .multi_transactions_dialog import MultiTransactionsWidget
 
@@ -37,7 +37,7 @@ class ConsolidateWorker(QtCore.QObject):
     def __init__(
         self,
         address: Address,
-        wallet: Abstract_Wallet,
+        wallet: AbstractWallet,
         include_coinbase: bool,
         include_non_coinbase: bool,
         include_frozen: bool,
@@ -109,7 +109,7 @@ class ConsolidateCoinsWizard(QtWidgets.QWizard):
     def __init__(
         self,
         address: Address,
-        wallet: Abstract_Wallet,
+        wallet: AbstractWallet,
         main_window,
         parent: Optional[QtWidgets.QWidget] = None,
     ):
@@ -119,7 +119,7 @@ class ConsolidateCoinsWizard(QtWidgets.QWizard):
         self.tx_thread: Optional[QtCore.QThread] = None
 
         self.address: Address = address
-        self.wallet: Abstract_Wallet = wallet
+        self.wallet: AbstractWallet = wallet
         self.transactions: Sequence[Transaction] = []
 
         self.coins_page = CoinSelectionPage()

--- a/electrumabc_gui/qt/installwizard.py
+++ b/electrumabc_gui/qt/installwizard.py
@@ -27,7 +27,7 @@ from electrumabc.util import (
     WalletFileException,
     finalization_print_error,
 )
-from electrumabc.wallet import Abstract_Wallet, Standard_Wallet
+from electrumabc.wallet import AbstractWallet, StandardWallet
 
 from .bip38_importer import Bip38Importer
 from .network_dialog import NetworkChoiceLayout
@@ -127,7 +127,7 @@ def wizard_dialog(func):
 
 
 class WalletAlreadyOpenInMemory(Exception):
-    def __init__(self, wallet: Abstract_Wallet):
+    def __init__(self, wallet: AbstractWallet):
         super().__init__()
         self.wallet = wallet
 
@@ -898,7 +898,7 @@ class DerivationPathScanner(QThread):
             tmp_storage = WalletStorage(storage_path, in_memory_only=True)
             tmp_storage.put("seed_type", self.seed_type)
             tmp_storage.put("keystore", k.dump())
-            wallet = Standard_Wallet(tmp_storage)
+            wallet = StandardWallet(tmp_storage)
             try:
                 wallet.start_threads(network)
                 wallet.synchronize()

--- a/electrumabc_gui/qt/main_window.py
+++ b/electrumabc_gui/qt/main_window.py
@@ -84,7 +84,7 @@ from electrumabc.util import (
     format_satoshis_plain,
     format_time,
 )
-from electrumabc.wallet import Abstract_Wallet, Multisig_Wallet, sweep_preparations
+from electrumabc.wallet import AbstractWallet, MultisigWallet, sweep_preparations
 
 from . import address_dialog, exception_window, external_plugins_window, qrwindow
 from .address_list import AddressList
@@ -212,7 +212,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
     # signal, preferably via Qt.DirectConnection
     on_timer_signal = pyqtSignal()
 
-    def __init__(self, gui_object: ElectrumGui, wallet: Abstract_Wallet):
+    def __init__(self, gui_object: ElectrumGui, wallet: AbstractWallet):
         QtWidgets.QMainWindow.__init__(self)
 
         self.gui_object = gui_object
@@ -1796,7 +1796,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
 
     def show_qr_window(self):
         if not self.qr_window:
-            self.qr_window = qrwindow.QR_Window()
+            self.qr_window = qrwindow.QRWindow()
             self.qr_window.setAttribute(Qt.WA_DeleteOnClose, True)
             weakSelf = Weak.ref(self)
 
@@ -3505,7 +3505,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             if len(mpk_list) > 1:
 
                 def label(key):
-                    if isinstance(self.wallet, Multisig_Wallet):
+                    if isinstance(self.wallet, MultisigWallet):
                         return _("cosigner") + " " + str(key + 1)
                     return ""
 
@@ -4005,7 +4005,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             self.show_message(_("This is a watching-only wallet"))
             return
 
-        if isinstance(self.wallet, Multisig_Wallet):
+        if isinstance(self.wallet, MultisigWallet):
             if bip38:
                 self.show_error(
                     _("WARNING: This is a multi-signature wallet.")

--- a/electrumabc_gui/qt/multi_transactions_dialog.py
+++ b/electrumabc_gui/qt/multi_transactions_dialog.py
@@ -7,7 +7,7 @@ from PyQt5 import QtGui, QtWidgets
 from electrumabc import transaction
 from electrumabc.bitcoin import sha256
 from electrumabc.constants import XEC
-from electrumabc.wallet import Abstract_Wallet
+from electrumabc.wallet import AbstractWallet
 
 from .util import MessageBoxMixin
 
@@ -18,7 +18,7 @@ class MultiTransactionsWidget(QtWidgets.QWidget, MessageBoxMixin):
     def __init__(self, wallet, main_window, parent=None):
         super().__init__(parent)
         self.setMinimumWidth(800)
-        self.wallet: Abstract_Wallet = wallet
+        self.wallet: AbstractWallet = wallet
         self.transactions: Sequence[transaction.Transaction] = []
         self.main_window = main_window
 

--- a/electrumabc_gui/qt/qrwindow.py
+++ b/electrumabc_gui/qt/qrwindow.py
@@ -35,7 +35,7 @@ from .qrcodewidget import QRCodeWidget, copy_to_clipboard, save_to_file
 from .util import Buttons, MessageBoxMixin, WWLabel
 
 
-class QR_Window(QtWidgets.QWidget, MessageBoxMixin):
+class QRWindow(QtWidgets.QWidget, MessageBoxMixin):
     def __init__(self):
         # Top-level window.
         super().__init__()

--- a/electrumabc_gui/qt/sign_verify_dialog.py
+++ b/electrumabc_gui/qt/sign_verify_dialog.py
@@ -29,7 +29,7 @@ from .password_dialog import PasswordDialog
 from .util import MessageBoxMixin
 
 if TYPE_CHECKING:
-    from electrumabc.wallet import Abstract_Wallet
+    from electrumabc.wallet import AbstractWallet
 
 
 class CollapsibleSection(QWidget):
@@ -81,7 +81,7 @@ class CollapsibleSection(QWidget):
 
 class SignVerifyDialog(QDialog, MessageBoxMixin):
     def __init__(
-        self, wallet: Abstract_Wallet, address: Optional[Address] = None, parent=None
+        self, wallet: AbstractWallet, address: Optional[Address] = None, parent=None
     ):
         super().__init__(parent)
         self.setWindowModality(Qt.WindowModal)

--- a/electrumabc_gui/qt/util.py
+++ b/electrumabc_gui/qt/util.py
@@ -29,7 +29,7 @@ from electrumabc.paymentrequest import PR_EXPIRED, PR_PAID, PR_UNCONFIRMED, PR_U
 from electrumabc.printerror import PrintError, print_error
 from electrumabc.simple_config import SimpleConfig
 from electrumabc.util import Weak, finalization_print_error
-from electrumabc.wallet import Abstract_Wallet
+from electrumabc.wallet import AbstractWallet
 
 if platform.system() == "Windows":
     MONOSPACE_FONT = "Consolas"
@@ -678,7 +678,7 @@ class MyTreeWidget(QtWidgets.QTreeWidget):
         parent: QtWidgets.QWidget,
         headers,
         config: SimpleConfig,
-        wallet: Abstract_Wallet,
+        wallet: AbstractWallet,
         stretch_column=None,
         editable_columns=None,
         *,

--- a/electrumabc_plugins/cosigner_pool/qt.py
+++ b/electrumabc_plugins/cosigner_pool/qt.py
@@ -41,7 +41,7 @@ from electrumabc.i18n import _
 from electrumabc.plugins import BasePlugin, hook
 from electrumabc.printerror import print_error
 from electrumabc.util import InvalidPassword, Weak, bfh, bh2u
-from electrumabc.wallet import Multisig_Wallet
+from electrumabc.wallet import MultisigWallet
 from electrumabc_gui.qt.transaction_dialog import TxDialog, show_transaction
 
 
@@ -220,7 +220,7 @@ class Plugin(BasePlugin):
                 )
             )
             return
-        if isinstance(wallet, Multisig_Wallet):
+        if isinstance(wallet, MultisigWallet):
             window.cosigner_pool_state = State(self, window)
             self.windows.append(window)
             self.update(window)
@@ -386,7 +386,7 @@ class Plugin(BasePlugin):
             return
 
         wallet = window.wallet
-        if isinstance(wallet.keystore, keystore.Hardware_KeyStore):
+        if isinstance(wallet.keystore, keystore.HardwareKeyStore):
             window.show_warning(
                 _("An encrypted transaction was retrieved from cosigning pool.")
                 + "\n"
@@ -441,7 +441,7 @@ class Plugin(BasePlugin):
             return
         try:
             k = bh2u(bitcoin.deserialize_xprv(xprv)[-1])
-            EC = bitcoin.EC_KEY(bfh(k))
+            EC = bitcoin.ECKey(bfh(k))
             message = bh2u(EC.decrypt_message(message))
         except Exception as e:
             traceback.print_exc(file=sys.stdout)

--- a/electrumabc_plugins/digitalbitbox/digitalbitbox.py
+++ b/electrumabc_plugins/digitalbitbox/digitalbitbox.py
@@ -39,12 +39,12 @@ try:
         verify_message,
     )
     from electrumabc.i18n import _
-    from electrumabc.keystore import Hardware_KeyStore
+    from electrumabc.keystore import HardwareKeyStore
     from electrumabc.printerror import print_error
     from electrumabc.transaction import Transaction
     from electrumabc.util import UserCancelled, to_string
 
-    from ..hw_wallet import HardwareClientBase, HW_PluginBase
+    from ..hw_wallet import HardwareClientBase, HWPluginBase
 
     DIGIBOX = True
 except ImportError:
@@ -69,7 +69,7 @@ def derive_keys(x):
 MIN_MAJOR_VERSION = 5
 
 
-class DigitalBitbox_Client(HardwareClientBase):
+class DigitalBitboxClient(HardwareClientBase):
     def __init__(self, plugin, hidDevice):
         HardwareClientBase.__init__(self, plugin=plugin)
         self.dbb_hid = hidDevice
@@ -504,12 +504,12 @@ class DigitalBitbox_Client(HardwareClientBase):
 #
 
 
-class DigitalBitbox_KeyStore(Hardware_KeyStore):
+class DigitalBitboxKeyStore(HardwareKeyStore):
     hw_type = "digitalbitbox"
     device = "DigitalBitbox"
 
     def __init__(self, d):
-        Hardware_KeyStore.__init__(self, d)
+        HardwareKeyStore.__init__(self, d)
         self.force_watching_only = False
         self.maxInputs = 14  # maximum inputs per single sign command
 
@@ -797,15 +797,15 @@ class DigitalBitbox_KeyStore(Hardware_KeyStore):
             tx.raw = tx.serialize()
 
 
-class DigitalBitboxPlugin(HW_PluginBase):
+class DigitalBitboxPlugin(HWPluginBase):
 
     libraries_available = DIGIBOX
-    keystore_class = DigitalBitbox_KeyStore
+    keystore_class = DigitalBitboxKeyStore
     client = None
     DEVICE_IDS = [(0x03EB, 0x2402)]  # Digital Bitbox
 
     def __init__(self, parent, config, name):
-        HW_PluginBase.__init__(self, parent, config, name)
+        HWPluginBase.__init__(self, parent, config, name)
         if self.libraries_available:
             self.device_manager().register_devices(self.DEVICE_IDS, plugin=self)
 
@@ -822,7 +822,7 @@ class DigitalBitboxPlugin(HW_PluginBase):
             self.handler = handler
             client = self.get_dbb_device(device)
             if client is not None:
-                client = DigitalBitbox_Client(self, client)
+                client = DigitalBitboxClient(self, client)
             return client
         else:
             return None

--- a/electrumabc_plugins/digitalbitbox/qt.py
+++ b/electrumabc_plugins/digitalbitbox/qt.py
@@ -1,6 +1,6 @@
 from electrumabc.i18n import _
 from electrumabc.plugins import hook
-from electrumabc.wallet import Standard_Wallet
+from electrumabc.wallet import StandardWallet
 
 from ..hw_wallet.qt import QtHandlerBase, QtPluginBase
 from .digitalbitbox import DigitalBitboxPlugin
@@ -11,11 +11,11 @@ class Plugin(DigitalBitboxPlugin, QtPluginBase):
     icon_paired = ":icons/digitalbitbox.png"
 
     def create_handler(self, window):
-        return DigitalBitbox_Handler(window)
+        return DigitalBitboxHandler(window)
 
     @hook
     def receive_menu(self, menu, addrs, wallet):
-        if type(wallet) is not Standard_Wallet:
+        if type(wallet) is not StandardWallet:
             return
 
         keystore = wallet.get_keystore()
@@ -43,6 +43,6 @@ class Plugin(DigitalBitboxPlugin, QtPluginBase):
             menu.addAction(_("Show on {}").format(self.device), show_address)
 
 
-class DigitalBitbox_Handler(QtHandlerBase):
+class DigitalBitboxHandler(QtHandlerBase):
     def __init__(self, win):
-        super(DigitalBitbox_Handler, self).__init__(win, "Digital Bitbox")
+        super(DigitalBitboxHandler, self).__init__(win, "Digital Bitbox")

--- a/electrumabc_plugins/fusion/cmdline.py
+++ b/electrumabc_plugins/fusion/cmdline.py
@@ -37,16 +37,16 @@ from .plugin import FusionPlugin
 if TYPE_CHECKING:
     from electrumabc.daemon import Daemon
     from electrumabc.simple_config import SimpleConfig
-    from electrumabc.wallet import Abstract_Wallet
+    from electrumabc.wallet import AbstractWallet
 
 
 class WalletToFuse(NamedTuple):
     name: str
-    wallet: Abstract_Wallet
+    wallet: AbstractWallet
     password: Optional[str]
 
 
-def is_password_valid(wallet: Abstract_Wallet, pwd: str) -> bool:
+def is_password_valid(wallet: AbstractWallet, pwd: str) -> bool:
     try:
         wallet.storage.check_password(pwd)
     except InvalidPassword:
@@ -55,7 +55,7 @@ def is_password_valid(wallet: Abstract_Wallet, pwd: str) -> bool:
 
 
 def find_password_in_list(
-    wallet: Abstract_Wallet, passwords: List[str]
+    wallet: AbstractWallet, passwords: List[str]
 ) -> Optional[str]:
     for pwd in passwords:
         if is_password_valid(wallet, pwd):

--- a/electrumabc_plugins/fusion/fusion.py
+++ b/electrumabc_plugins/fusion/fusion.py
@@ -58,7 +58,7 @@ from electrumabc.util import (
     do_in_main_thread,
     format_satoshis,
 )
-from electrumabc.wallet import Multisig_Wallet, Standard_Wallet
+from electrumabc.wallet import MultisigWallet, StandardWallet
 
 from . import compatibility, encrypt
 from . import fusion_pb2 as pb
@@ -111,14 +111,14 @@ def can_fuse_from(wallet):
     return not (
         wallet.is_watching_only()
         or wallet.is_hardware()
-        or isinstance(wallet, Multisig_Wallet)
+        or isinstance(wallet, MultisigWallet)
     )
 
 
 def can_fuse_to(wallet):
     """We can only fuse to wallets that are p2pkh with HD generation. We do
     *not* need the private keys."""
-    return isinstance(wallet, Standard_Wallet)
+    return isinstance(wallet, StandardWallet)
 
 
 # Some internal stuff

--- a/electrumabc_plugins/fusion/qt.py
+++ b/electrumabc_plugins/fusion/qt.py
@@ -39,7 +39,7 @@ from electrumabc.address import Address
 from electrumabc.i18n import _, ngettext
 from electrumabc.plugins import hook, run_hook
 from electrumabc.util import InvalidPassword, do_in_main_thread, inv_dict
-from electrumabc.wallet import Abstract_Wallet
+from electrumabc.wallet import AbstractWallet
 from electrumabc_gui.qt.amountedit import XECAmountEdit
 from electrumabc_gui.qt.main_window import ElectrumWindow
 from electrumabc_gui.qt.popup_widget import KillPopupLabel, ShowPopupLabel
@@ -619,14 +619,14 @@ class Plugin(FusionPlugin, QObject):
         """Convenience: Given a wallet instance, derefernces the weak_window
         attribute of the wallet and returns a strong reference to the window.
         May return None if the window is gone (deallocated)."""
-        assert isinstance(wallet, Abstract_Wallet)
+        assert isinstance(wallet, AbstractWallet)
         return (wallet.weak_window and wallet.weak_window()) or None
 
     @classmethod
     def get_suitable_dialog_window_parent(cls, wallet_or_window):
         """Convenience: Given a wallet or a window instance, return a suitable
         'top level window' parent to use for dialog boxes."""
-        if isinstance(wallet_or_window, Abstract_Wallet):
+        if isinstance(wallet_or_window, AbstractWallet):
             wallet = wallet_or_window
             window = cls.window_for_wallet(wallet)
             return (window and window.top_level_window()) or None

--- a/electrumabc_plugins/hw_wallet/__init__.py
+++ b/electrumabc_plugins/hw_wallet/__init__.py
@@ -1,2 +1,2 @@
 from .cmdline import CmdLineHandler  # noqa: F401
-from .plugin import HardwareClientBase, HardwareHandlerBase, HW_PluginBase  # noqa: F401
+from .plugin import HardwareClientBase, HardwareHandlerBase, HWPluginBase  # noqa: F401

--- a/electrumabc_plugins/hw_wallet/plugin.py
+++ b/electrumabc_plugins/hw_wallet/plugin.py
@@ -39,12 +39,12 @@ if TYPE_CHECKING:
     import threading
 
     from electrumabc.base_wizard import BaseWizard
-    from electrumabc.keystore import Hardware_KeyStore
-    from electrumabc.wallet import Abstract_Wallet
+    from electrumabc.keystore import HardwareKeyStore
+    from electrumabc.wallet import AbstractWallet
 
 
-class HW_PluginBase(BasePlugin):
-    keystore_class: Type[Hardware_KeyStore]
+class HWPluginBase(BasePlugin):
+    keystore_class: Type[HardwareKeyStore]
     libraries_available: bool
 
     DEVICE_IDS: Iterable[Any]
@@ -87,7 +87,7 @@ class HW_PluginBase(BasePlugin):
         return device
 
     @hook
-    def close_wallet(self, wallet: Abstract_Wallet):
+    def close_wallet(self, wallet: AbstractWallet):
         for keystore in wallet.get_keystores():
             if isinstance(keystore, self.keystore_class):
                 self.device_manager().unpair_xpub(keystore.xpub)
@@ -165,7 +165,7 @@ class HardwareClientBase:
 
     handler: Optional[HardwareHandlerBase]
 
-    def __init__(self, *, plugin: HW_PluginBase):
+    def __init__(self, *, plugin: HWPluginBase):
         self.plugin = plugin
 
     def device_manager(self) -> DeviceMgr:
@@ -215,7 +215,7 @@ class HardwareHandlerBase:
     win = None
     device: str
 
-    def get_wallet(self) -> Optional[Abstract_Wallet]:
+    def get_wallet(self) -> Optional[AbstractWallet]:
         if self.win is not None:
             if hasattr(self.win, "wallet"):
                 return self.win.wallet
@@ -322,7 +322,7 @@ def validate_op_return_output_and_get_data(
 def only_hook_if_libraries_available(func):
     # note: this decorator must wrap @hook, not the other way around,
     # as 'hook' uses the name of the function it wraps
-    def wrapper(self: HW_PluginBase, *args, **kwargs):
+    def wrapper(self: HWPluginBase, *args, **kwargs):
         if not self.libraries_available:
             return None
         return func(self, *args, **kwargs)

--- a/electrumabc_plugins/hw_wallet/qt.py
+++ b/electrumabc_plugins/hw_wallet/qt.py
@@ -55,11 +55,11 @@ from electrumabc_gui.qt.util import (
     char_width_in_lineedit,
 )
 
-from .plugin import HardwareHandlerBase, HW_PluginBase
+from .plugin import HardwareHandlerBase, HWPluginBase
 
 if TYPE_CHECKING:
-    from electrumabc.keystore import Hardware_KeyStore
-    from electrumabc.wallet import Abstract_Wallet
+    from electrumabc.keystore import HardwareKeyStore
+    from electrumabc.wallet import AbstractWallet
 
 
 # The trickiest thing about this handler was getting windows properly
@@ -218,7 +218,7 @@ class QtHandlerBase(HardwareHandlerBase, QObject, PrintError):
         self.done.set()
 
 
-class ThreadJob_TaskThread_Facade(TaskThread):
+class ThreadJobTaskThreadFacade(TaskThread):
     """This class is really a ThreadJob intended to mimic the TaskThread's
     semantics. (Which we need since it can send signals/callbacks to the GUI
     thread).
@@ -271,8 +271,8 @@ class ThreadJob_TaskThread_Facade(TaskThread):
 class QtPluginBase(object):
     @hook
     def load_wallet(
-        self: Union[QtPluginBase, HW_PluginBase],
-        wallet: Abstract_Wallet,
+        self: Union[QtPluginBase, HWPluginBase],
+        wallet: AbstractWallet,
         window: ElectrumWindow,
     ):
         for i, keystore in enumerate(wallet.get_keystores()):
@@ -297,16 +297,16 @@ class QtPluginBase(object):
             handler = self.create_handler(window)
             handler.button = button
             keystore.handler = handler
-            keystore.thread = ThreadJob_TaskThread_Facade(
+            keystore.thread = ThreadJobTaskThreadFacade(
                 self, window.on_error, name=wallet.diagnostic_name() + f"/keystore{i}"
             )
             # Trigger a pairing
             keystore.thread.add(partial(self.get_client, keystore))
 
     def choose_device(
-        self: Union["QtPluginBase", HW_PluginBase],
+        self: Union["QtPluginBase", HWPluginBase],
         window: ElectrumWindow,
-        keystore: Hardware_KeyStore,
+        keystore: HardwareKeyStore,
     ) -> Optional[str]:
         """This dialog box should be usable even if the user has
         forgotten their PIN or it is in bootloader mode."""
@@ -321,7 +321,7 @@ class QtPluginBase(object):
             device_id = info.device.id_
         return device_id
 
-    def show_settings_dialog(self, window: ElectrumWindow, keystore: Hardware_KeyStore):
+    def show_settings_dialog(self, window: ElectrumWindow, keystore: HardwareKeyStore):
         def connect():
             self.choose_device(window, keystore)
 

--- a/electrumabc_plugins/keepkey/keepkey.py
+++ b/electrumabc_plugins/keepkey/keepkey.py
@@ -9,12 +9,12 @@ from electrumabc.bitcoin import (
     deserialize_xpub,
 )
 from electrumabc.i18n import _
-from electrumabc.keystore import Hardware_KeyStore, is_xpubkey, parse_xpubkey
+from electrumabc.keystore import HardwareKeyStore, is_xpubkey, parse_xpubkey
 from electrumabc.plugins import Device
 from electrumabc.transaction import deserialize
 from electrumabc.util import UserCancelled, bfh, bh2u
 
-from ..hw_wallet import HW_PluginBase
+from ..hw_wallet import HWPluginBase
 from ..hw_wallet.plugin import (
     is_any_tx_output_on_change_branch,
     validate_op_return_output_and_get_data,
@@ -24,7 +24,7 @@ from ..hw_wallet.plugin import (
 TIM_NEW, TIM_RECOVER, TIM_MNEMONIC, TIM_PRIVKEY = range(0, 4)
 
 
-class KeepKey_KeyStore(Hardware_KeyStore):
+class KeepKeyKeyStore(HardwareKeyStore):
     hw_type = "keepkey"
     device = "KeepKey"
 
@@ -75,7 +75,7 @@ class KeepKey_KeyStore(Hardware_KeyStore):
         self.plugin.sign_transaction(self, tx, prev_tx, xpub_path)
 
 
-class KeepKeyPlugin(HW_PluginBase):
+class KeepKeyPlugin(HWPluginBase):
     # Derived classes provide:
     #
     #  class-static variables: client_class, firmware_URL, handler_class,
@@ -85,14 +85,14 @@ class KeepKeyPlugin(HW_PluginBase):
     firmware_URL = "https://www.keepkey.com"
     libraries_URL = "https://github.com/keepkey/python-keepkey"
     minimum_firmware = (1, 0, 0)
-    keystore_class = KeepKey_KeyStore
+    keystore_class = KeepKeyKeyStore
     usb_context = None
     SUPPORTED_XTYPES = ("standard", "p2wsh-p2sh", "p2wsh")
 
     MAX_LABEL_LEN = 32
 
     def __init__(self, parent, config, name):
-        HW_PluginBase.__init__(self, parent, config, name)
+        HWPluginBase.__init__(self, parent, config, name)
 
         try:
             import keepkeylib

--- a/electrumabc_plugins/ledger/qt.py
+++ b/electrumabc_plugins/ledger/qt.py
@@ -5,7 +5,7 @@ from PyQt5.QtCore import pyqtSignal
 
 from electrumabc.i18n import _
 from electrumabc.plugins import hook
-from electrumabc.wallet import Standard_Wallet
+from electrumabc.wallet import StandardWallet
 from electrumabc_gui.qt.util import WindowModalDialog
 
 from ..hw_wallet.qt import QtHandlerBase, QtPluginBase
@@ -17,11 +17,11 @@ class Plugin(LedgerPlugin, QtPluginBase):
     icon_paired = ":icons/ledger.png"
 
     def create_handler(self, window):
-        return Ledger_Handler(window)
+        return LedgerHandler(window)
 
     @hook
     def receive_menu(self, menu, addrs, wallet):
-        if type(wallet) is not Standard_Wallet:
+        if type(wallet) is not StandardWallet:
             return
         keystore = wallet.get_keystore()
         if type(keystore) == self.keystore_class and len(addrs) == 1:
@@ -32,12 +32,12 @@ class Plugin(LedgerPlugin, QtPluginBase):
             menu.addAction(_("Show on Ledger"), show_address)
 
 
-class Ledger_Handler(QtHandlerBase):
+class LedgerHandler(QtHandlerBase):
     setup_signal = pyqtSignal()
     auth_signal = pyqtSignal(object)
 
     def __init__(self, win):
-        super(Ledger_Handler, self).__init__(win, "Ledger")
+        super(LedgerHandler, self).__init__(win, "Ledger")
         self.setup_signal.connect(self.setup_dialog)
         self.auth_signal.connect(self.auth_dialog)
 

--- a/electrumabc_plugins/satochip/qt.py
+++ b/electrumabc_plugins/satochip/qt.py
@@ -52,7 +52,7 @@ class Plugin(SatochipPlugin, QtPluginBase):
     #    BasePlugin.__init__(self, parent, config, name)
 
     def create_handler(self, window):
-        return Satochip_Handler(window)
+        return SatochipHandler(window)
 
     def requires_settings(self):
         # Return True to add a Settings button.
@@ -79,9 +79,9 @@ class Plugin(SatochipPlugin, QtPluginBase):
             SatochipSettingsDialog(window, self, keystore, device_id).exec_()
 
 
-class Satochip_Handler(QtHandlerBase):
+class SatochipHandler(QtHandlerBase):
     def __init__(self, win):
-        super(Satochip_Handler, self).__init__(win, "Satochip")
+        super(SatochipHandler, self).__init__(win, "Satochip")
 
     # TODO: something?
 

--- a/electrumabc_plugins/satochip/satochip.py
+++ b/electrumabc_plugins/satochip/satochip.py
@@ -11,9 +11,9 @@ from electrumabc import networks
 from electrumabc.bitcoin import Hash, SignatureType, hash_160, serialize_xpub, var_int
 from electrumabc.constants import PROJECT_NAME
 from electrumabc.i18n import _
-from electrumabc.keystore import Hardware_KeyStore
+from electrumabc.keystore import HardwareKeyStore
 from electrumabc.mnemo import (
-    Mnemonic_Electrum,
+    MnemonicElectrum,
     bip39_mnemonic_to_seed,
     is_seed,
     seed_type_name,
@@ -22,10 +22,10 @@ from electrumabc.plugins import Device
 from electrumabc.printerror import PrintError, is_verbose, print_error
 from electrumabc.transaction import Transaction
 from electrumabc.util import bfh, bh2u
-from electrumabc.wallet import Standard_Wallet
+from electrumabc.wallet import StandardWallet
 from electrumabc_gui.qt.qrcodewidget import QRDialog
 
-from ..hw_wallet.plugin import HardwareClientBase, HW_PluginBase
+from ..hw_wallet.plugin import HardwareClientBase, HWPluginBase
 
 try:
     # pysatochip
@@ -298,12 +298,12 @@ class SatochipClient(HardwareClientBase, PrintError):
                 return (True, oldpin, newpin)
 
 
-class Satochip_KeyStore(Hardware_KeyStore):
+class SatochipKeyStore(HardwareKeyStore):
     hw_type = "satochip"
     device = "Satochip"
 
     def __init__(self, d):
-        Hardware_KeyStore.__init__(self, d)
+        HardwareKeyStore.__init__(self, d)
         # print_error("[satochip] Satochip_KeyStore: __init__(): xpub:"+str(d.get('xpub')) )#debugSatochip
         # print_error("[satochip] Satochip_KeyStore: __init__(): derivation"+str(d.get('derivation')))#debugSatochip
         self.force_watching_only = False
@@ -311,7 +311,7 @@ class Satochip_KeyStore(Hardware_KeyStore):
 
     def dump(self):
         # our additions to the stored data about keystore -- only during creation?
-        d = Hardware_KeyStore.dump(self)
+        d = HardwareKeyStore.dump(self)
         return d
 
     def get_derivation(self):
@@ -578,17 +578,17 @@ class Satochip_KeyStore(Hardware_KeyStore):
         return
 
 
-class SatochipPlugin(HW_PluginBase):
+class SatochipPlugin(HWPluginBase):
     SUPPORTS_XEC_BIP44_DERIVATION = True
 
     libraries_available = LIBS_AVAILABLE
     minimum_library = (0, 0, 0)
-    keystore_class = Satochip_KeyStore
+    keystore_class = SatochipKeyStore
     DEVICE_IDS = [(SATOCHIP_VID, SATOCHIP_PID)]
     SUPPORTED_XTYPES = "standard"
 
     def __init__(self, parent, config, name):
-        HW_PluginBase.__init__(self, parent, config, name)
+        HWPluginBase.__init__(self, parent, config, name)
 
         if not LIBS_AVAILABLE:
             return
@@ -848,7 +848,7 @@ class SatochipPlugin(HW_PluginBase):
             return
 
         # Standard_Wallet => not multisig, must be bip32
-        if type(wallet) is not Standard_Wallet:
+        if type(wallet) is not StandardWallet:
             keystore.handler.show_error(
                 _(
                     "This function is only available for standard wallets when using {}."
@@ -969,7 +969,7 @@ class SatochipPlugin(HW_PluginBase):
             raise Exception("Unknown seed type", wizard.seed_type)
 
     def derive_bip32_seed(self, seed, passphrase):
-        self.bip32_seed = Mnemonic_Electrum("en").mnemonic_to_seed(seed, passphrase)
+        self.bip32_seed = MnemonicElectrum("en").mnemonic_to_seed(seed, passphrase)
 
     def derive_bip39_seed(self, seed, passphrase):
         self.bip32_seed = bip39_mnemonic_to_seed(seed, passphrase)

--- a/electrumabc_plugins/trezor/trezor.py
+++ b/electrumabc_plugins/trezor/trezor.py
@@ -9,13 +9,13 @@ from electrumabc.bitcoin import (
     deserialize_xpub,
 )
 from electrumabc.i18n import _
-from electrumabc.keystore import Hardware_KeyStore, is_xpubkey, parse_xpubkey
+from electrumabc.keystore import HardwareKeyStore, is_xpubkey, parse_xpubkey
 from electrumabc.networks import NetworkConstants
 from electrumabc.plugins import Device
 from electrumabc.transaction import deserialize
 from electrumabc.util import UserCancelled, bfh, bh2u, versiontuple
 
-from ..hw_wallet import HW_PluginBase
+from ..hw_wallet import HWPluginBase
 
 try:
     import trezorlib
@@ -57,7 +57,7 @@ TIM_NEW, TIM_RECOVER = range(2)
 TREZOR_PRODUCT_KEY = "Trezor"
 
 
-class TrezorKeyStore(Hardware_KeyStore):
+class TrezorKeyStore(HardwareKeyStore):
     hw_type = "trezor"
     device = TREZOR_PRODUCT_KEY
 
@@ -116,7 +116,7 @@ class LibraryFoundButUnusable(Exception):
         self.library_version = library_version
 
 
-class TrezorPlugin(HW_PluginBase):
+class TrezorPlugin(HWPluginBase):
     # Derived classes provide:
     #
     #  class-static variables: client_class, firmware_URL, handler_class,


### PR DESCRIPTION
As we are about to break compatibility in the next release (#260), use this opportunity to rename some classes to PEP8 standards (`Abstract_Wallet` -> `AbstractWallet`).