### PR TITLE
fix string splitting in format_satoshis

### DIFF
--- a/electrumabc/util.py
+++ b/electrumabc/util.py
@@ -530,10 +530,11 @@ def format_satoshis(
         decimal_format += "f}"
         result = decimal_format.format(value).rstrip("0")
     dp = _cached_dp
-    try:
+
+    if dp in result:
         integer_part, fract_part = result.split(dp)
-    except ValueError:
-        raise
+    else:
+        integer_part, fract_part = result, ""
 
     if len(fract_part) < num_zeros:
         fract_part += "0" * (num_zeros - len(fract_part))


### PR DESCRIPTION
This hopefully addresses #283, but I'm not sure because I don't know how to reproduce the issue.

The `try: except...` clause previously used was nonsense that did not catch any error. Replace it with a simple check to find out if the amount string contains a decimal point. If not, assume it only contains an integer. I'm not sure what could cause the string not to have a decimal point, but then I 'm not entirely in control of what `locale.format_string` produces. Maybe their is an exotic/buggy locale setting that produces values without a dp.