### PR TITLE
shuffle transaction inputs and outputs

### DIFF
--- a/electrumabc/transaction.py
+++ b/electrumabc/transaction.py
@@ -24,6 +24,7 @@
 # CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 import hashlib
+import random
 import struct
 import warnings
 from typing import Optional, Tuple, Union
@@ -780,10 +781,9 @@ class Transaction:
             s += bitcoin.int_to_hex(txin["value"], 8)
         return s
 
-    def BIP_LI01_sort(self):
-        # See https://github.com/kristovatlas/rfc/blob/master/bips/bip-li01.mediawiki
-        self._inputs.sort(key=lambda i: (i["prevout_hash"], i["prevout_n"]))
-        self._outputs.sort(key=lambda o: (o[2], self.pay_script(o[1])))
+    def shuffle_inputs_outputs(self):
+        random.shuffle(self._inputs)
+        random.shuffle(self._outputs)
 
     def serialize_output(self, output):
         output_type, addr, amount = output

--- a/electrumabc/wallet.py
+++ b/electrumabc/wallet.py
@@ -209,7 +209,7 @@ def sweep(
     tx = Transaction.from_io(
         inputs, outputs, locktime=locktime, sign_schnorr=sign_schnorr
     )
-    tx.BIP_LI01_sort()
+    tx.shuffle_inputs_outputs()
     tx.sign(keypairs)
     return tx
 
@@ -2160,8 +2160,7 @@ class AbstractWallet(PrintError, SPVDelegate):
         if sats_per_byte > 100:
             raise ExcessiveFee()
 
-        # Sort the inputs and outputs deterministically
-        tx.BIP_LI01_sort()
+        tx.shuffle_inputs_outputs()
         # Timelock tx to current height.
         locktime = 0
         if config.is_current_block_locktime_enabled():
@@ -2440,7 +2439,7 @@ class AbstractWallet(PrintError, SPVDelegate):
         locktime = 0
         if enable_current_block_locktime:
             locktime = self.get_local_height()
-        # note: no need to call tx.BIP_LI01_sort() here - single input/output
+        # note: no need to call tx.shuffle_inputs_outputs here - single input/output
         return Transaction.from_io(
             inputs, outputs, locktime=locktime, sign_schnorr=sign_schnorr
         )


### PR DESCRIPTION
Change strategy regarding transaction inputs/outputs ordering. 

The Bitcoin ABC wallet  shuffles inputs and outputs, while Electrum was sorting them in a deterministic order. Both strategies are viable ways of improving user privacy and making wallet fingerprinting harder, but the randomization helps also users of other wallets. If most wallets apply randomization, then the wallets that don't will stand out less. It will be difficult to guess if a simple transaction (one or two inputs, one or two outputs) that matches some sorting rules did it intentionally or by random luck.