### PR TITLE
guard against loading unsupported contact type

### DIFF
--- a/electrumabc/contacts.py
+++ b/electrumabc/contacts.py
@@ -91,6 +91,9 @@ class Contacts(PrintError):
             name, address, typ = d.get("name"), d.get("address"), d.get("type")
             if not all(isinstance(a, str) for a in (name, address, typ)):
                 continue  # skip invalid-looking data
+            # Filter out invalid or no longer supported types (e.g cashacct)
+            if typ not in contact_types:
+                continue
             if typ == "address" and not Address.is_valid(address):
                 continue
             out.append(Contact(name, address, typ))


### PR DESCRIPTION
This should fix #287. An old (pre-eCash) wallet file could contain CashAcount contacts, and when I removed the CashAccount feature in #249 I did not guard against loading such contacts from the wallet file.

Closes #287 