### PR TITLE
[build] don't rely on remote repositories, always use the local repo

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -9,8 +9,6 @@ common: &COMMON_TEMPLATE
       git fetch origin pull/$CIRRUS_PR/head:pull/$CIRRUS_PR
       git reset --hard $CIRRUS_CHANGE_IN_REPO
     fi
-  env:
-    GIT_REPO: $CIRRUS_WORKING_DIR
 
 task:
   name: "Build MacOS DMG"

--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -244,6 +244,11 @@ if [ "$GIT_REPO" != "$DEFAULT_GIT_REPO" ]; then
     info "Picked up override from env: GIT_REPO=${GIT_REPO}"
 fi
 export GIT_DIR_NAME=`basename $GIT_REPO`
+
+: "${ELECTRUM_ROOT:=$(git rev-parse --show-toplevel)}"
+export ELECTRUM_ROOT
+export CONTRIB="${ELECTRUM_ROOT}/contrib"
+export DISTDIR="${ELECTRUM_ROOT}/dist"
 export PACKAGE="ElectrumABC"
 export SCRIPTNAME="electrum-abc"
 export PYI_SKIP_TAG="${PYI_SKIP_TAG:-0}" # Set this to non-zero to make PyInstaller skip tagging the bootloader
@@ -255,6 +260,9 @@ fi
 
 export ELECTRUM_LOCALE_REPO="https://github.com/Electron-Cash/electrum-locale"
 export ELECTRUM_LOCALE_COMMIT="848004f800821a3bceaa23d00eeccf78ddb94eb5"
+
+# Newer git errors-out about permissions here sometimes, so do this
+git config --global --add safe.directory $(readlink -f "$ELECTRUM_ROOT")
 
 # Build a command line argument for docker, enabling interactive mode if stdin
 # is a tty and enabling tty in docker if stdout is a tty.

--- a/contrib/base.sh
+++ b/contrib/base.sh
@@ -230,20 +230,6 @@ export PY_VER_MAJOR="3.9"  # as it appears in fs paths
 # If you change PYTHON_VERSION above, update this by downloading the files manually and doing a sha256sum on it.
 export PYTHON_SRC_TARBALL_HASH="125b0c598f1e15d2aa65406e83f792df7d171cdf38c16803b149994316a3080f"
 export PYTHON_MACOS_BINARY_HASH="351fe18f4fb03be7afac5e4012fc0a51345f43202af43ef620cf1eee5ee36578"
-export DEFAULT_GIT_REPO=https://github.com/Bitcoin-ABC/ElectrumABC
-if [ -z "$GIT_REPO" ] ; then
-    # If no override from env is present, use default. Support for overrides
-    # for the GIT_REPO has been added to allows contributors to test containers
-    # that are on local filesystem (while devving) or are their own github forks
-    export GIT_REPO="$DEFAULT_GIT_REPO"
-fi
-if [ "$GIT_REPO" != "$DEFAULT_GIT_REPO" ]; then
-    # We check if it's default because we unconditionally propagate $GIT_REPO
-    # in env to _build.sh inside the docker container, and we don't want to
-    # print this message if it turns out to just be the default.
-    info "Picked up override from env: GIT_REPO=${GIT_REPO}"
-fi
-export GIT_DIR_NAME=`basename $GIT_REPO`
 
 : "${ELECTRUM_ROOT:=$(git rev-parse --show-toplevel)}"
 export ELECTRUM_ROOT

--- a/contrib/build-linux/README.md
+++ b/contrib/build-linux/README.md
@@ -3,21 +3,25 @@ Source tarballs
 
 ✗ _This script does not produce reproducible output (yet!)._
 
-1. To create the source tarball (with the libsecp library included):
+1. To ensure no accidental local changes are included, run:
+
+    ```
+    $ contrib/make_clean
+    ```
+
+2. To create the source tarball (with the libsecp library included):
 
     ```
     $ contrib/make_linux_sdist
     ```
 
-    Alternatively, you may use docker to build a srcdist tarball:
+    Alternatively, you may use a docker with all required dependencies installed:
 
     ```
-    $ contrib/build-linux/srcdist_docker/build.sh COMMIT_OR_TAG
+    $ contrib/build-linux/srcdist_docker/build.sh
     ```
 
-    Where `COMMIT_OR_TAG` is a git commit or branch or tag (eg `master`, `4.0.2`, etc).
-
-2. A `.tar.gz` and a `.zip` file of Electrum ABC will be placed in the `dist/` subdirectory.
+3. A `.tar.gz` and a `.zip` file of Electrum ABC will be placed in the `dist/` subdirectory.
 
 
 AppImage

--- a/contrib/build-linux/README.md
+++ b/contrib/build-linux/README.md
@@ -33,11 +33,14 @@ AppImage
 1. To create a deterministic Linux AppImage (standalone bundle):
 
     ```
-    $ contrib/build-linux/appimage/build.sh COMMIT_OR_TAG
+    $ contrib/make_clean
+    $ git checkout COMMIT_OR_TAG
+    $ contrib/build-linux/appimage/build.sh
     ```
 
     Where `COMMIT_OR_TAG` is a git commit or branch or tag (eg `master`, `4.0.2`, etc).
+    The `make_clean` command can be omitted for testing purposes.
 
-2. The built stand-alone Linux program will be placed in `dist/`.
+3. The built stand-alone Linux program will be placed in `dist/`.
 
-3. The above requires docker.  See [appimage/README.md](appimage/README.md).
+4. The above requires docker.  See [appimage/README.md](appimage/README.md).

--- a/contrib/build-linux/appimage/Dockerfile_ub1804
+++ b/contrib/build-linux/appimage/Dockerfile_ub1804
@@ -54,3 +54,15 @@ RUN echo deb ${UBUNTU_MIRROR} bionic main restricted universe multiverse > /etc/
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \
     apt-get clean
+
+# create new user to avoid using root; but with sudo access and no password for convenience.
+ENV USER="user"
+ENV HOME_DIR="/home/${USER}"
+ENV WORK_DIR="${HOME_DIR}/wspace" \
+    PATH="${HOME_DIR}/.local/bin:${PATH}"
+RUN useradd --create-home --shell /bin/bash ${USER}
+RUN usermod -append --groups sudo ${USER}
+RUN echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+WORKDIR ${WORK_DIR}
+RUN chown --recursive ${USER} ${WORK_DIR}
+USER ${USER}

--- a/contrib/build-linux/appimage/README.md
+++ b/contrib/build-linux/appimage/README.md
@@ -8,14 +8,9 @@ This assumes an Ubuntu host, but it should not be too hard to adapt to another
 similar system. The docker commands should be executed in the project's root
 folder.
 
-1. Install Docker  (Ubuntu instructions -- other platforms vary)
+1. Install Docker
 
-    ```
-    $ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
-    $ sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
-    $ sudo apt-get update
-    $ sudo apt-get install -y docker-ce
-    ```
+    See `contrib/docker_notes.md`.
 
 2. Build binary
 

--- a/contrib/build-linux/appimage/README.md
+++ b/contrib/build-linux/appimage/README.md
@@ -20,7 +20,8 @@ folder.
 2. Build binary
 
     ```
-    $ sudo contrib/build-linux/appimage/build.sh REVISION_TAG_OR_BRANCH_OR_COMMIT_TAG
+    $ git checkout REVISION_TAG_OR_BRANCH_OR_COMMIT_TAG
+    $ sudo contrib/build-linux/appimage/build.sh
     ```
 
     _Note:_ If you are using a MacOS host, run the above **without** `sudo`.

--- a/contrib/build-linux/appimage/README.md
+++ b/contrib/build-linux/appimage/README.md
@@ -21,7 +21,7 @@ folder.
 
     ```
     $ git checkout REVISION_TAG_OR_BRANCH_OR_COMMIT_TAG
-    $ sudo contrib/build-linux/appimage/build.sh
+    $ contrib/build-linux/appimage/build.sh
     ```
 
     _Note:_ If you are using a MacOS host, run the above **without** `sudo`.

--- a/contrib/build-linux/appimage/_build.sh
+++ b/contrib/build-linux/appimage/_build.sh
@@ -2,15 +2,8 @@
 
 set -e
 
-PROJECT_ROOT="$(dirname "$(readlink -e "$0")")/../../.."
-CONTRIB="$PROJECT_ROOT/contrib"
+. ../../base.sh
 
-# Newer git errors-out about permissions here sometimes, so do this
-git config --global --add safe.directory $(readlink -f "$PROJECT_ROOT")
-
-. "$CONTRIB"/base.sh
-
-DISTDIR="$PROJECT_ROOT/dist"
 BUILDDIR="$CONTRIB/build-linux/appimage/build/appimage"
 APPDIR="$BUILDDIR/$PACKAGE.AppDir"
 CACHEDIR="$CONTRIB/build-linux/appimage/.cache/appimage"
@@ -39,7 +32,7 @@ download_if_not_exist "$CACHEDIR/Python-$PYTHON_VERSION.tar.xz" "https://www.pyt
 verify_hash "$CACHEDIR/Python-$PYTHON_VERSION.tar.xz" $PYTHON_SRC_TARBALL_HASH
 
 (
-    cd "$PROJECT_ROOT"
+    cd "${ELECTRUM_ROOT}"
     for pkg in secp zbar ; do
         "$CONTRIB"/make_$pkg || fail "Could not build $pkg"
     done
@@ -84,13 +77,13 @@ info "Installing pip"
 
 info "Preparing electrum-locale"
 (
-    cd "$PROJECT_ROOT"
+    cd "${ELECTRUM_ROOT}"
     setup_pkg "electrum-locale" ${ELECTRUM_LOCALE_REPO} ${ELECTRUM_LOCALE_COMMIT} "$CONTRIB"
     if ! which msgfmt > /dev/null 2>&1; then
         fail "Please install gettext"
     fi
     for i in ./locale/*; do
-        dir="$PROJECT_ROOT/electrumabc/$i/LC_MESSAGES"
+        dir="${ELECTRUM_ROOT}/electrumabc/$i/LC_MESSAGES"
         mkdir -p $dir
         msgfmt --output-file="$dir/electron-cash.mo" "$i/electron-cash.po" || true
     done
@@ -104,13 +97,13 @@ mkdir -p "$CACHEDIR/pip_cache"
 "$python" -m pip install --no-deps --no-warn-script-location --no-binary :all: --cache-dir "$CACHEDIR/pip_cache" -r "$CONTRIB/deterministic-build/requirements.txt"
 "$python" -m pip install --no-deps --no-warn-script-location --no-binary :all: --only-binary pyqt5 --cache-dir "$CACHEDIR/pip_cache" -r "$CONTRIB/deterministic-build/requirements-binaries.txt"
 "$python" -m pip install --no-deps --no-warn-script-location --no-binary :all: --cache-dir "$CACHEDIR/pip_cache" -r "$CONTRIB/deterministic-build/requirements-hw.txt"
-"$python" -m pip install --no-deps --no-warn-script-location --cache-dir "$CACHEDIR/pip_cache" "$PROJECT_ROOT"
+"$python" -m pip install --no-deps --no-warn-script-location --cache-dir "$CACHEDIR/pip_cache" "${ELECTRUM_ROOT}"
 "$python" -m pip uninstall -y -r "$CONTRIB/requirements/requirements-build-uninstall.txt"
 
 
 info "Copying desktop integration"
-cp -fp "$PROJECT_ROOT/$SCRIPTNAME.desktop" "$APPDIR/$SCRIPTNAME.desktop"
-cp -fp "$PROJECT_ROOT/icons/electrumABC.png" "$APPDIR/electrumABC.png"
+cp -fp "${ELECTRUM_ROOT}/$SCRIPTNAME.desktop" "$APPDIR/$SCRIPTNAME.desktop"
+cp -fp "${ELECTRUM_ROOT}/icons/electrumABC.png" "$APPDIR/electrumABC.png"
 
 
 # add launcher

--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -73,11 +73,8 @@ MAPPED_DIR=/opt/electrumabc
 mkdir "$FRESH_CLONE_DIR/contrib/build-linux/home" || fail "Failed to create home directory"
 
 (
-    # NOTE: We propagate forward the GIT_REPO override to the container's env,
-    # just in case it needs to see it.
     $SUDO docker run $DOCKER_RUN_TTY \
     -e HOME="$MAPPED_DIR/contrib/build-linux/home" \
-    -e GIT_REPO="$GIT_REPO" \
     -e BUILD_DEBUG="$BUILD_DEBUG" \
     --name $CONTAINERNAME \
     -v $FRESH_CLONE_DIR:$MAPPED_DIR:delegated \

--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -15,14 +15,7 @@ docker_version=`docker --version`
 
 if [ "$?" != 0 ]; then
     echo ''
-    echo "Please install docker by issuing the following commands (assuming you are on Ubuntu):"
-    echo ''
-    echo '$ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -'
-    echo '$ sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"'
-    echo '$ sudo apt-get update'
-    echo '$ sudo apt-get install -y docker-ce'
-    echo ''
-    fail "Docker is required to build for Windows"
+    fail "Docker is required to build for AppImage"
 fi
 
 set -e

--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -29,21 +29,12 @@ set -e
 
 info "Using docker: $docker_version"
 
-# Only set SUDO if its not been set already
-if [ -z ${SUDO+x} ] ; then
-    SUDO=""  # on macOS (and others?) we don't do sudo for the docker commands ...
-    if [ $(uname) = "Linux" ]; then
-        # .. on Linux we do
-        SUDO="sudo"
-    fi
-fi
-
 DOCKER_SUFFIX=ub1804
 IMGNAME="electrumabc-appimage-builder-img-$DOCKER_SUFFIX"
 CONTAINERNAME="electrumabc-appimage-builder-cont-$DOCKER_SUFFIX"
 
 info "Creating docker image ..."
-$SUDO docker build -t $IMGNAME \
+docker build -t $IMGNAME \
     -f contrib/build-linux/appimage/Dockerfile_$DOCKER_SUFFIX \
     --build-arg UBUNTU_MIRROR=$UBUNTU_MIRROR \
     contrib/build-linux/appimage \
@@ -54,7 +45,7 @@ MAPPED_DIR=/opt/electrumabc
 mkdir "${ELECTRUM_ROOT}/contrib/build-linux/appimage/home" || fail "Failed to create home directory"
 
 (
-    $SUDO docker run $DOCKER_RUN_TTY \
+    docker run $DOCKER_RUN_TTY \
     -e HOME="$MAPPED_DIR/contrib/build-linux/appimage/home" \
     -e BUILD_DEBUG="$BUILD_DEBUG" \
     --name $CONTAINERNAME \

--- a/contrib/build-linux/appimage/build.sh
+++ b/contrib/build-linux/appimage/build.sh
@@ -5,12 +5,6 @@ test -n "$here" -a -d "$here" || (echo "Cannot determine build dir. FIXME!" && e
 
 . "$here"/../../base.sh # functions we use below (fail, et al)
 
-if [ ! -z "$1" ]; then
-    REV="$1"
-else
-    fail "Please specify a release tag or branch to build (eg: master or 4.0.0, etc)"
-fi
-
 if [ ! -d 'contrib' ]; then
     fail "Please run this script form the top-level git directory"
 fi
@@ -55,44 +49,27 @@ $SUDO docker build -t $IMGNAME \
     contrib/build-linux/appimage \
     || fail "Failed to create docker image"
 
-# This is the place where we checkout and put the exact revision we want to work
-# on. Docker will run mapping this directory to /opt/electrumabc
-FRESH_CLONE=`pwd`/contrib/build-linux/fresh_clone
-FRESH_CLONE_DIR=$FRESH_CLONE/$GIT_DIR_NAME
 MAPPED_DIR=/opt/electrumabc
 
-(
-    $SUDO rm -fr $FRESH_CLONE && \
-        mkdir -p $FRESH_CLONE && \
-        cd $FRESH_CLONE  && \
-        git clone $GIT_REPO && \
-        cd $GIT_DIR_NAME && \
-        git checkout $REV
-) || fail "Could not create a fresh clone from git"
-
-mkdir "$FRESH_CLONE_DIR/contrib/build-linux/home" || fail "Failed to create home directory"
+mkdir "${ELECTRUM_ROOT}/contrib/build-linux/appimage/home" || fail "Failed to create home directory"
 
 (
     $SUDO docker run $DOCKER_RUN_TTY \
-    -e HOME="$MAPPED_DIR/contrib/build-linux/home" \
+    -e HOME="$MAPPED_DIR/contrib/build-linux/appimage/home" \
     -e BUILD_DEBUG="$BUILD_DEBUG" \
     --name $CONTAINERNAME \
-    -v $FRESH_CLONE_DIR:$MAPPED_DIR:delegated \
+    -v ${ELECTRUM_ROOT}:$MAPPED_DIR:delegated \
     --rm \
     --workdir $MAPPED_DIR/contrib/build-linux/appimage \
     -u $(id -u $USER):$(id -g $USER) \
     $IMGNAME \
-    ./_build.sh $REV
+    ./_build.sh
 ) || fail "Build inside docker container failed"
 
 popd
 
-info "Copying built files out of working clone..."
-mkdir -p dist/
-cp -fpvR $FRESH_CLONE_DIR/dist/* dist/ || fail "Could not copy files"
-
-info "Removing $FRESH_CLONE ..."
-$SUDO rm -fr $FRESH_CLONE
+info "Removing temporary docker HOME ..."
+rm -fr "${ELECTRUM_ROOT}/contrib/build-linux/appimage/home"
 
 echo ""
 info "Done. Built AppImage has been placed in dist/"

--- a/contrib/build-linux/srcdist_docker/Dockerfile
+++ b/contrib/build-linux/srcdist_docker/Dockerfile
@@ -33,3 +33,15 @@ RUN apt-get update -q && \
     rm -rf /var/lib/apt/lists/* && \
     apt-get autoremove -y && \
     apt-get clean
+
+# create new user to avoid using root; but with sudo access and no password for convenience.
+ENV USER="user"
+ENV HOME_DIR="/home/${USER}"
+ENV WORK_DIR="${HOME_DIR}/wspace" \
+    PATH="${HOME_DIR}/.local/bin:${PATH}"
+RUN useradd --create-home --shell /bin/bash ${USER}
+RUN usermod -append --groups sudo ${USER}
+RUN echo "%sudo ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+WORKDIR ${WORK_DIR}
+RUN chown --recursive ${USER} ${WORK_DIR}
+USER ${USER}

--- a/contrib/build-linux/srcdist_docker/_build.sh
+++ b/contrib/build-linux/srcdist_docker/_build.sh
@@ -2,20 +2,15 @@
 
 set -e
 
-PROJECT_ROOT="$(dirname "$(readlink -e "$0")")/../../.."
-CONTRIB="$PROJECT_ROOT/contrib"
-DISTDIR="$PROJECT_ROOT/dist"
-
 export GCC_STRIP_BINARIES="1"
 
-. "$CONTRIB"/base.sh
+. ../../base.sh
 
-rm -fvr "$DISTDIR"
 mkdir -p "$DISTDIR"
 
 python3 --version || fail "No python"
 
-pushd $PROJECT_ROOT
+pushd ${ELECTRUM_ROOT}
 
 info "Setting up Python venv ..."
 python3 -m venv env

--- a/contrib/build-linux/srcdist_docker/build.sh
+++ b/contrib/build-linux/srcdist_docker/build.sh
@@ -70,11 +70,8 @@ FRESH_CLONE_DIR=$FRESH_CLONE/$GIT_DIR_NAME
 mkdir "$FRESH_CLONE_DIR/contrib/build-linux/home" || fail "Failed to create home directory"
 
 (
-    # NOTE: We propagate forward the GIT_REPO override to the container's env,
-    # just in case it needs to see it.
     $SUDO docker run $DOCKER_RUN_TTY \
     -e HOME="$MAPPED_DIR/contrib/build-linux/home" \
-    -e GIT_REPO="$GIT_REPO" \
     -e BUILD_DEBUG="$BUILD_DEBUG" \
     --name $CONTAINERNAME \
     -v $FRESH_CLONE_DIR:$MAPPED_DIR:delegated \

--- a/contrib/build-linux/srcdist_docker/build.sh
+++ b/contrib/build-linux/srcdist_docker/build.sh
@@ -15,14 +15,7 @@ docker_version=`docker --version`
 
 if [ "$?" != 0 ]; then
     echo ''
-    echo "Please install docker by issuing the following commands (assuming you are on Ubuntu):"
-    echo ''
-    echo '$ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -'
-    echo '$ sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"'
-    echo '$ sudo apt-get update'
-    echo '$ sudo apt-get install -y docker-ce'
-    echo ''
-    fail "Docker is required to build for Windows"
+    fail "Docker is required to build"
 fi
 
 set -e

--- a/contrib/build-linux/srcdist_docker/build.sh
+++ b/contrib/build-linux/srcdist_docker/build.sh
@@ -29,28 +29,19 @@ set -e
 
 info "Using docker: $docker_version"
 
-# Only set SUDO if its not been set already
-if [ -z ${SUDO+x} ] ; then
-    SUDO=""  # on macOS (and others?) we don't do sudo for the docker commands ...
-    if [ $(uname) = "Linux" ]; then
-        # .. on Linux we do
-        SUDO="sudo"
-    fi
-fi
-
 IMGNAME="electrumabc-srcdist-builder-img"
 MAPPED_DIR=/opt/electrumabc
 CONTAINERNAME="electrumabc-srcdist-builder-cont"
 
 info "Creating docker image ..."
-$SUDO docker build -t $IMGNAME \
+docker build -t $IMGNAME \
     contrib/build-linux/srcdist_docker \
     || fail "Failed to create docker image"
 
 mkdir "${ELECTRUM_ROOT}/contrib/build-linux/home" || fail "Failed to create home directory"
 
 (
-    $SUDO docker run $DOCKER_RUN_TTY \
+    docker run $DOCKER_RUN_TTY \
     -e HOME="$MAPPED_DIR/contrib/build-linux/home" \
     -e BUILD_DEBUG="$BUILD_DEBUG" \
     --name $CONTAINERNAME \

--- a/contrib/build-wine/README.md
+++ b/contrib/build-wine/README.md
@@ -18,10 +18,5 @@ Where BRANCH_OR_TAG above is a git branch or tag you wish to build.
 The `make_clean` command can be omitted for testing purposes, if you want
 local uncommited changes to be included in the built .exe files.
 
-Note: If on a Linux host, the above script may ask you for your password as
-docker requires commands be run via sudo.  Make sure you are in the /etc/sudoers
-file.  On a macOS host, this is not the case and docker can be run as a normal
-user.
-
 The built .exe files will be placed in: `dist/`
 

--- a/contrib/build-wine/README.md
+++ b/contrib/build-wine/README.md
@@ -9,9 +9,14 @@ Don't worry! It's fast and produces 100% reproducible builds.
 You may do so by issuing the following command (from the top-level of this
 repository)::
 
-    $ contrib/build-wine/build.sh BRACH_OR_TAG
+    $ contrib/make_clean
+    $ git checkout BRANCH_OR_TAG
+    $ contrib/build-wine/build.sh
 
 Where BRANCH_OR_TAG above is a git branch or tag you wish to build.
+
+The `make_clean` command can be omitted for testing purposes, if you want
+local uncommited changes to be included in the built .exe files.
 
 Note: If on a Linux host, the above script may ask you for your password as
 docker requires commands be run via sudo.  Make sure you are in the /etc/sudoers

--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -24,15 +24,7 @@ git config --global --add safe.directory $(readlink -f "$here"/../..)  # /homedi
 
 . "$here"/../base.sh # functions we use below (fail, et al)
 
-if [ ! -z "$1" ]; then
-    to_build="$1"
-else
-    fail "Please specify a release tag or branch to build (eg: master or 4.0.0, etc)"
-fi
-
 set -e
-
-git checkout "$to_build" || fail "Could not branch or tag $to_build"
 
 GIT_COMMIT_HASH=$(git rev-parse HEAD)
 

--- a/contrib/build-wine/_build.sh
+++ b/contrib/build-wine/_build.sh
@@ -44,7 +44,7 @@ rm -fr /tmp/electrum-build
 mkdir -p /tmp/electrum-build
 
 (
-    cd "$PROJECT_ROOT"
+    cd "$ELECTRUM_ROOT"
     for pkg in secp zbar ; do
         "$here"/../make_$pkg || fail "Could not build $pkg"
     done

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -84,12 +84,9 @@ FRESH_CLONE_DIR="$FRESH_CLONE/$GIT_DIR_NAME"
 ) || fail "Could not create a fresh clone from git"
 
 (
-    # NOTE: We propagate forward the GIT_REPO override to the container's env,
-    # just in case it needs to see it.
     $SUDO docker run $DOCKER_RUN_TTY \
     -u $USER_ID:$GROUP_ID \
     -e HOME=/homedir \
-    -e GIT_REPO="$GIT_REPO" \
     -e WIN_ARCH="$WIN_ARCH" \
     -e BUILD_DEBUG="$BUILD_DEBUG" \
     -e PYI_SKIP_TAG="$PYI_SKIP_TAG" \

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -13,12 +13,6 @@ if [ "$WIN_ARCH" != "$DEFAULT_WIN_ARCH" ]; then
     info "Picked up override from env: WIN_ARCH=${WIN_ARCH}"
 fi
 
-if [ ! -z "$1" ]; then
-    REV="$1"
-else
-    fail "Please specify a release tag or branch to build (eg: master or 4.0.0, etc)"
-fi
-
 if [ ! -d 'contrib' ]; then
     fail "Please run this script form the top-level Electrum ABC git directory"
 fi
@@ -68,21 +62,6 @@ $SUDO docker build -t $IMGNAME \
             contrib/build-wine/docker \
     || fail "Failed to create docker image"
 
-# This is the place where we checkout and put the exact revision we want to work
-# on. Docker will run mapping this directory to /homedir/wine/drive_c/electrumabc
-# which inside wine will look like c:\electrumabc.
-FRESH_CLONE=`pwd`/contrib/build-wine/fresh_clone
-FRESH_CLONE_DIR="$FRESH_CLONE/$GIT_DIR_NAME"
-
-(
-    $SUDO rm -fr "$FRESH_CLONE" && \
-        mkdir -p "$FRESH_CLONE" && \
-        cd "$FRESH_CLONE"  && \
-        git clone "$GIT_REPO" && \
-        cd "$GIT_DIR_NAME" && \
-        git checkout $REV
-) || fail "Could not create a fresh clone from git"
-
 (
     $SUDO docker run $DOCKER_RUN_TTY \
     -u $USER_ID:$GROUP_ID \
@@ -91,26 +70,26 @@ FRESH_CLONE_DIR="$FRESH_CLONE/$GIT_DIR_NAME"
     -e BUILD_DEBUG="$BUILD_DEBUG" \
     -e PYI_SKIP_TAG="$PYI_SKIP_TAG" \
     --name ec-wine-builder-cont \
-    -v "$FRESH_CLONE_DIR":/homedir/wine/drive_c/electrumabc:delegated \
+    -v "${ELECTRUM_ROOT}":/homedir/wine/drive_c/electrumabc:delegated \
     --rm \
     --workdir /homedir/wine/drive_c/electrumabc/contrib/build-wine \
     $IMGNAME \
-    ./_build.sh $REV
+    ./_build.sh
 ) || fail "Build inside docker container failed"
 
 popd
 
 info "Copying .exe files out of our build directory ..."
 mkdir -p dist/
-files="$FRESH_CLONE_DIR"/contrib/build-wine/dist/*.exe
+files="${ELECTRUM_ROOT}"/contrib/build-wine/dist/*.exe
 for f in $files; do
     bn=`basename "$f"`
     cp -fpv "$f" dist/"$bn" || fail "Failed to copy $bn"
     touch dist/"$bn" || fail "Failed to update timestamp on $bn"
 done
 
-info "Removing $FRESH_CLONE ..."
-$SUDO rm -fr "$FRESH_CLONE"
+info "Removing temporary build/ and dist/ directories"
+rm -fr "${ELECTRUM_ROOT}/contrib/build-wine/dist" "${ELECTRUM_ROOT}/contrib/build-wine/build"
 
 echo ""
 info "Done. Built .exe files have been placed in dist/"

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -37,15 +37,6 @@ set -e
 
 info "Using docker: $docker_version"
 
-# Only set SUDO if its not been set already
-if [ -z ${SUDO+x} ] ; then
-    SUDO=""  # on macOS (and others?) we don't do sudo for the docker commands ...
-    if [ $(uname) = "Linux" ]; then
-        # .. on Linux we do
-        SUDO="sudo"
-    fi
-fi
-
 USER_ID=$(id -u $USER)
 GROUP_ID=$(id -g $USER)
 
@@ -55,7 +46,7 @@ GROUP_ID=$(id -g $USER)
 IMGNAME="ec-wine-builder-img_${USER_ID}_${GROUP_ID}"
 
 info "Creating docker image ..."
-$SUDO docker build -t $IMGNAME \
+docker build -t $IMGNAME \
             --build-arg USER_ID=$USER_ID \
             --build-arg GROUP_ID=$GROUP_ID \
             --build-arg UBUNTU_MIRROR=$UBUNTU_MIRROR \
@@ -63,7 +54,7 @@ $SUDO docker build -t $IMGNAME \
     || fail "Failed to create docker image"
 
 (
-    $SUDO docker run $DOCKER_RUN_TTY \
+    docker run $DOCKER_RUN_TTY \
     -u $USER_ID:$GROUP_ID \
     -e HOME=/homedir \
     -e WIN_ARCH="$WIN_ARCH" \

--- a/contrib/build-wine/build.sh
+++ b/contrib/build-wine/build.sh
@@ -23,13 +23,6 @@ docker_version=`docker --version`
 
 if [ "$?" != 0 ]; then
     echo ''
-    echo "Please install docker by issuing the following commands (assuming you are on Ubuntu):"
-    echo ''
-    echo '$ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -'
-    echo '$ sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"'
-    echo '$ sudo apt-get update'
-    echo '$ sudo apt-get install -y docker-ce'
-    echo ''
     fail "Docker is required to build for Windows"
 fi
 

--- a/contrib/docker_notes.md
+++ b/contrib/docker_notes.md
@@ -1,0 +1,20 @@
+# Notes about using Docker in the build scripts
+
+- To install Docker:
+
+    This assumes an Ubuntu (x86_64) host, but it should not be too hard to adapt to another similar system.
+
+    ```
+    $ curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
+    $ sudo add-apt-repository "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
+    $ sudo apt-get update
+    $ sudo apt-get install -y docker-ce
+    ```
+
+- To communicate with the docker daemon, the build scripts either need to be called via sudo,
+  or the unix user on the host system (e.g. the user you run as) needs to be
+  part of the `docker` group. i.e.:
+  ```
+  $ sudo usermod -aG docker ${USER}
+  ```
+  (and then reboot or similar for it to take effect)

--- a/contrib/make_clean
+++ b/contrib/make_clean
@@ -1,7 +1,15 @@
 #!/bin/bash
+# Delete everything in the repository that is not part of the git repository
+# some caches for downloaded (and rarely updated) dependencies.
 
 set -e
 
-here=$(dirname $(realpath "$0" 2> /dev/null || grealpath "$0"))
+if [ ! -f 'electrum-abc' ]; then
+    fail "Please run this script from the top-level Electrum ABC git directory"
+fi
 
-rm -Rf "$here/build"
+source $( dirname -- "$BASH_SOURCE" )/base.sh
+
+git clean -xdff \
+ --exclude=contrib/osx/.cache \
+ -- .

--- a/contrib/make_linux_sdist
+++ b/contrib/make_linux_sdist
@@ -11,21 +11,15 @@ set -e
 
 pushd "$contrib"/..
 
-# EC_PACKAGE_VERSION and EC_PACKAGE_NAME are used by setup.py to specify
-# generated filename with a version from git tag. Otherwise defaults are used.
-# As of latest setuptools, the version with git commit tag is not tolerated so
-# we only use the git tag for display.
 TAGGED_VERSION=`git describe --tags` || fail "Could not get determine git tag version"
-EC_PACKAGE_NAME="${PACKAGE}"
-export EC_PACKAGE_NAME
 
-info "Making SrcDist for version: ${EC_PACKAGE_NAME}-${TAGGED_VERSION} ..."
+info "Making SrcDist for version: ${PACKAGE}-${TAGGED_VERSION} ..."
 
 "$contrib"/make_locale && \
     "$contrib"/make_packages && \
     python3 setup.py sdist --enable-secp --enable-zbar --format=zip,gztar || fail "Failed."
 
-unset EC_PACKAGE_NAME TAGGED_VERSION
+unset TAGGED_VERSION
 
 info "Linux source distribution (including compiled libseck256k1 & libzbar) has been placed in dist/"
 

--- a/setup.py
+++ b/setup.py
@@ -168,8 +168,8 @@ setup(
     cmdclass={
         "sdist": MakeAllBeforeSdist,
     },
-    name=os.environ.get("EC_PACKAGE_NAME") or PROJECT_NAME_NO_SPACES,
-    version=os.environ.get("EC_PACKAGE_VERSION") or get_version(),
+    name=PROJECT_NAME_NO_SPACES,
+    version=get_version(),
     install_requires=requirements,
     extras_require={
         "hardware": requirements_hw,


### PR DESCRIPTION
The build scripts currently rely on access to github.com for code that already exists in the local repository. This is wasteful and will become even more wasteful when Electrum ABC is part of the Bitcoin ABC monorepo.

This PR simplifies the build script to always use the local source code, and not rely on git tags to build the release files.
Reproducibility is not affected, as it is still possible to checkout a commit to build this particular version of the program.