### PR TITLE
fix portable behavior

### DIFF
--- a/contrib/build-wine/docker/Dockerfile
+++ b/contrib/build-wine/docker/Dockerfile
@@ -19,7 +19,7 @@ RUN echo deb ${UBUNTU_MIRROR} ${UBUNTUDIST} main restricted universe multiverse 
         gnupg2=2.2.27-3ubuntu2.1 \
         ca-certificates=20211016 \
         wget=1.21.2-2ubuntu1 \
-        git=1:2.34.1-1ubuntu1.8 \
+        git=1:2.34.1-1ubuntu1.9 \
         p7zip-full=16.02+dfsg-8 \
         make=4.3-4.1build1 \
         autotools-dev=20220109.1 \
@@ -51,9 +51,9 @@ RUN echo "78b185fabdb323971d13bd329fefc8038e08559aa51c4996de18db0639a51df6 /tmp/
         # cabextract is needed for winetricks to install the .NET framework
         cabextract=1.9-3 \
         # xvfb is needed to launch the Visual Studio installer
-        xvfb=2:21.1.3-2ubuntu2.7 \
+        xvfb=2:21.1.4-2ubuntu1.7~22.04.1 \
         # winbind is needed for the Visual Studio installer and cl.exe PDB generation
-        winbind=2:4.15.13+dfsg-0ubuntu1
+        winbind=2:4.15.13+dfsg-0ubuntu1.1
 
 RUN rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \

--- a/electrum-abc
+++ b/electrum-abc
@@ -41,6 +41,7 @@ import multiprocessing
 import os
 import sys
 import threading
+import warnings
 from typing import Any
 
 import electrumabc.web as web
@@ -102,12 +103,21 @@ if jnius is not None:
     threading.Thread.run = thread_check_run
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
-IS_BUNDLE = getattr(sys, "frozen", False)
-IS_LOCAL = not IS_BUNDLE and os.path.exists(
-    os.path.join(script_dir, "electrum-abc.desktop")
+is_pyinstaller = getattr(sys, "frozen", False)
+is_appimage = "APPIMAGE" in os.environ
+# is_local: unpacked tar.gz but not pip installed, or git clone
+is_local = (
+    not is_pyinstaller
+    and not is_appimage
+    and os.path.exists(os.path.join(script_dir, "electrum-abc.desktop"))
 )
+is_git_clone = is_local and os.path.exists(os.path.join(script_dir, ".git"))
 
-if IS_LOCAL:
+if is_git_clone:
+    # developers should probably see all deprecation warnings.
+    warnings.simplefilter("default", DeprecationWarning)
+
+if is_local:
     sys.path.insert(0, os.path.join(script_dir, "packages"))
 
 
@@ -487,17 +497,31 @@ def process_config_options(args: argparse.Namespace) -> dict:
     if config_options.get("server"):
         config_options["auto_connect"] = False
 
+    config_options["cwd"] = cwd = os.getcwd()
+
     # FIXME: this can probably be achieved with a runtime hook (pyinstaller)
-    try:
-        tmp_folder = os.path.join(sys._MEIPASS, "is_portable")  # pylint: disable=W0212
-        config_options["portable"] = IS_BUNDLE and os.path.exists(tmp_folder)
-    except AttributeError:
-        config_options["portable"] = False
+    if is_pyinstaller and os.path.exists(os.path.join(sys._MEIPASS, "is_portable")):
+        config_options["portable"] = True
 
     if config_options.get("portable"):
-        config_options["data_path"] = os.path.join(
-            os.path.dirname(os.path.realpath(__file__)), PORTABLE_DATA_DIR
-        )
+        if is_local:
+            # running from git clone or local source: put datadir next to main script
+            datadir = os.path.join(
+                os.path.dirname(os.path.realpath(__file__)), PORTABLE_DATA_DIR
+            )
+        else:
+            # Running a binary or installed source. The most generic but still
+            # reasonable thing is to use the current working directory.
+            # note: The main script is often unpacked to a temporary directory from a
+            #       bundled executable, and we don't want to put the datadir inside a
+            #       temp dir.
+            # note: Re the portable .exe on Windows, when the user double-clicks it,
+            #       CWD gets set to the parent dir, i.e. we will put the datadir next
+            #       to the exe
+            datadir = os.path.join(
+                os.path.dirname(os.path.realpath(cwd)), PORTABLE_DATA_DIR
+            )
+        config_options["data_path"] = datadir
 
     is_verbose = config_options.get("verbose")
     set_verbosity(is_verbose)

--- a/electrumabc/commands.py
+++ b/electrumabc/commands.py
@@ -1302,7 +1302,7 @@ def add_global_options(parser):
         action="store_true",
         dest="portable",
         default=False,
-        help="Use local 'electron_cash_data' directory",
+        help="Use local 'electrum_abc_data' directory",
     )
     group.add_argument(
         "-w", "--wallet", dest="wallet_path", help="wallet path", type=os.path.abspath


### PR DESCRIPTION
The main change here is that we fix the broken portable.exe behavior caused by recent versions of PyInstaller now setting the `__file__` attribute to the temp folder where the bundle is temporarily extracted. We don't want the data dir in a temp folder, we want it next to the exe, so use `os.getcwd` instead.

As a bonus, this probably fixes the `--portable` CLI option which I suspect was broken in Electron Cash when an attempt was made to support py2app. This will allow to run the AppImage or source dist with that option, from a hard drive or USB thumbdrive.

This also enables deprecation warnings for developers (anyone running this from a git clone)

Commits backported:
----

revert py2app support change for portable detection

The way `config["portable"]` is set  overwrites the --portable command line flag.

https://github.com/Electron-Cash/Electron-Cash/pull/345/commits/c99d4e213ee1a0eaefbcf4d9195c1136a0d1d1e2

----

 run_electrum: small clean-up, and hide DeprecationWarnings if not git

- rename `is_bundle` to `is_pyinstaller` (no semantic changes, just to clearer name)
- define `is_appimage`
- add comment to explain `is_local`
  - its value is the same as before (but more explicit definition)
- define `is_git_clone`, and restrict DeprecationWarnings to that case

https://github.com/spesmilo/electrum/commit/5f1a13e4ea9bd3b1a1780e3f7888ea1e9af0765c

----

"--portable": make behaviour independent of pyinstaller version

pyinstaller 4.3 changed the value of `__file__`.
This change makes our behaviour independent of that pyinstaller change (we always behave like old versions of pyinstaller).

https://github.com/spesmilo/electrum/commit/5b500f08ea2618c08b47a99176f323810c924690

----

"--portable": more consistent behaviour

The old and new behaviour is as follows:
1. "pyinstaller" case: portable `.exe`, other `.exe`s with `--portable`, and `.dmg` with `--portable` - uses `$PWD` - note that when you double-click the portable `.exe` on Windows, `$PWD` is set to the parent folder, i.e. the datadir gets put next to the `.exe`
2. appimage `--portable` - was broken (see #5551) - (CHANGED NOW to) uses `$PWD`
3. git clone - next to `run_electrum`
4. unpacking `tar.gz` and running locally from it - next to `run_electrum`
5. `pip install *.tar.gz`, and calling "electrum --portable" from terminal - used python's user script directory - `~/.local/bin/electrum_data` - `$VIRTUAL_ENV/bin/electrum_data` - (CHANGED NOW to) uses `$PWD`

That is, we now almost always put the datadir in `$PWD`, except for the local source case, where we put it next to `run_electrum`.

The "appimage" case (2) is now fixed.

The only breaking change is re case 5 which previously behaved completely unintuitively and most likely not in a useful way.

https://github.com/spesmilo/electrum/commit/6a34d93ce2388feeae320ab1c614bc48ad2d4b31