### PR TITLE
fix integer overflow for amount selection

### DIFF
--- a/electrumabc_gui/qt/address_list.py
+++ b/electrumabc_gui/qt/address_list.py
@@ -65,8 +65,10 @@ class AddressList(MyTreeWidget):
         address = Qt.UserRole + 0
         can_edit_label = Qt.UserRole + 1
 
-    # emits the total number of satoshis for coins on selected addresses
-    selected_amount_changed = pyqtSignal(int)
+    # Emits the total number of satoshis for coins on selected addresses. It emits an
+    # integer, but we define it as a generic object because Qt would translate int to
+    # a 32 bits integer, which causes overflows for amounts > 21,474,836.47 XEC
+    selected_amount_changed = pyqtSignal(object)
     selection_cleared = pyqtSignal()
 
     def __init__(self, main_window: ElectrumWindow, *, picker=False):

--- a/electrumabc_gui/qt/utxo_list.py
+++ b/electrumabc_gui/qt/utxo_list.py
@@ -97,8 +97,10 @@ class UTXOList(MyTreeWidget):
     # sort by amount, descending
     default_sort = MyTreeWidget.SortSpec(Col.amount, Qt.DescendingOrder)
 
-    # emits the total number of satoshis for selected coins
-    selected_amount_changed = pyqtSignal(int)
+    # Emits the total number of satoshis for selected coins. It emits an
+    # integer, but we define it as a generic object because Qt would translate int to
+    # a 32 bits integer, which causes overflows for amounts > 21,474,836.47 XEC
+    selected_amount_changed = pyqtSignal(object)
     selection_cleared = pyqtSignal()
 
     def __init__(self, main_window: ElectrumWindow):


### PR DESCRIPTION
Qt translates `int` into a C int (32 bytes signed integer), which causes overflows when the selected amount in satoshis is larger than the int32 max.

The tradeoff of using a generic PythonObject is performance, as there will be a lot of overhead. But this is not an issue as this codepath is only triggered rarely and at low frequency, by users cliocking on coins or addresses in the GUI.

