### PR TITLE
Fix transaction version for hardware wallets

### DIFF
--- a/electrumabc_plugins/ledger/ledger.py
+++ b/electrumabc_plugins/ledger/ledger.py
@@ -618,11 +618,16 @@ class LedgerKeyStore(HardwareKeyStore):
                     inputIndex,
                     chipInputs,
                     redeemScripts[inputIndex],
+                    version=tx.version,
                     cashAddr=True,
                 )
             else:
                 client_ledger.startUntrustedTransaction(
-                    True, inputIndex, chipInputs, redeemScripts[inputIndex]
+                    True,
+                    inputIndex,
+                    chipInputs,
+                    redeemScripts[inputIndex],
+                    version=tx.version,
                 )
             # we don't set meaningful outputAddress, amount and fees
             # as we only care about the alternateEncoding==True branch
@@ -647,11 +652,20 @@ class LedgerKeyStore(HardwareKeyStore):
                 singleInput = [chipInputs[inputIndex]]
                 if cashaddr and client_electrum.supports_cashaddr():
                     client_ledger.startUntrustedTransaction(
-                        False, 0, singleInput, redeemScripts[inputIndex], cashAddr=True
+                        False,
+                        0,
+                        singleInput,
+                        redeemScripts[inputIndex],
+                        version=tx.version,
+                        cashAddr=True,
                     )
                 else:
                     client_ledger.startUntrustedTransaction(
-                        False, 0, singleInput, redeemScripts[inputIndex]
+                        False,
+                        0,
+                        singleInput,
+                        redeemScripts[inputIndex],
+                        version=tx.version,
                     )
                 inputSignature = client_ledger.untrustedHashSign(
                     inputsPaths[inputIndex], pin, lockTime=tx.locktime, sighashType=0x41

--- a/electrumabc_plugins/trezor/trezor.py
+++ b/electrumabc_plugins/trezor/trezor.py
@@ -402,7 +402,7 @@ class TrezorPlugin(HWPluginBase):
         client = self.get_client(keystore)
         inputs = self.tx_inputs(tx, xpub_path, True)
         outputs = self.tx_outputs(keystore.get_derivation(), tx, client)
-        details = SignTx(lock_time=tx.locktime)
+        details = SignTx(lock_time=tx.locktime, version=tx.version)
         signatures, signed_tx = client.sign_tx(
             self.get_coin_name(), inputs, outputs, details=details, prev_txes=prev_tx
         )


### PR DESCRIPTION
Switching to transaction `version=2` in #267 broke support for Trezor and Ledger devices. The transaction version needs to be explicitly specified when calling the relevant signing API.