### PR TITLE
address consolidation tool: fix min/max value/height selection

### DIFF
--- a/electrumabc_gui/qt/consolidate_coins_dialog.py
+++ b/electrumabc_gui/qt/consolidate_coins_dialog.py
@@ -142,6 +142,20 @@ class ConsolidateCoinsWizard(QtWidgets.QWizard):
         if self.currentPage() is self.tx_page:
             self.tx_page.update_status(TransactionsStatus.NOT_STARTED)
             self.tx_thread = QtCore.QThread()
+
+            min_value = None
+            if self.coins_page.filter_by_min_value_cb.isChecked():
+                min_value = self.coins_page.get_minimum_value()
+            max_value = None
+            if self.coins_page.filter_by_max_value_cb.isChecked():
+                max_value = self.coins_page.get_maximum_value()
+            min_height = None
+            if self.coins_page.filter_by_min_height_cb.isChecked():
+                min_height = self.coins_page.minimum_height_sb.value()
+            max_height = None
+            if self.coins_page.filter_by_max_height_cb.isChecked():
+                max_height = self.coins_page.maximum_height_sb.value()
+
             self.worker = ConsolidateWorker(
                 self.address,
                 self.wallet,
@@ -149,10 +163,10 @@ class ConsolidateCoinsWizard(QtWidgets.QWizard):
                 self.coins_page.include_non_coinbase_cb.isChecked(),
                 self.coins_page.include_frozen_cb.isChecked(),
                 self.coins_page.include_slp_cb.isChecked(),
-                self.coins_page.get_minimum_value(),
-                self.coins_page.get_maximum_value(),
-                self.coins_page.minimum_height_sb.value(),
-                self.coins_page.maximum_height_sb.value(),
+                min_value,
+                max_value,
+                min_height,
+                max_height,
                 self.output_page.get_output_address(),
                 self.output_page.tx_size_sb.value(),
             )
@@ -245,7 +259,7 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
         )
 
         self.maximum_height_sb = BlockHeightSpinBox()
-        self.maximum_height_sb.setValue(1_000_000)
+        self.maximum_height_sb.setValue(10_000_000)
         self.maximum_height_sb.valueChanged.connect(self.on_min_or_max_height_changed)
         self.filter_by_max_height_cb = self.add_filter_by_value_line(
             "Maximum block height", self.maximum_height_sb

--- a/electrumabc_gui/qt/consolidate_coins_dialog.py
+++ b/electrumabc_gui/qt/consolidate_coins_dialog.py
@@ -122,7 +122,7 @@ class ConsolidateCoinsWizard(QtWidgets.QWizard):
         self.wallet: AbstractWallet = wallet
         self.transactions: Sequence[Transaction] = []
 
-        self.coins_page = CoinSelectionPage()
+        self.coins_page = CoinSelectionPage(self.wallet.get_local_height())
         self.addPage(self.coins_page)
 
         self.output_page = OutputsPage(address)
@@ -213,7 +213,7 @@ class BlockHeightSpinBox(QtWidgets.QSpinBox):
 
 
 class CoinSelectionPage(QtWidgets.QWizardPage):
-    def __init__(self, parent=None):
+    def __init__(self, blockchain_height, parent=None):
         super().__init__(parent)
         self.setTitle("Filter coins")
 
@@ -259,7 +259,9 @@ class CoinSelectionPage(QtWidgets.QWizardPage):
         )
 
         self.maximum_height_sb = BlockHeightSpinBox()
-        self.maximum_height_sb.setValue(10_000_000)
+        self.maximum_height_sb.setValue(
+            blockchain_height + 1 if blockchain_height > 0 else 10_000_000
+        )
         self.maximum_height_sb.valueChanged.connect(self.on_min_or_max_height_changed)
         self.filter_by_max_height_cb = self.add_filter_by_value_line(
             "Maximum block height", self.maximum_height_sb


### PR DESCRIPTION
The address consolidation tool did not seem to work on testnet. The problem was that we always pass a max block height even if the corresponding checkbox is not checked, and that the default value is lower than the current testnet block height.

This fixes the issue by passing None if the checkbox is unchecked, and also by setting a larger default maximum block height (in case users check the box but don't increase the value). This should give us some wiggle room.

The problem is the same for min and max value, and min block height, except that the default values for these are more sane (less likely to filter out values by accident)