### PR TITLE
Enable ordered outputs for OP_RETURN use cases (SLP...)

### DIFF
--- a/electrumabc/address.py
+++ b/electrumabc/address.py
@@ -25,6 +25,7 @@
 # Many of the functions in this file are copied from ElectrumX
 from __future__ import annotations
 
+import abc
 import hashlib
 import struct
 from collections import namedtuple
@@ -45,6 +46,14 @@ from .util import cachedproperty, inv_dict
 
 _sha256 = hashlib.sha256
 hex_to_bytes = bytes.fromhex
+
+
+class DestinationType(abc.ABC):
+    """Base class for TxOutput destination types"""
+
+    @abc.abstractmethod
+    def to_ui_string(self) -> str:
+        pass
 
 
 class AddressError(Exception):
@@ -106,7 +115,7 @@ def double_sha256(x):
     return sha256(sha256(x))
 
 
-class UnknownAddress:
+class UnknownAddress(DestinationType):
     def to_ui_string(self):
         return "<UnknownAddress>"
 
@@ -233,7 +242,7 @@ class PublicKey(namedtuple("PublicKeyTuple", "pubkey")):
         return "<PubKey {}>".format(self.__str__())
 
 
-class ScriptOutput(namedtuple("ScriptAddressTuple", "script")):
+class ScriptOutput(namedtuple("ScriptAddressTuple", "script"), DestinationType):
     @classmethod
     def from_string(self, string):
         """Instantiate from a mixture of opcodes and raw data."""
@@ -341,7 +350,7 @@ class ScriptOutput(namedtuple("ScriptAddressTuple", "script")):
 
 
 # A namedtuple for easy comparison and unique hashing
-class Address(namedtuple("AddressTuple", "hash160 kind")):
+class Address(namedtuple("AddressTuple", "hash160 kind"), DestinationType):
     # Address kinds
     ADDR_P2PKH = 0
     ADDR_P2SH = 1

--- a/electrumabc/coinchooser.py
+++ b/electrumabc/coinchooser.py
@@ -28,7 +28,7 @@ from math import floor, log10
 
 from .bitcoin import CASH, TYPE_ADDRESS, sha256
 from .printerror import PrintError
-from .transaction import Transaction
+from .transaction import Transaction, TxOutput
 from .util import NotEnoughFunds
 
 
@@ -167,7 +167,8 @@ class CoinChooserBase(PrintError):
         dust = sum(amount for amount in amounts if amount < dust_threshold)
         amounts = [amount for amount in amounts if amount >= dust_threshold]
         change = [
-            (TYPE_ADDRESS, addr, amount) for addr, amount in zip(change_addrs, amounts)
+            TxOutput(TYPE_ADDRESS, addr, amount)
+            for addr, amount in zip(change_addrs, amounts)
         ]
         self.print_error("change:", change)
         if dust:

--- a/electrumabc/commands.py
+++ b/electrumabc/commands.py
@@ -45,7 +45,7 @@ from .paymentrequest import PR_EXPIRED, PR_PAID, PR_UNCONFIRMED, PR_UNKNOWN, PR_
 from .plugins import run_hook
 from .printerror import print_error
 from .simple_config import SimpleConfig
-from .transaction import OPReturn, Transaction, multisig_script, tx_from_str
+from .transaction import OPReturn, Transaction, TxOutput, multisig_script, tx_from_str
 from .util import format_satoshis, json_decode, to_bytes
 from .version import PACKAGE_VERSION
 from .wallet import create_new_wallet, restore_wallet_from_text
@@ -427,7 +427,7 @@ class Commands:
                 txin["num_sig"] = 1
 
         outputs = [
-            (TYPE_ADDRESS, Address.from_string(x["address"]), int(x["value"]))
+            TxOutput(TYPE_ADDRESS, Address.from_string(x["address"]), int(x["value"]))
             for x in outputs
         ]
         tx = Transaction.from_io(
@@ -696,7 +696,7 @@ class Commands:
         for address, amount in outputs:
             address = self._resolver(address)
             amount = satoshis(amount)
-            final_outputs.append((TYPE_ADDRESS, address, amount))
+            final_outputs.append(TxOutput(TYPE_ADDRESS, address, amount))
 
         coins = self.wallet.get_spendable_coins(domain, self.config)
         if feerate is not None:

--- a/electrumabc/paymentrequest.py
+++ b/electrumabc/paymentrequest.py
@@ -51,7 +51,7 @@ from .address import Address, PublicKey
 from .bitcoin import TYPE_ADDRESS
 from .constants import PROJECT_NAME, PROJECT_NAME_NO_SPACES, XEC
 from .printerror import PrintError, print_error
-from .transaction import Transaction
+from .transaction import Transaction, TxOutput
 from .util import FileImportFailed, FileImportFailedEncrypted, bfh, bh2u
 from .version import PACKAGE_VERSION
 
@@ -164,7 +164,7 @@ class PaymentRequest:
         self.outputs = []
         for o in self.details.outputs:
             addr = transaction.get_address_from_output_script(o.script)[1]
-            self.outputs.append((TYPE_ADDRESS, addr, o.amount))
+            self.outputs.append(TxOutput(TYPE_ADDRESS, addr, o.amount))
         self.memo = self.details.memo
         self.payment_url = self.details.payment_url
 
@@ -272,10 +272,10 @@ class PaymentRequest:
     def get_amount(self):
         return sum(map(lambda x: x[2], self.outputs))
 
-    def get_address(self):
+    def get_address(self) -> str:
         o = self.outputs[0]
-        assert o[0] == TYPE_ADDRESS
-        return o[1].to_ui_string()
+        assert o.type == TYPE_ADDRESS
+        return o.destination.to_ui_string()
 
     def get_requestor(self):
         return self.requestor if self.requestor else self.get_address()

--- a/electrumabc/tests/test_transaction.py
+++ b/electrumabc/tests/test_transaction.py
@@ -113,22 +113,27 @@ class TestTransaction(unittest.TestCase):
             tx.as_dict(), {"hex": unsigned_blob, "complete": False, "final": True}
         )
         self.assertEqual(
-            tx.get_outputs(),
+            [(o.destination, o.value) for o in tx.outputs()],
             [(Address.from_string("1MYXdf4moacvaEKZ57ozerpJ3t9xSeN6LK"), 20112408)],
         )
         self.assertEqual(
-            tx.get_output_addresses(),
+            [o.destination for o in tx.outputs()],
             [Address.from_string("1MYXdf4moacvaEKZ57ozerpJ3t9xSeN6LK")],
         )
 
+        def tx_has_address(addr: Address) -> bool:
+            return any(addr == o.destination for o in tx.outputs()) or (
+                addr in (inp.get("address") for inp in tx.inputs())
+            )
+
         self.assertTrue(
-            tx.has_address(Address.from_string("1MYXdf4moacvaEKZ57ozerpJ3t9xSeN6LK"))
+            tx_has_address(Address.from_string("1MYXdf4moacvaEKZ57ozerpJ3t9xSeN6LK"))
         )
         self.assertTrue(
-            tx.has_address(Address.from_string("13Vp8Y3hD5Cb6sERfpxePz5vGJizXbWciN"))
+            tx_has_address(Address.from_string("13Vp8Y3hD5Cb6sERfpxePz5vGJizXbWciN"))
         )
         self.assertFalse(
-            tx.has_address(Address.from_string("1CQj15y1N7LDHp7wTt28eoD1QhHgFgxECH"))
+            tx_has_address(Address.from_string("1CQj15y1N7LDHp7wTt28eoD1QhHgFgxECH"))
         )
 
         self.assertEqual(tx.serialize(), unsigned_blob)

--- a/electrumabc/transaction.py
+++ b/electrumabc/transaction.py
@@ -808,7 +808,9 @@ class Transaction:
     def shuffle_inputs(self):
         random.shuffle(self._inputs)
 
-    def shuffle_outputs(self):
+    def sort_outputs(self, shuffle: bool = True):
+        """Put the op_return output first, and then shuffle the other outputs unless
+        this behavior is explicitely disabled."""
         op_returns = []
         other_outputs = []
         for txo in self._outputs:
@@ -816,8 +818,8 @@ class Transaction:
                 op_returns.append(txo)
             else:
                 other_outputs.append(txo)
-
-        random.shuffle(other_outputs)
+        if shuffle:
+            random.shuffle(other_outputs)
         self._outputs = op_returns + other_outputs
 
     def serialize_output(self, output):

--- a/electrumabc/transaction.py
+++ b/electrumabc/transaction.py
@@ -778,8 +778,10 @@ class Transaction:
             s += bitcoin.int_to_hex(txin["value"], 8)
         return s
 
-    def shuffle_inputs_outputs(self):
+    def shuffle_inputs(self):
         random.shuffle(self._inputs)
+
+    def shuffle_outputs(self):
         random.shuffle(self._outputs)
 
     def serialize_output(self, output):

--- a/electrumabc/wallet.py
+++ b/electrumabc/wallet.py
@@ -213,7 +213,8 @@ def sweep(
     tx = Transaction.from_io(
         inputs, outputs, locktime=locktime, sign_schnorr=sign_schnorr
     )
-    tx.shuffle_inputs_outputs()
+    tx.shuffle_inputs()
+    tx.shuffle_outputs()
     tx.sign(keypairs)
     return tx
 
@@ -2170,7 +2171,8 @@ class AbstractWallet(PrintError, SPVDelegate):
         if sats_per_byte > 100:
             raise ExcessiveFee()
 
-        tx.shuffle_inputs_outputs()
+        tx.shuffle_inputs()
+        tx.shuffle_outputs()
         # Timelock tx to current height.
         locktime = 0
         if config.is_current_block_locktime_enabled():
@@ -2449,7 +2451,7 @@ class AbstractWallet(PrintError, SPVDelegate):
         locktime = 0
         if enable_current_block_locktime:
             locktime = self.get_local_height()
-        # note: no need to call tx.shuffle_inputs_outputs here - single input/output
+        # note: no need to shuffle inputs or outputs here - single input/output
         return Transaction.from_io(
             inputs, outputs, locktime=locktime, sign_schnorr=sign_schnorr
         )

--- a/electrumabc/wallet.py
+++ b/electrumabc/wallet.py
@@ -214,7 +214,7 @@ def sweep(
         inputs, outputs, locktime=locktime, sign_schnorr=sign_schnorr
     )
     tx.shuffle_inputs()
-    tx.shuffle_outputs()
+    tx.sort_outputs()
     tx.sign(keypairs)
     return tx
 
@@ -2057,6 +2057,7 @@ class AbstractWallet(PrintError, SPVDelegate):
         fixed_fee=None,
         change_addr=None,
         sign_schnorr=None,
+        shuffle_outputs=True,
     ):
         """sign_schnorr flag controls whether to mark the tx as signing with
         schnorr or not. Specify either a bool, or set the flag to 'None' to use
@@ -2169,7 +2170,8 @@ class AbstractWallet(PrintError, SPVDelegate):
             raise ExcessiveFee()
 
         tx.shuffle_inputs()
-        tx.shuffle_outputs()
+        tx.sort_outputs(shuffle=shuffle_outputs)
+
         # Timelock tx to current height.
         locktime = 0
         if config.is_current_block_locktime_enabled():

--- a/electrumabc_gui/qt/main_window.py
+++ b/electrumabc_gui/qt/main_window.py
@@ -66,6 +66,7 @@ from electrumabc.transaction import (
     OPReturn,
     SerializationError,
     Transaction,
+    TxOutput,
     tx_from_str,
 )
 from electrumabc.util import (
@@ -2203,7 +2204,7 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             outputs = self.payto_e.get_outputs(self.max_button.isChecked())
             if not outputs:
                 _type, addr = self.get_payto_or_dummy()
-                outputs = [(_type, addr, amount)]
+                outputs = [TxOutput(_type, addr, amount)]
             try:
                 opreturn_message = (
                     self.message_opreturn_e.text()
@@ -2446,8 +2447,8 @@ class ElectrumWindow(QtWidgets.QMainWindow, MessageBoxMixin, PrintError):
             self.show_error(_("No outputs"))
             return
 
-        for _type, addr, amount in outputs:
-            if amount is None:
+        for o in outputs:
+            if o.value is None:
                 self.show_error(_("Invalid Amount"))
                 return
 

--- a/electrumabc_gui/stdio.py
+++ b/electrumabc_gui/stdio.py
@@ -7,6 +7,7 @@ from electrumabc.bitcoin import CASH, TYPE_ADDRESS
 from electrumabc.constants import SCRIPT_NAME
 from electrumabc.printerror import set_verbosity
 from electrumabc.storage import WalletStorage
+from electrumabc.transaction import TxOutput
 from electrumabc.util import format_satoshis
 from electrumabc.wallet import Wallet
 
@@ -255,7 +256,14 @@ class ElectrumGui:
 
         try:
             tx = self.wallet.mktx(
-                [(TYPE_ADDRESS, self.str_recipient, amount)], password, self.config, fee
+                [
+                    TxOutput(
+                        TYPE_ADDRESS, Address.from_string(self.str_recipient), amount
+                    )
+                ],
+                password,
+                self.config,
+                fee,
             )
         except Exception as e:
             print(str(e))

--- a/electrumabc_gui/text.py
+++ b/electrumabc_gui/text.py
@@ -12,6 +12,7 @@ from electrumabc.bitcoin import CASH, TYPE_ADDRESS
 from electrumabc.constants import SCRIPT_NAME
 from electrumabc.printerror import set_verbosity
 from electrumabc.storage import WalletStorage
+from electrumabc.transaction import TxOutput
 from electrumabc.util import format_satoshis
 from electrumabc.wallet import Wallet
 
@@ -436,7 +437,14 @@ class ElectrumGui:
             password = None
         try:
             tx = self.wallet.mktx(
-                [(TYPE_ADDRESS, self.str_recipient, amount)], password, self.config, fee
+                [
+                    TxOutput(
+                        TYPE_ADDRESS, Address.from_string(self.str_recipient), amount
+                    )
+                ],
+                password,
+                self.config,
+                fee,
             )
         except Exception as e:
             self.show_message(str(e))

--- a/electrumabc_plugins/digitalbitbox/digitalbitbox.py
+++ b/electrumabc_plugins/digitalbitbox/digitalbitbox.py
@@ -655,8 +655,8 @@ class DigitalBitboxKeyStore(HardwareKeyStore):
                     )  # should never happen
 
             # Build pubkeyarray from outputs
-            for _type, address, amount in tx.outputs():
-                info = tx.output_info.get(address)
+            for o in tx.outputs():
+                info = tx.output_info.get(o.destination)
                 if info is not None:
                     index, xpubs, m, script_type = info
                     changePath = self.get_derivation() + "/%d/%d" % index

--- a/electrumabc_plugins/keepkey/keepkey.py
+++ b/electrumabc_plugins/keepkey/keepkey.py
@@ -1,4 +1,5 @@
 from binascii import unhexlify
+from typing import TYPE_CHECKING
 
 from electrumabc import networks
 from electrumabc.address import Address
@@ -20,6 +21,9 @@ from ..hw_wallet.plugin import (
     is_any_tx_output_on_change_branch,
     validate_op_return_output_and_get_data,
 )
+
+if TYPE_CHECKING:
+    from electrumabc.transaction import Transaction
 
 # TREZOR initialization methods
 TIM_NEW, TIM_RECOVER, TIM_MNEMONIC, TIM_PRIVKEY = range(0, 4)
@@ -491,7 +495,7 @@ class KeepKeyPlugin(HWPluginBase):
 
         return inputs
 
-    def tx_outputs(self, derivation, tx):
+    def tx_outputs(self, derivation, tx: Transaction):
         def create_output_by_derivation():
             keepkey_script_type = self.get_keepkey_output_script_type(script_type)
             if len(xpubs) == 1:
@@ -523,7 +527,7 @@ class KeepKeyPlugin(HWPluginBase):
             if _type == TYPE_SCRIPT:
                 txoutputtype.script_type = self.types.PAYTOOPRETURN
                 txoutputtype.op_return_data = validate_op_return_output_and_get_data(
-                    o, max_pushes=1
+                    o.destination, max_pushes=1
                 )
             elif _type == TYPE_ADDRESS:
                 txoutputtype.script_type = self.types.PAYTOADDRESS
@@ -537,7 +541,7 @@ class KeepKeyPlugin(HWPluginBase):
         any_output_on_change_branch = is_any_tx_output_on_change_branch(tx)
 
         for o in tx.outputs():
-            _type, address, amount = o
+            _type, address, amount = o.type, o.destination, o.value
             use_create_by_derivation = False
 
             info = tx.output_info.get(address)

--- a/electrumabc_plugins/trezor/trezor.py
+++ b/electrumabc_plugins/trezor/trezor.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import sys
 import traceback
 from binascii import unhexlify
+from typing import TYPE_CHECKING
 
 from electrumabc.base_wizard import HWD_SETUP_NEW_WALLET
 from electrumabc.bitcoin import (
@@ -18,6 +21,9 @@ from electrumabc.transaction import deserialize
 from electrumabc.util import UserCancelled, bfh, bh2u, versiontuple
 
 from ..hw_wallet import HWPluginBase
+
+if TYPE_CHECKING:
+    from electrumabc.transaction import Transaction
 
 try:
     import trezorlib
@@ -492,7 +498,7 @@ class TrezorPlugin(HWPluginBase):
 
         return MultisigRedeemScriptType(pubkeys=pubkeys, signatures=signatures, m=m)
 
-    def tx_outputs(self, derivation, tx, client):
+    def tx_outputs(self, derivation, tx: Transaction, client):
         def create_output_by_derivation():
             deriv = parse_path("/%d/%d" % index)
             multisig = self._make_multisig(m, [(xpub, deriv) for xpub in xpubs])
@@ -552,7 +558,8 @@ class TrezorPlugin(HWPluginBase):
         has_change = False
         any_output_on_change_branch = self.is_any_tx_output_on_change_branch(tx)
 
-        for _type, address, amount in tx.outputs():
+        for o in tx.outputs():
+            _type, address, amount = o.type, o.destination, o.value
             use_create_by_derivation = False
             info = tx.output_info.get(address)
             if info is not None and not has_change:


### PR DESCRIPTION
#272 implemented shuffling of outputs in transactions, with no consideration for the type of the output.

The previous implementation before that used a deterministic sorting based on the output amount and script, which by shear luck resulted in OP_RETURN outputs always being the first output because it has a zero amount.

This PR restores this behavior of putting the OP_RETURN always first, and adds a way to keep the other outputs sorted when using OP_RETURN. This is needed for crafting SLP transactions (see https://www.youtube.com/watch?v=TU1LBd9aVlc)