### PR TITLE
Stop setting the transaction locktime to the current block height

### DIFF
--- a/electrumabc/simple_config.py
+++ b/electrumabc/simple_config.py
@@ -328,6 +328,9 @@ class SimpleConfig(PrintError):
     def is_current_block_locktime_enabled(self) -> bool:
         return self.get("enable_current_block_locktime", True)
 
+    def set_current_block_locktime_enabled(self, flag: bool):
+        self.set_key("enable_current_block_locktime", flag, save=True)
+
 
 def read_user_config(path: str) -> dict:
     """Parse the user config settings and return it as a dictionary.

--- a/electrumabc/simple_config.py
+++ b/electrumabc/simple_config.py
@@ -326,7 +326,7 @@ class SimpleConfig(PrintError):
         return device
 
     def is_current_block_locktime_enabled(self) -> bool:
-        return self.get("enable_current_block_locktime", True)
+        return self.get("enable_current_block_locktime", False)
 
     def set_current_block_locktime_enabled(self, flag: bool):
         self.set_key("enable_current_block_locktime", flag, save=True)

--- a/electrumabc/simple_config.py
+++ b/electrumabc/simple_config.py
@@ -325,6 +325,9 @@ class SimpleConfig(PrintError):
             device = ""
         return device
 
+    def is_current_block_locktime_enabled(self) -> bool:
+        return self.get("enable_current_block_locktime", True)
+
 
 def read_user_config(path: str) -> dict:
     """Parse the user config settings and return it as a dictionary.

--- a/electrumabc_gui/qt/history_list.py
+++ b/electrumabc_gui/qt/history_list.py
@@ -316,7 +316,9 @@ class HistoryList(MyTreeWidget):
             _("&Details"), lambda: self.main_window.show_transaction(tx, label)
         )
         if is_unconfirmed and tx:
-            child_tx = self.wallet.cpfp(tx, 0)
+            child_tx = self.wallet.cpfp(
+                tx, 0, self.config.is_current_block_locktime_enabled()
+            )
             if child_tx:
                 menu.addAction(
                     _("Child pays for parent"),

--- a/electrumabc_gui/qt/main_window.py
+++ b/electrumabc_gui/qt/main_window.py
@@ -5141,7 +5141,9 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
         if fee > max_fee:
             self.show_error(_("Max fee exceeded"))
             return
-        new_tx = self.wallet.cpfp(parent_tx, fee)
+        new_tx = self.wallet.cpfp(
+            parent_tx, fee, self.config.is_current_block_locktime_enabled()
+        )
         if new_tx is None:
             self.show_error(_("CPFP no longer valid"))
             return

--- a/electrumabc_gui/qt/settings_dialog.py
+++ b/electrumabc_gui/qt/settings_dialog.py
@@ -540,6 +540,15 @@ class SettingsDialog(WindowModalDialog):
         legacy_p2sh_cb.stateChanged.connect(self.on_legacy_p2sh_cb)
         global_tx_widgets.append((legacy_p2sh_cb, None))
 
+        locktime_cb = QtWidgets.QCheckBox(_("Enable current block locktime"))
+        locktime_cb.setToolTip(
+            _("Enable setting transaction locktime to current block height")
+        )
+        locktime_cb.setChecked(self.config.is_current_block_locktime_enabled())
+        locktime_cb.toggled.connect(self.config.set_current_block_locktime_enabled)
+
+        global_tx_widgets.append((locktime_cb, None))
+
         # Schnorr
         use_schnorr_cb = QtWidgets.QCheckBox(_("Sign with Schnorr signatures"))
         use_schnorr_cb.setChecked(self.wallet.is_schnorr_enabled())


### PR DESCRIPTION
By default Electrum ABC will now use `locktime=0` for transactions. The previous behavior can be enabled again in the settings, just in case it becomes useful some day for coin splitting (for now all that matters is that Electron Cash still sets the locktime, as the BCH block height is ahead of the eCash block height).