### PR TITLE
fix -wp / --walletpassword option

### DIFF
--- a/electrum-abc
+++ b/electrum-abc
@@ -299,6 +299,11 @@ def init_cmdline(config_options: dict, server):
             raise NotImplementedError("CLI functionality of encrypted hw wallets")
         if config.get("password"):
             password = config.get("password")
+        elif "wallet_password" in config_options:
+            print_msg(
+                'Warning: unlocking wallet with commandline argument "--walletpassword"'
+            )
+            password = config_options["wallet_password"]
         else:
             password = prompt_password()
             if not password:


### PR DESCRIPTION
This option was lost in a commit backported from Electrum: 4831972759cfd3e9f5f6eb15454f2da607809328
The option was initially added in Electron Cash after the fork from Electrum: https://github.com/Electron-Cash/Electron-Cash/pull/740

Note that the option must be passed directly to commands that need it (e.g  `load_wallet`). It is not remembered between commands, so passing it to the  `daemon start` command does not work.
