### PR TITLE
fix multicoin freezing and unfreezing

### DIFF
--- a/electrumabc_gui/qt/utxo_list.py
+++ b/electrumabc_gui/qt/utxo_list.py
@@ -415,7 +415,7 @@ class UTXOList(MyTreeWidget):
         else:
             # multi-selection
             menu.addSeparator()
-            selected_outpoints = [coin.get_name for coin in selected_coins]
+            selected_outpoints = [coin.get_name() for coin in selected_coins]
             if any(not coin.is_frozen for coin in selected_coins):
                 # they have some coin-level non-frozen in the selection, so add the
                 # menu action "Freeze coins"


### PR DESCRIPTION
This was broken in 5.2.0 (#256, commit 864474d23eacb0e5d64abc18c73115613378100f). As a result, when selecting multiple coins, the Freeze and Unfreeze menu actions didn't do anything because the wallet didn't receive proper coin names.
